### PR TITLE
Expose rate-limit timestamps to Lua statusline

### DIFF
--- a/lib/libui/chatwidget/events/protocol_dispatch/lifecycle.rs
+++ b/lib/libui/chatwidget/events/protocol_dispatch/lifecycle.rs
@@ -100,6 +100,7 @@ impl ChatWidget {
         if let Some(forked_from_id) = forked_from_id {
             self.emit_forked_process_event(forked_from_id);
         }
+        self.refresh_status_line();
         if !self.suppress_session_configured_redraw {
             self.request_redraw();
         }

--- a/lib/libui/chatwidget/render.rs
+++ b/lib/libui/chatwidget/render.rs
@@ -170,6 +170,8 @@ impl ChatWidget {
         if self.halluacinate.is_none() {
             self.bottom_pane.set_status_line_enabled(false);
             self.set_status_line(None);
+        } else {
+            self.refresh_status_line();
         }
     }
 
@@ -582,27 +584,27 @@ impl ChatWidget {
         let last_input_tokens = last_usage.input_tokens;
         let last_output_tokens = last_usage.output_tokens;
 
-        let five_hour = self
-            .rate_limit_snapshots_by_limit_id
-            .get("chaos")
-            .and_then(|s| s.primary.as_ref())
-            .map(|w| {
-                serde_json::json!({
-                    "used_pct": w.used_percent,
-                    "remaining_pct": (100.0f64 - w.used_percent).clamp(0.0f64, 100.0f64),
-                    "window_minutes": w.window_minutes,
-                })
-            });
+        let chaos_rate_limit = self.rate_limit_snapshots_by_limit_id.get("chaos");
+        let rate_limit_captured_at_epoch_seconds =
+            chaos_rate_limit.map(|s| s.captured_at.as_second());
 
-        let weekly = self
-            .rate_limit_snapshots_by_limit_id
-            .get("chaos")
+        let five_hour = chaos_rate_limit.and_then(|s| s.primary.as_ref()).map(|w| {
+            serde_json::json!({
+                "used_pct": w.used_percent,
+                "remaining_pct": (100.0f64 - w.used_percent).clamp(0.0f64, 100.0f64),
+                "window_minutes": w.window_minutes,
+                "resets_at_epoch_seconds": w.resets_at_epoch_seconds,
+            })
+        });
+
+        let weekly = chaos_rate_limit
             .and_then(|s| s.secondary.as_ref())
             .map(|w| {
                 serde_json::json!({
                     "used_pct": w.used_percent,
                     "remaining_pct": (100.0f64 - w.used_percent).clamp(0.0f64, 100.0f64),
                     "window_minutes": w.window_minutes,
+                    "resets_at_epoch_seconds": w.resets_at_epoch_seconds,
                 })
             });
 
@@ -640,6 +642,7 @@ impl ChatWidget {
             },
             "five_hour": five_hour,
             "weekly": weekly,
+            "rate_limit_captured_at_epoch_seconds": rate_limit_captured_at_epoch_seconds,
         })
     }
 }

--- a/lib/libui/status/rate_limits.rs
+++ b/lib/libui/status/rate_limits.rs
@@ -61,6 +61,8 @@ pub struct RateLimitWindowDisplay {
     pub used_percent: f64,
     /// Human-readable local reset time.
     pub resets_at: Option<String>,
+    /// Reset time as epoch seconds, used by scriptable statusline renderers for projection math.
+    pub resets_at_epoch_seconds: Option<i64>,
     /// Window length in minutes when provided by the server.
     pub window_minutes: Option<i64>,
 }
@@ -75,6 +77,7 @@ impl RateLimitWindowDisplay {
         Self {
             used_percent: window.used_percent,
             resets_at,
+            resets_at_epoch_seconds: window.resets_at,
             window_minutes: window.window_minutes,
         }
     }
@@ -352,6 +355,7 @@ mod tests {
         RateLimitWindowDisplay {
             used_percent,
             resets_at: Some("soon".to_string()),
+            resets_at_epoch_seconds: None,
             window_minutes: Some(300),
         }
     }
@@ -409,11 +413,13 @@ mod tests {
             primary: Some(RateLimitWindowDisplay {
                 used_percent: 20.0,
                 resets_at: Some("soon".to_string()),
+                resets_at_epoch_seconds: None,
                 window_minutes: Some(60),
             }),
             secondary: Some(RateLimitWindowDisplay {
                 used_percent: 40.0,
                 resets_at: Some("later".to_string()),
+                resets_at_epoch_seconds: None,
                 window_minutes: None,
             }),
             credits: None,


### PR DESCRIPTION
## Summary
- expose rate-limit reset epoch seconds in the statusline display model
- include reset/capture timestamps in the Lua statusline context
- allow Lua statusline renderers to compute quota projections such as weekly pace

## Test
- cargo check -p libui

Signed-off-by: Mira <mira-agent@agentmail.to>