### PR TITLE
fix(console): preserve WezTerm main scrollback

### DIFF
--- a/bin/console/src/lib.rs
+++ b/bin/console/src/lib.rs
@@ -675,9 +675,11 @@ async fn run_ratatui_app(
 
     let use_alt_screen = determine_alt_screen_mode(no_alt_screen, config.tui_alternate_screen);
     tui.set_alt_screen_enabled(use_alt_screen);
-    if !use_alt_screen && chaos_kern::terminal::terminal_info().name == TerminalName::WezTerm {
-        // WezTerm does not add bounded-scroll-region output (DECSTBM) to native
-        // scrollback. Only relevant in inline mode; alt-screen has no scrollback anyway.
+    if terminal_needs_unbounded_main_scrollback(chaos_kern::terminal::terminal_info().name) {
+        // The main transcript renders in the normal terminal buffer even when
+        // overlays are allowed to use alt-screen. WezTerm does not add
+        // bounded-scroll-region output (DECSTBM) to native scrollback, so keep
+        // the main transcript unbounded there.
         tui.set_top_reserved_rows(0);
     }
     let managers = boot_core(&config);
@@ -802,6 +804,10 @@ fn restore() {
     }
 }
 
+fn terminal_needs_unbounded_main_scrollback(terminal: TerminalName) -> bool {
+    matches!(terminal, TerminalName::WezTerm)
+}
+
 /// Determine whether to use the terminal's alternate screen buffer.
 ///
 /// The alternate screen buffer provides a cleaner fullscreen experience without polluting
@@ -869,6 +875,20 @@ mod tests {
             .chaos_home(temp_dir.path().to_path_buf())
             .build()
             .await
+    }
+
+    #[test]
+    fn wezterm_main_scrollback_stays_unbounded_even_when_alt_screen_is_available() {
+        assert!(terminal_needs_unbounded_main_scrollback(
+            TerminalName::WezTerm
+        ));
+    }
+
+    #[test]
+    fn non_wezterm_main_scrollback_keeps_reserved_top_row() {
+        assert!(!terminal_needs_unbounded_main_scrollback(
+            TerminalName::Unknown
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

Restores the WezTerm scrollback workaround for the main transcript regardless of whether overlay alt-screen support is enabled. The main TUI transcript still renders in the normal terminal buffer, so WezTerm needs `top_reserved_rows = 0` even when picker/overlay screens may use alt-screen.

Adds focused tests for the terminal helper so WezTerm remains on the unbounded-scrollback path while other terminals keep the sticky top-row reservation.

## Why

Commit `7f6409511` gated the WezTerm workaround behind `!use_alt_screen`. In default WezTerm config, `auto` permits alt-screen for overlays, so the workaround stopped running even though the main transcript still used the normal buffer. That reintroduced empty/broken native scrollback in fresh WezTerm tabs.

## How to verify

- [x] `just fmt`
- [x] `cargo test -p chaos-console wezterm_main_scrollback_stays_unbounded_even_when_alt_screen_is_available --all-features`
- [x] `cargo test -p chaos-console non_wezterm_main_scrollback_keeps_reserved_top_row --all-features`
- [x] Builds on target hardware: `just install`
- [ ] Full `just test` pass

Notes: I installed `cargo-nextest` and ran `just test`; it builds successfully but the full suite fails in existing/unrelated tests, starting with `chaos-kern review_prompts::tests::{review_diff_prefetch_disables_external_diff_helpers, review_diff_prefetch_disables_textconv_helpers}` and then many `chaos-kern::suite` harness tests. The targeted tests for this patch pass.

AI review: Mira reviewed the final diff for scope, contribution guidelines, and the WezTerm/alt-screen boundary before opening this PR.