### PR TITLE
fix(parrot): gate Codex rate limit parsing to OpenAI

### DIFF
--- a/lib/libui/chatwidget/tests.rs
+++ b/lib/libui/chatwidget/tests.rs
@@ -2277,6 +2277,43 @@ async fn rate_limit_snapshot_updates_and_retains_plan_type() {
 }
 
 #[tokio::test]
+async fn statusline_ctx_exposes_weekly_rate_limit_window() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None).await;
+
+    chat.on_rate_limit_snapshot(Some(RateLimitSnapshot {
+        limit_id: Some("chaos".to_string()),
+        limit_name: Some("chaos".to_string()),
+        primary: Some(RateLimitWindow {
+            used_percent: 8.0,
+            window_minutes: Some(300),
+            resets_at: Some(1_778_843_500),
+        }),
+        secondary: Some(RateLimitWindow {
+            used_percent: 12.0,
+            window_minutes: Some(10_080),
+            resets_at: Some(1_779_182_173),
+        }),
+        credits: None,
+        plan_type: Some(PlanType::Pro),
+    }));
+
+    let ctx = chat.build_statusline_ctx();
+    assert_eq!(ctx["five_hour"]["used_pct"], 8.0);
+    assert_eq!(ctx["five_hour"]["remaining_pct"], 92.0);
+    assert_eq!(ctx["five_hour"]["window_minutes"], 300);
+    assert_eq!(ctx["five_hour"]["resets_at_epoch_seconds"], 1_778_843_500);
+    assert_eq!(ctx["weekly"]["used_pct"], 12.0);
+    assert_eq!(ctx["weekly"]["remaining_pct"], 88.0);
+    assert_eq!(ctx["weekly"]["window_minutes"], 10_080);
+    assert_eq!(ctx["weekly"]["resets_at_epoch_seconds"], 1_779_182_173);
+    assert!(
+        ctx["rate_limit_captured_at_epoch_seconds"]
+            .as_i64()
+            .is_some()
+    );
+}
+
+#[tokio::test]
 async fn rate_limit_snapshots_keep_separate_entries_per_limit_id() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None).await;
 

--- a/sys/kern/providers/parrot/src/endpoint/responses.rs
+++ b/sys/kern/providers/parrot/src/endpoint/responses.rs
@@ -147,11 +147,14 @@ impl<T: HttpTransport, A: AuthProvider> ResponsesClient<T, A> {
             )
             .await?;
 
+        let use_openai_codex_rate_limits =
+            self.session.provider().name.eq_ignore_ascii_case("openai");
         Ok(spawn_response_stream(
             stream_response,
             self.session.provider().stream_idle_timeout,
             self.sse_telemetry.clone(),
             turn_state,
+            use_openai_codex_rate_limits,
         ))
     }
 }

--- a/sys/kern/providers/parrot/src/rate_limits.rs
+++ b/sys/kern/providers/parrot/src/rate_limits.rs
@@ -18,15 +18,22 @@ impl Display for RateLimitError {
     }
 }
 
-/// Parses the default Chaos rate-limit header family into a `RateLimitSnapshot`.
+/// Parses the default legacy Chaos rate-limit header family into a `RateLimitSnapshot`.
 pub fn parse_default_rate_limit(headers: &HeaderMap) -> Option<RateLimitSnapshot> {
     parse_rate_limit_for_limit(headers, /*limit_id*/ None)
 }
 
 /// Parses all known rate-limit header families into update records keyed by limit id.
