### PR TITLE
fix(tui): preserve WezTerm scrollback

### DIFF
--- a/bin/console/src/lib.rs
+++ b/bin/console/src/lib.rs
@@ -33,6 +33,7 @@ use chaos_kern::models_manager::CollaborationModesConfig;
 use chaos_kern::path_utils;
 use chaos_kern::runtime_db::get_runtime_db;
 use chaos_kern::terminal::Multiplexer;
+use chaos_kern::terminal::TerminalName;
 use chaos_proc::StateRuntime;
 use chaos_pwd::find_chaos_home;
 use chaos_realpath::AbsolutePathBuf;
@@ -674,6 +675,15 @@ async fn run_ratatui_app(
 
     let use_alt_screen = determine_alt_screen_mode(no_alt_screen, config.tui_alternate_screen);
     tui.set_alt_screen_enabled(use_alt_screen);
+    if chaos_kern::terminal::terminal_info().name == TerminalName::WezTerm {
+        // WezTerm does not add lines scrolled out of a bounded scroll region
+        // (DECSTBM with a pinned top row) to native scrollback. The sticky top
+        // bar reserves row 0 and uses a bounded region for history insertion,
+        // which makes mouse-wheel scrollback appear empty. Prefer native
+        // scrollback in WezTerm until the top bar can be rendered without
+        // constraining the scroll region.
+        tui.set_top_reserved_rows(0);
+    }
     let managers = boot_core(&config);
 
     let app_result = App::run(

--- a/lib/libui/tui.rs
+++ b/lib/libui/tui.rs
@@ -249,6 +249,15 @@ impl Tui {
         self.alt_screen_enabled = enabled;
     }
 
+    /// Set how many top rows the inline viewport reserves for chrome outside
+    /// the normal scrollback flow.
+    ///
+    /// Keeping this at zero preserves the terminal's native scrollback on
+    /// terminals that do not add bounded-scroll-region output to scrollback.
+    pub fn set_top_reserved_rows(&mut self, rows: u16) {
+        self.top_reserved_rows = rows;
+    }
+
     pub fn set_notification_method(&mut self, method: NotificationMethod) {
         self.notification_backend = Some(detect_backend(method));
     }


### PR DESCRIPTION
## Summary
- disable the sticky top reserved row when running inside WezTerm
- preserve WezTerm native scrollback by avoiding bounded scroll-region history insertion there
- expose a small Tui setter for top reserved rows

## Test plan
- cargo check -p chaos-console
- manually verified in WezTerm that scrollback works after install

Signed-off-by: Mira <mira-agent@agentmail.to>