-pub fn parse_all_rate_limits(headers: &HeaderMap) -> Vec<RateLimitSnapshot> {
+pub fn parse_all_rate_limits(
+    headers: &HeaderMap,
+    use_openai_codex_headers: bool,
+) -> Vec<RateLimitSnapshot> {
     let mut snapshots = Vec::new();
-    if let Some(snapshot) = parse_default_rate_limit(headers) {
+    if let Some(snapshot) = parse_rate_limit_for_limit_with_options(
+        headers,
+        /*limit_id*/ None,
+        use_openai_codex_headers,
+    ) {
         snapshots.push(snapshot);
     }
 
@@ -35,14 +42,19 @@ pub fn parse_all_rate_limits(headers: &HeaderMap) -> Vec<RateLimitSnapshot> {
     for name in headers.keys() {
         let header_name = name.as_str().to_ascii_lowercase();
         if let Some(limit_id) = header_name_to_limit_id(&header_name)
-            && !matches!(limit_id.as_str(), "chaos" | "codex")
+            .map(|limit_id| canonical_limit_id(limit_id, use_openai_codex_headers))
+            && !matches!(limit_id.as_str(), "chaos")
         {
             limit_ids.insert(limit_id);
         }
     }
 
     snapshots.extend(limit_ids.into_iter().filter_map(|limit_id| {
-        let snapshot = parse_rate_limit_for_limit(headers, Some(limit_id.as_str()))?;
+        let snapshot = parse_rate_limit_for_limit_with_options(
+            headers,
+            Some(limit_id.as_str()),
+            use_openai_codex_headers,
+        )?;
         has_rate_limit_data(&snapshot).then_some(snapshot)
     }));
 
@@ -57,18 +69,25 @@ pub fn parse_rate_limit_for_limit(
     headers: &HeaderMap,
     limit_id: Option<&str>,
 ) -> Option<RateLimitSnapshot> {
+    parse_rate_limit_for_limit_with_options(headers, limit_id, false)
+}
+
+/// Parses rate-limit headers with OpenAI Codex proxy aliases enabled.
+///
+/// `x-codex-*` is a ChatGPT/OpenAI-specific header family. Keep it opt-in so
+/// OpenAI-compatible providers that only happen to use the Responses endpoint do
+/// not have their unrelated `x-codex-*` headers interpreted as Chaos limits.
+pub fn parse_rate_limit_for_limit_with_options(
+    headers: &HeaderMap,
+    limit_id: Option<&str>,
+    use_openai_codex_headers: bool,
+) -> Option<RateLimitSnapshot> {
     let requested_limit = limit_id.map(str::trim).filter(|name| !name.is_empty());
-    let normalized_limit = requested_limit
-        .unwrap_or("chaos")
-        .to_ascii_lowercase()
-        .replace('_', "-");
-    // Omitted limit ids still read the legacy `x-chaos-*` header family while
-    // reporting the default logical limit id as `chaos`.
-    let header_limit = requested_limit
-        .unwrap_or("chaos")
-        .to_ascii_lowercase()
-        .replace('_', "-");
-    let prefix = format!("x-{header_limit}");
+    let normalized_limit_id = requested_limit
+        .map(normalize_limit_id)
+        .map(|limit_id| canonical_limit_id(limit_id, use_openai_codex_headers))
+        .unwrap_or_else(|| "chaos".to_string());
+    let prefix = select_header_prefix(headers, requested_limit, use_openai_codex_headers);
     let primary = parse_rate_limit_window(
         headers,
         &format!("{prefix}-primary-used-percent"),
@@ -83,8 +102,7 @@ pub fn parse_rate_limit_for_limit(
         &format!("{prefix}-secondary-reset-at"),
     );
 
-    let normalized_limit_id = normalize_limit_id(normalized_limit);
-    let credits = parse_credits_snapshot(headers);
+    let credits = parse_credits_snapshot(headers, &prefix);
     let limit_name_header = format!("{prefix}-limit-name");
     let parsed_limit_name = parse_header_str(headers, &limit_name_header)
         .map(str::trim)
@@ -97,7 +115,7 @@ pub fn parse_rate_limit_for_limit(
         primary,
         secondary,
         credits,
-        plan_type: None,
+        plan_type: parse_plan_type(headers, &prefix),
     })
 }
 
@@ -205,10 +223,10 @@ fn parse_rate_limit_window(
     })
 }
 
-fn parse_credits_snapshot(headers: &HeaderMap) -> Option<CreditsSnapshot> {
-    let has_credits = parse_header_bool(headers, "x-chaos-credits-has-credits")?;
-    let unlimited = parse_header_bool(headers, "x-chaos-credits-unlimited")?;
-    let balance = parse_header_str(headers, "x-chaos-credits-balance")
+fn parse_credits_snapshot(headers: &HeaderMap, prefix: &str) -> Option<CreditsSnapshot> {
+    let has_credits = parse_header_bool(headers, &format!("{prefix}-credits-has-credits"))?;
+    let unlimited = parse_header_bool(headers, &format!("{prefix}-credits-unlimited"))?;
+    let balance = parse_header_str(headers, &format!("{prefix}-credits-balance"))
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(std::string::ToString::to_string);
@@ -217,6 +235,13 @@ fn parse_credits_snapshot(headers: &HeaderMap) -> Option<CreditsSnapshot> {
         unlimited,
         balance,
     })
+}
+
+fn parse_plan_type(headers: &HeaderMap, prefix: &str) -> Option<PlanType> {
+    let raw = parse_header_str(headers, &format!("{prefix}-plan-type"))?
+        .trim()
+        .to_ascii_lowercase();
+    serde_json::from_value(serde_json::Value::String(raw)).ok()
 }
 
 fn parse_header_f64(headers: &HeaderMap, name: &str) -> Option<f64> {
@@ -260,6 +285,87 @@ fn normalize_limit_id(name: impl Into<String>) -> String {
     name.into().trim().to_ascii_lowercase().replace('-', "_")
 }
 
+fn canonical_limit_id(limit_id: String, use_openai_codex_headers: bool) -> String {
+    if !use_openai_codex_headers {
+        return limit_id;
+    }
+
+    if limit_id == "codex" {
+        "chaos".to_string()
+    } else if let Some(suffix) = limit_id.strip_prefix("codex_") {
+        format!("chaos_{suffix}")
+    } else {
+        limit_id
+    }
+}
+
+fn select_header_prefix(
+    headers: &HeaderMap,
+    requested_limit: Option<&str>,
+    use_openai_codex_headers: bool,
+) -> String {
+    let candidates = header_prefix_candidates(requested_limit, use_openai_codex_headers);
+    candidates
+        .iter()
+        .find(|prefix| header_prefix_has_data(headers, prefix))
+        .cloned()
+        .unwrap_or_else(|| candidates[0].clone())
+}
+
+fn header_prefix_candidates(
+    requested_limit: Option<&str>,
+    use_openai_codex_headers: bool,
+) -> Vec<String> {
+    let Some(requested_limit) = requested_limit else {
+        if use_openai_codex_headers {
+            return vec!["x-codex".to_string(), "x-chaos".to_string()];
+        }
+        return vec!["x-chaos".to_string()];
+    };
+
+    let normalized = normalize_limit_id(requested_limit);
+    if matches!(normalized.as_str(), "chaos" | "codex") {
+        if use_openai_codex_headers {
+            return vec!["x-codex".to_string(), "x-chaos".to_string()];
+        }
+        return vec!["x-chaos".to_string()];
+    }
+    let hyphenated = normalized.replace('_', "-");
+    let suffix = normalized
+        .strip_prefix("chaos_")
+        .or_else(|| {
+            use_openai_codex_headers
+                .then(|| normalized.strip_prefix("codex_"))
+                .flatten()
+        })
+        .unwrap_or(normalized.as_str())
+        .replace('_', "-");
+
+    let mut candidates = if use_openai_codex_headers {
+        vec![
+            format!("x-codex-{suffix}"),
+            format!("x-chaos-{suffix}"),
+            format!("x-{hyphenated}"),
+        ]
+    } else {
+        vec![format!("x-{hyphenated}")]
+    };
+    candidates.dedup();
+    candidates
+}
+
+fn header_prefix_has_data(headers: &HeaderMap, prefix: &str) -> bool {
+    [
+        "primary-used-percent",
+        "secondary-used-percent",
+        "credits-has-credits",
+        "plan-type",
+        "limit-name",
+    ]
+    .iter()
+    .any(|suffix| headers.contains_key(format!("{prefix}-{suffix}")))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -270,6 +376,53 @@ mod tests {
     fn parse_rate_limit_for_limit_defaults_to_codex_headers() {
         let mut headers = HeaderMap::new();
         headers.insert(
+            "x-codex-primary-used-percent",
+            HeaderValue::from_static("12.5"),
+        );
+        headers.insert(
+            "x-codex-primary-window-minutes",
+            HeaderValue::from_static("60"),
+        );
+        headers.insert(
+            "x-codex-primary-reset-at",
+            HeaderValue::from_static("1704069000"),
+        );
+        headers.insert("x-codex-plan-type", HeaderValue::from_static("pro"));
+
+        let snapshot =
+            parse_rate_limit_for_limit_with_options(&headers, None, true).expect("snapshot");
+        assert_eq!(snapshot.limit_id.as_deref(), Some("chaos"));
+        assert_eq!(snapshot.limit_name, None);
+        assert_eq!(snapshot.plan_type, Some(PlanType::Pro));
+        let primary = snapshot.primary.expect("primary");
+        assert_eq!(primary.used_percent, 12.5);
+        assert_eq!(primary.window_minutes, Some(60));
+        assert_eq!(primary.resets_at, Some(1704069000));
+    }
+
+    #[test]
+    fn codex_headers_are_ignored_unless_openai_codex_headers_are_enabled() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-codex-primary-used-percent",
+            HeaderValue::from_static("12.5"),
+        );
+        headers.insert(
+            "x-codex-primary-window-minutes",
+            HeaderValue::from_static("60"),
+        );
+
+        let snapshot = parse_rate_limit_for_limit(&headers, None).expect("snapshot");
+        assert_eq!(snapshot.limit_id.as_deref(), Some("chaos"));
+        assert_eq!(snapshot.primary, None);
+        assert_eq!(snapshot.secondary, None);
+        assert_eq!(snapshot.credits, None);
+    }
+
+    #[test]
+    fn parse_rate_limit_for_limit_falls_back_to_legacy_chaos_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
             "x-chaos-primary-used-percent",
             HeaderValue::from_static("12.5"),
         );
@@ -277,18 +430,30 @@ mod tests {
             "x-chaos-primary-window-minutes",
             HeaderValue::from_static("60"),
         );
-        headers.insert(
-            "x-chaos-primary-reset-at",
-            HeaderValue::from_static("1704069000"),
-        );
 
-        let snapshot = parse_rate_limit_for_limit(&headers, None).expect("snapshot");
+        let snapshot =
+            parse_rate_limit_for_limit_with_options(&headers, None, true).expect("snapshot");
         assert_eq!(snapshot.limit_id.as_deref(), Some("chaos"));
-        assert_eq!(snapshot.limit_name, None);
         let primary = snapshot.primary.expect("primary");
         assert_eq!(primary.used_percent, 12.5);
         assert_eq!(primary.window_minutes, Some(60));
-        assert_eq!(primary.resets_at, Some(1704069000));
+    }
+
+    #[test]
+    fn parse_rate_limit_for_explicit_default_limit_reads_codex_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-codex-primary-used-percent",
+            HeaderValue::from_static("12.5"),
+        );
+
+        let snapshot = parse_rate_limit_for_limit_with_options(&headers, Some("chaos"), true)
+            .expect("snapshot");
+        assert_eq!(snapshot.limit_id.as_deref(), Some("chaos"));
+        assert_eq!(
+            snapshot.primary.as_ref().map(|window| window.used_percent),
+            Some(12.5)
+        );
     }
 
     #[test]
@@ -308,7 +473,8 @@ mod tests {
         );
 
         let snapshot =
-            parse_rate_limit_for_limit(&headers, Some("chaos_secondary")).expect("snapshot");
+            parse_rate_limit_for_limit_with_options(&headers, Some("chaos_secondary"), true)
+                .expect("snapshot");
         assert_eq!(snapshot.limit_id.as_deref(), Some("chaos_secondary"));
         assert_eq!(snapshot.limit_name, None);
         let primary = snapshot.primary.expect("primary");
@@ -322,16 +488,17 @@ mod tests {
     fn parse_rate_limit_for_limit_prefers_limit_name_header() {
         let mut headers = HeaderMap::new();
         headers.insert(
-            "x-chaos-bengalfox-primary-used-percent",
+            "x-codex-bengalfox-primary-used-percent",
             HeaderValue::from_static("80"),
         );
         headers.insert(
-            "x-chaos-bengalfox-limit-name",
+            "x-codex-bengalfox-limit-name",
             HeaderValue::from_static("gpt-5.4-codex-sonic"),
         );
 
         let snapshot =
-            parse_rate_limit_for_limit(&headers, Some("chaos_bengalfox")).expect("snapshot");
+            parse_rate_limit_for_limit_with_options(&headers, Some("chaos_bengalfox"), true)
+                .expect("snapshot");
         assert_eq!(snapshot.limit_id.as_deref(), Some("chaos_bengalfox"));
         assert_eq!(snapshot.limit_name.as_deref(), Some("gpt-5.4-codex-sonic"));
     }
@@ -340,18 +507,18 @@ mod tests {
     fn parse_all_rate_limits_reads_all_limit_families() {
         let mut headers = HeaderMap::new();
         headers.insert(
-            "x-chaos-primary-used-percent",
+            "x-codex-primary-used-percent",
             HeaderValue::from_static("12.5"),
         );
         headers.insert(
-            "x-chaos-secondary-primary-used-percent",
+            "x-codex-bengalfox-primary-used-percent",
             HeaderValue::from_static("80"),
         );
 
-        let updates = parse_all_rate_limits(&headers);
+        let updates = parse_all_rate_limits(&headers, true);
         assert_eq!(updates.len(), 2);
         assert_eq!(updates[0].limit_id.as_deref(), Some("chaos"));
-        assert_eq!(updates[1].limit_id.as_deref(), Some("chaos_secondary"));
+        assert_eq!(updates[1].limit_id.as_deref(), Some("chaos_bengalfox"));
         assert_eq!(updates[0].limit_name, None);
         assert_eq!(updates[1].limit_name, None);
     }
@@ -360,7 +527,7 @@ mod tests {
     fn parse_all_rate_limits_includes_default_codex_snapshot() {
         let headers = HeaderMap::new();
 
-        let updates = parse_all_rate_limits(&headers);
+        let updates = parse_all_rate_limits(&headers, true);
         assert_eq!(updates.len(), 1);
         assert_eq!(updates[0].limit_id.as_deref(), Some("chaos"));
         assert_eq!(updates[0].limit_name, None);

--- a/sys/kern/providers/parrot/src/sse/responses.rs
+++ b/sys/kern/providers/parrot/src/sse/responses.rs
@@ -2,6 +2,7 @@ use crate::common::ResponseEvent;
 use crate::common::ResponseStream;
 use crate::error::ApiError;
 use crate::rate_limits::parse_all_rate_limits;
+use crate::rate_limits::parse_rate_limit_event;
 use crate::telemetry::SseTelemetry;
 use chaos_abi::ResponseItem;
 use chaos_abi::TokenUsage;
@@ -65,8 +66,10 @@ pub fn spawn_response_stream(
     idle_timeout: Duration,
     telemetry: Option<Arc<dyn SseTelemetry>>,
     turn_state: Option<Arc<OnceLock<String>>>,
+    use_openai_codex_rate_limits: bool,
 ) -> ResponseStream {
-    let rate_limit_snapshots = parse_all_rate_limits(&stream_response.headers);
+    let rate_limit_snapshots =
+        parse_all_rate_limits(&stream_response.headers, use_openai_codex_rate_limits);
     let models_etag = stream_response
         .headers
         .get("X-Models-Etag")
@@ -105,7 +108,14 @@ pub fn spawn_response_stream(
                 .send(Ok(ResponseEvent::ServerReasoningIncluded(true)))
                 .await;
         }
-        process_sse(stream_response.bytes, tx_event, idle_timeout, telemetry).await;
+        process_sse_with_options(
+            stream_response.bytes,
+            tx_event,
+            idle_timeout,
+            telemetry,
+            use_openai_codex_rate_limits,
+        )
+        .await;
     });
 
     ResponseStream { rx_event }
@@ -368,6 +378,16 @@ pub async fn process_sse(
     idle_timeout: Duration,
     telemetry: Option<Arc<dyn SseTelemetry>>,
 ) {
+    process_sse_with_options(stream, tx_event, idle_timeout, telemetry, false).await;
+}
+
+async fn process_sse_with_options(
+    stream: ByteStream,
+    tx_event: mpsc::Sender<Result<ResponseEvent, ApiError>>,
+    idle_timeout: Duration,
+    telemetry: Option<Arc<dyn SseTelemetry>>,
+    use_openai_codex_rate_limits: bool,
+) {
     let mut stream = EventStream::<_, String>::new(stream);
     let mut response_error: Option<ApiError> = None;
     let mut last_server_model: Option<String> = None;
@@ -402,6 +422,17 @@ pub async fn process_sse(
 
         let data = sse.data().map(String::as_str).unwrap_or_default();
         trace!("SSE event: {}", data);
+
+        if use_openai_codex_rate_limits && let Some(snapshot) = parse_rate_limit_event(data) {
+            if tx_event
+                .send(Ok(ResponseEvent::RateLimits(snapshot)))
+                .await
+                .is_err()
+            {
+                return;
+            }
+            continue;
+        }
 
         let event: ResponsesStreamEvent = match serde_json::from_str(data) {
             Ok(event) => event,
@@ -503,6 +534,7 @@ mod tests {
     use assert_matches::assert_matches;
     use bytes::Bytes;
     use chaos_abi::ResponseItem;
+    use chaos_ipc::account::PlanType;
     use chaos_ipc::models::MessagePhase;
     use codex_client::StreamResponse;
     use futures::stream;
@@ -534,6 +566,13 @@ mod tests {
     }
 
     async fn run_sse(events: Vec<serde_json::Value>) -> Vec<ResponseEvent> {
+        run_sse_with_options(events, false).await
+    }
+
+    async fn run_sse_with_options(
+        events: Vec<serde_json::Value>,
+        use_openai_codex_rate_limits: bool,
+    ) -> Vec<ResponseEvent> {
         let mut body = String::new();
         for e in events {
             let kind = e
@@ -550,7 +589,13 @@ mod tests {
         let (tx, mut rx) = mpsc::channel::<Result<ResponseEvent, ApiError>>(8);
         let stream = ReaderStream::new(std::io::Cursor::new(body))
             .map_err(|err| TransportError::Network(err.to_string()));
-        tokio::spawn(process_sse(Box::pin(stream), tx, idle_timeout(), None));
+        tokio::spawn(process_sse_with_options(
+            Box::pin(stream),
+            tx,
+            idle_timeout(),
+            None,
+            use_openai_codex_rate_limits,
+        ));
 
         let mut out = Vec::new();
         while let Some(ev) = rx.recv().await {
@@ -730,6 +775,84 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn process_sse_emits_chaos_rate_limits_event_for_openai() {
+        let events = run_sse_with_options(
+            vec![
+                json!({
+                    "type": "chaos.rate_limits",
+                    "metered_limit_name": "chaos",
+                    "plan_type": "pro",
+                    "rate_limits": {
+                        "primary": {
+                            "used_percent": 8.0,
+                            "window_minutes": 300,
+                            "reset_at": 1778843500
+                        },
+                        "secondary": {
+                            "used_percent": 12.0,
+                            "window_minutes": 10080,
+                            "reset_at": 1779182173
+                        }
+                    },
+                    "credits": {
+                        "has_credits": false,
+                        "unlimited": false,
+                        "balance": null
+                    }
+                }),
+                json!({
+                    "type": "response.completed",
+                    "response": { "id": "resp1" }
+                }),
+            ],
+            true,
+        )
+        .await;
+
+        assert_eq!(events.len(), 2);
+        match &events[0] {
+            ResponseEvent::RateLimits(snapshot) => {
+                assert_eq!(snapshot.limit_id.as_deref(), Some("chaos"));
+                assert_eq!(snapshot.plan_type, Some(PlanType::Pro));
+                let primary = snapshot.primary.as_ref().expect("primary");
+                assert_eq!(primary.used_percent, 8.0);
+                assert_eq!(primary.window_minutes, Some(300));
+                let secondary = snapshot.secondary.as_ref().expect("secondary");
+                assert_eq!(secondary.used_percent, 12.0);
+                assert_eq!(secondary.window_minutes, Some(10080));
+            }
+            other => panic!("expected rate limits event, got {other:?}"),
+        }
+        assert_matches!(&events[1], ResponseEvent::Completed { .. });
+    }
+
+    #[tokio::test]
+    async fn process_sse_ignores_chaos_rate_limits_event_when_not_openai() {
+        let events = run_sse(vec![
+            json!({
+                "type": "chaos.rate_limits",
+                "metered_limit_name": "chaos",
+                "plan_type": "pro",
+                "rate_limits": {
+                    "primary": {
+                        "used_percent": 8.0,
+                        "window_minutes": 300,
+                        "reset_at": 1778843500
+                    }
+                }
+            }),
+            json!({
+                "type": "response.completed",
+                "response": { "id": "resp1" }
+            }),
+        ])
+        .await;
+
+        assert_eq!(events.len(), 1);
+        assert_matches!(&events[0], ResponseEvent::Completed { .. });
+    }
+
+    #[tokio::test]
     async fn error_when_error_event() {
         let raw_error = r#"{"type":"response.failed","sequence_number":3,"response":{"id":"resp_689bcf18d7f08194bf3440ba62fe05d803fee0cdac429894","object":"response","created_at":1755041560,"status":"failed","background":false,"error":{"code":"rate_limit_exceeded","message":"Rate limit reached for gpt-5.1 in organization org-AAA on tokens per min (TPM): Limit 30000, Used 22999, Requested 12528. Please try again in 11.054s. Visit https://platform.openai.com/account/rate-limits to learn more."}, "usage":null,"user":null,"metadata":{}}}"#;
 
@@ -903,7 +1026,7 @@ mod tests {
             bytes: Box::pin(bytes),
         };
 
-        let mut stream = spawn_response_stream(stream_response, idle_timeout(), None, None);
+        let mut stream = spawn_response_stream(stream_response, idle_timeout(), None, None, true);
         let event = stream
             .rx_event
             .recv()


### PR DESCRIPTION
## Summary
- parse `x-codex-*` rate-limit headers only for the OpenAI provider
- keep legacy `x-chaos-*` behavior for non-OpenAI / OpenAI-compatible providers
- wire `chaos.rate_limits` SSE events only when OpenAI Codex rate limits are enabled
- add regressions for OpenAI gating and weekly statusline context

## Tests
- `cargo test -p chaos-parrot rate_limit --lib`
- `cargo test -p libui statusline_ctx_exposes_weekly_rate_limit_window`