### PR TITLE
feat(console): show live turn progress tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ installing, use `just chaos`. For a local release run, use
 `just bigbang`. See [man/chaos-install.7.md](./man/chaos-install.7.md)
 for system requirements and logging controls.
 
+During a running turn, the console status row may show an approximate live token
+progress counter such as `~1.2K tokens`. This is a liveness/size indicator for
+the current response, not provider usage accounting; exact usage is still shown
+from provider-reported token counts when available.
+
 ---
 
 ## Docs

--- a/lib/libcontract/ipc/src/protocol/event_msg.rs
+++ b/lib/libcontract/ipc/src/protocol/event_msg.rs
@@ -57,6 +57,7 @@ use super::TokenCountEvent;
 use super::TurnAbortedEvent;
 use super::TurnCompleteEvent;
 use super::TurnDiffEvent;
+use super::TurnProgressEvent;
 use super::TurnStartedEvent;
 use super::UndoCompletedEvent;
 use super::UndoStartedEvent;
@@ -131,6 +132,12 @@ pub enum EventMsg {
     /// Usage update for the current session, including totals and last turn.
     /// Optional means unknown — UIs should not display when `None`.
     TokenCount(TokenCountEvent),
+
+    /// Approximate progress for the currently running turn.
+    ///
+    /// This is intentionally separate from [`TokenCountEvent`]: values are
+    /// client-facing liveness estimates, not provider usage accounting.
+    TurnProgress(TurnProgressEvent),
 
     /// Agent text output message
     AgentMessage(AgentMessageEvent),

--- a/lib/libcontract/ipc/src/protocol/events_agent.rs
+++ b/lib/libcontract/ipc/src/protocol/events_agent.rs
@@ -43,6 +43,22 @@ pub struct TurnStartedEvent {
     pub collaboration_mode_kind: ModeKind,
 }
 
+/// Approximate live progress for an in-flight model turn.
+///
+/// These counts are deliberately heuristic and must not be used for billing,
+/// context accounting, or rate-limit decisions. They exist only to make long
+/// running turns visibly alive in clients.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+pub struct TurnProgressEvent {
+    pub turn_id: String,
+    #[ts(type = "number")]
+    pub approx_reasoning_tokens: i64,
+    #[ts(type = "number")]
+    pub approx_output_tokens: i64,
+    #[ts(type = "number")]
+    pub approx_total_tokens: i64,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, TS)]
 pub struct AgentMessageEvent {
     pub message: String,

--- a/lib/libcontract/ipc/src/protocol/tests/serde.rs
+++ b/lib/libcontract/ipc/src/protocol/tests/serde.rs
@@ -139,6 +139,29 @@ fn turn_aborted_event_deserializes_without_turn_id() -> Result<()> {
 }
 
 #[test]
+fn turn_progress_event_serializes_as_approximate_progress() -> Result<()> {
+    let event = EventMsg::TurnProgress(TurnProgressEvent {
+        turn_id: "turn-1".to_string(),
+        approx_reasoning_tokens: 1200,
+        approx_output_tokens: 300,
+        approx_total_tokens: 1500,
+    });
+
+    assert_eq!(
+        serde_json::to_value(event)?,
+        json!({
+            "type": "turn_progress",
+            "turn_id": "turn-1",
+            "approx_reasoning_tokens": 1200,
+            "approx_output_tokens": 300,
+            "approx_total_tokens": 1500,
+        })
+    );
+
+    Ok(())
+}
+
+#[test]
 fn turn_context_item_deserializes_without_network() -> Result<()> {
     let item: TurnContextItem = serde_json::from_value(json!({
         "cwd": "/tmp",

--- a/lib/libui/bottom_pane.rs
+++ b/lib/libui/bottom_pane.rs
@@ -164,6 +164,8 @@ pub struct BottomPane {
     pending_input_preview: PendingInputPreview,
     /// Inactive threads with pending approval requests.
     pending_process_approvals: PendingProcessApprovals,
+    /// Approximate live model-token progress for the active turn.
+    turn_progress_message: Option<String>,
     context_window_percent: Option<i64>,
     context_window_used_tokens: Option<i64>,
 }

--- a/lib/libui/bottom_pane/state.rs
+++ b/lib/libui/bottom_pane/state.rs
@@ -40,6 +40,7 @@ impl BottomPane {
             pending_process_approvals: PendingProcessApprovals::new(),
             esc_backtrack_hint: false,
             animations_enabled,
+            turn_progress_message: None,
             context_window_percent: None,
             context_window_used_tokens: None,
         }
@@ -469,6 +470,7 @@ impl BottomPane {
             }
         } else {
             // Hide the status indicator when a task completes, but keep other modal views.
+            self.turn_progress_message = None;
             self.hide_status_indicator();
         }
     }
@@ -575,13 +577,31 @@ impl BottomPane {
         }
     }
 
+    /// Update the approximate live model progress shown in the active status row.
+    pub fn set_turn_progress_message(&mut self, message: Option<String>) {
+        if self.turn_progress_message == message {
+            return;
+        }
+
+        self.turn_progress_message = message;
+        self.sync_status_inline_message();
+        self.request_redraw();
+    }
+
     /// Copy unified-exec summary text into the active status row, if any.
     ///
     /// This keeps status-line inline text synchronized without forcing the
     /// standalone unified-exec footer row to be visible.
     fn sync_status_inline_message(&mut self) {
         if let Some(status) = self.status.as_mut() {
-            status.update_inline_message(self.unified_exec_footer.summary_text());
+            let mut parts = Vec::new();
+            if let Some(progress) = self.turn_progress_message.as_ref() {
+                parts.push(progress.clone());
+            }
+            if let Some(exec_summary) = self.unified_exec_footer.summary_text() {
+                parts.push(exec_summary);
+            }
+            status.update_inline_message((!parts.is_empty()).then(|| parts.join(" · ")));
         }
     }
 

--- a/lib/libui/chatwidget/events/protocol_dispatch/dispatch.rs
+++ b/lib/libui/chatwidget/events/protocol_dispatch/dispatch.rs
@@ -101,6 +101,7 @@ impl ChatWidget {
                 self.set_token_info(ev.info);
                 self.on_rate_limit_snapshot(ev.rate_limits);
             }
+            EventMsg::TurnProgress(ev) => self.on_turn_progress(ev),
             EventMsg::Warning(WarningEvent { message }) => self.on_warning(message),
             EventMsg::ModelReroute(_) => {}
             EventMsg::Error(ErrorEvent {

--- a/lib/libui/chatwidget/events/protocol_dispatch/lifecycle.rs
+++ b/lib/libui/chatwidget/events/protocol_dispatch/lifecycle.rs
@@ -5,6 +5,7 @@ use chaos_ipc::protocol::McpStartupCompleteEvent;
 use chaos_ipc::protocol::McpStartupStatus;
 use chaos_ipc::protocol::McpStartupUpdateEvent;
 use chaos_ipc::protocol::TurnAbortReason;
+use chaos_ipc::protocol::TurnProgressEvent;
 use chaos_kern::config::Constrained;
 
 use crate::history_cell;
@@ -138,10 +139,22 @@ impl ChatWidget {
         self.pending_status_indicator_restore = false;
         self.bottom_pane
             .set_interrupt_hint_visible(/*visible*/ true);
+        self.bottom_pane.set_turn_progress_message(None);
         self.set_status_header(String::from("Working"));
         self.full_reasoning_buffer.clear();
         self.reasoning_buffer.clear();
         self.request_redraw();
+    }
+
+    pub(crate) fn on_turn_progress(&mut self, event: TurnProgressEvent) {
+        if !self.agent_turn_running {
+            return;
+        }
+        let message = format!(
+            "~{} tokens",
+            crate::status::format_tokens_compact(event.approx_total_tokens)
+        );
+        self.bottom_pane.set_turn_progress_message(Some(message));
     }
 
     pub(crate) fn on_task_complete(

--- a/lib/libui/status_indicator_widget.rs
+++ b/lib/libui/status_indicator_widget.rs
@@ -340,6 +340,21 @@ mod tests {
     }
 
     #[test]
+    fn renders_inline_progress_message() {
+        let tx = make_app_event_sender();
+        let mut w = StatusIndicatorWidget::new(tx, crate::tui::FrameRequester::test_dummy(), false);
+        w.update_inline_message(Some("~1.2K tokens".to_string()));
+        w.is_paused = true;
+        w.elapsed_running = Duration::ZERO;
+
+        let rendered = render_test_backend_debug(80, 1, |f| {
+            w.render(f.area(), f.buffer_mut());
+        });
+
+        assert!(rendered.contains("~1.2K tokens"), "{rendered}");
+    }
+
+    #[test]
     fn renders_wrapped_details_panama_two_lines() {
         let tx = make_app_event_sender();
         let mut w = StatusIndicatorWidget::new(tx, crate::tui::FrameRequester::test_dummy(), false);

--- a/srv/mcpd/src/chaos_runner.rs
+++ b/srv/mcpd/src/chaos_runner.rs
@@ -356,6 +356,7 @@ async fn run_event_loop(
                     | EventMsg::AgentReasoningRawContent(_)
                     | EventMsg::TurnStarted(_)
                     | EventMsg::TokenCount(_)
+                    | EventMsg::TurnProgress(_)
                     | EventMsg::AgentReasoning(_)
                     | EventMsg::AgentReasoningSectionBreak(_)
                     | EventMsg::McpToolCallBegin(_)

--- a/sys/exec/fork/src/event_processor_with_human_output/helpers.rs
+++ b/sys/exec/fork/src/event_processor_with_human_output/helpers.rs
@@ -93,6 +93,7 @@ impl EventProcessorWithHumanOutput {
                 msg,
                 EventMsg::ProcessNameUpdated(_)
                     | EventMsg::TokenCount(_)
+                    | EventMsg::TurnProgress(_)
                     | EventMsg::TurnStarted(_)
                     | EventMsg::ExecApprovalRequest(_)
                     | EventMsg::ApplyPatchApprovalRequest(_)

--- a/sys/exec/fork/src/event_processor_with_human_output/processor.rs
+++ b/sys/exec/fork/src/event_processor_with_human_output/processor.rs
@@ -763,6 +763,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
             EventMsg::ProcessNameUpdated(_)
             | EventMsg::ExecApprovalRequest(_)
             | EventMsg::ApplyPatchApprovalRequest(_)
+            | EventMsg::TurnProgress(_)
             | EventMsg::TerminalInteraction(_)
             | EventMsg::ExecCommandOutputDelta(_)
             | EventMsg::GetHistoryEntryResponse(_)

--- a/sys/kern/kern/src/chaos/session/event.rs
+++ b/sys/kern/kern/src/chaos/session/event.rs
@@ -27,6 +27,19 @@ impl Session {
         self.send_event_raw(event).await;
     }
 
+    /// Deliver a live-only event to clients without persisting it to rollout.
+    ///
+    /// Use this for high-frequency, reconstructable UI affordances such as
+    /// progress indicators. Durable conversation state should use
+    /// [`Self::send_event`] instead.
+    pub(crate) async fn send_transient_event(&self, turn_context: &TurnContext, msg: EventMsg) {
+        let event = Event {
+            id: turn_context.sub_id.clone(),
+            msg,
+        };
+        self.deliver_event_raw(event).await;
+    }
+
     pub(crate) async fn send_event_raw(&self, event: Event) {
         let rollout_items = vec![RolloutItem::EventMsg(event.msg.clone())];
         self.persist_rollout_items(&rollout_items).await;

--- a/sys/kern/kern/src/chaos/turn.rs
+++ b/sys/kern/kern/src/chaos/turn.rs
@@ -45,6 +45,7 @@ mod sampling;
 
 use preparation::run_auto_compact;
 use preparation::run_pre_sampling_compact;
+use execution::TurnProgressTracker;
 use sampling::run_sampling_request;
 
 #[derive(Debug)]
@@ -250,6 +251,11 @@ pub(crate) async fn run_turn(
     // which contains many turns, from the perspective of the user, it is a single turn.
     let turn_diff_tracker = Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new()));
     let mut server_model_warning_emitted_for_turn = false;
+    // Keep the approximate live progress scoped to the whole user-visible turn,
+    // not to an individual Responses API request. Tool calls, hook continuations,
+    // and other follow-up sampling requests should advance the same counter; the
+    // UI clears it when the turn completes.
+    let mut turn_progress = TurnProgressTracker::new();
 
     // `ModelClientSession` is turn-scoped and caches WebSocket + sticky routing state, so we
     // reuse one instance across retries within this turn.
@@ -338,6 +344,7 @@ pub(crate) async fn run_turn(
             Arc::clone(&turn_context),
             Arc::clone(&turn_diff_tracker),
             &mut client_session,
+            &mut turn_progress,
             turn_metadata_header.as_deref(),
             sampling_request_input,
             &mut server_model_warning_emitted_for_turn,

--- a/sys/kern/kern/src/chaos/turn/execution.rs
+++ b/sys/kern/kern/src/chaos/turn/execution.rs
@@ -1,10 +1,13 @@
 use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
 
 use chaos_epoll::OrCancelExt;
 use chaos_ipc::config_types::ModeKind;
 use chaos_ipc::items::TurnItem;
 use chaos_ipc::models::ResponseInputItem;
 use chaos_ipc::protocol::EventMsg;
+use chaos_ipc::protocol::TurnProgressEvent;
 use futures::future::BoxFuture;
 use futures::prelude::*;
 use futures::stream::FuturesOrdered;
@@ -36,6 +39,82 @@ use super::super::response_parsing::{
     flush_assistant_text_segments_for_item, handle_assistant_item_done_in_plan_mode,
 };
 use super::SamplingRequestResult;
+
+const TURN_PROGRESS_EMIT_INTERVAL: Duration = Duration::from_millis(500);
+const APPROX_CHARS_PER_TOKEN: usize = 4;
+const APPROX_SILENT_THINKING_TOKENS_PER_SECOND: u64 = 25;
+
+#[derive(Debug)]
+struct TurnProgressTracker {
+    output_chars: usize,
+    reasoning_chars: usize,
+    last_emitted_total_tokens: i64,
+    last_emit_at: Instant,
+    started_at: Instant,
+}
+
+impl TurnProgressTracker {
+    fn new() -> Self {
+        let now = Instant::now();
+        // Allow the first non-zero observation to emit immediately.
+        Self {
+            output_chars: 0,
+            reasoning_chars: 0,
+            last_emitted_total_tokens: 0,
+            last_emit_at: now - TURN_PROGRESS_EMIT_INTERVAL,
+            started_at: now,
+        }
+    }
+
+    fn observe_output_delta(&mut self, delta: &str) {
+        self.output_chars = self.output_chars.saturating_add(delta.chars().count());
+    }
+
+    fn observe_reasoning_delta(&mut self, delta: &str) {
+        self.reasoning_chars = self.reasoning_chars.saturating_add(delta.chars().count());
+    }
+
+    async fn emit_if_due(&mut self, sess: &Session, turn_context: &TurnContext) {
+        let now = Instant::now();
+        if now.duration_since(self.last_emit_at) < TURN_PROGRESS_EMIT_INTERVAL {
+            return;
+        }
+
+        let observed_reasoning_tokens = approx_tokens_from_chars(self.reasoning_chars);
+        let synthetic_thinking_tokens = self.synthetic_thinking_tokens(now);
+        let approx_reasoning_tokens = observed_reasoning_tokens.max(synthetic_thinking_tokens);
+        let approx_output_tokens = approx_tokens_from_chars(self.output_chars);
+        let approx_total_tokens = approx_reasoning_tokens + approx_output_tokens;
+        if approx_total_tokens == 0 || approx_total_tokens == self.last_emitted_total_tokens {
+            return;
+        }
+
+        self.last_emit_at = now;
+        self.last_emitted_total_tokens = approx_total_tokens;
+        sess.send_transient_event(
+            turn_context,
+            EventMsg::TurnProgress(TurnProgressEvent {
+                turn_id: turn_context.sub_id.clone(),
+                approx_reasoning_tokens,
+                approx_output_tokens,
+                approx_total_tokens,
+            }),
+        )
+        .await;
+    }
+
+    fn synthetic_thinking_tokens(&self, now: Instant) -> i64 {
+        let elapsed_ms = now
+            .saturating_duration_since(self.started_at)
+            .as_millis()
+            .min(i64::MAX as u128) as i64;
+        elapsed_ms * APPROX_SILENT_THINKING_TOKENS_PER_SECOND as i64 / 1_000
+    }
+}
+
+fn approx_tokens_from_chars(chars: usize) -> i64 {
+    chars.div_ceil(APPROX_CHARS_PER_TOKEN) as i64
+}
 
 #[allow(clippy::too_many_arguments)]
 #[instrument(level = "trace",
@@ -87,6 +166,7 @@ pub(super) async fn try_run_sampling_request(
     let mut last_agent_message: Option<String> = None;
     let mut active_item: Option<TurnItem> = None;
     let mut should_emit_turn_diff = false;
+    let mut progress = TurnProgressTracker::new();
     let plan_mode = turn_context.collaboration_mode.mode == ModeKind::Plan;
     let mut assistant_message_stream_parsers = AssistantMessageStreamParsers::new(plan_mode);
     let mut plan_mode_state = plan_mode.then(|| PlanModeStreamState::new(&turn_context.sub_id));
@@ -100,14 +180,23 @@ pub(super) async fn try_run_sampling_request(
             from = field::Empty,
         );
 
-        let event = match stream
-            .next()
-            .instrument(trace_span!(parent: &handle_responses, "receiving"))
-            .or_cancel(&cancellation_token)
-            .await
+        let event = match tokio::time::timeout(
+            TURN_PROGRESS_EMIT_INTERVAL,
+            stream
+                .next()
+                .instrument(trace_span!(parent: &handle_responses, "receiving"))
+                .or_cancel(&cancellation_token),
+        )
+        .await
         {
-            Ok(event) => event,
-            Err(chaos_epoll::CancelErr::Cancelled) => break Err(ChaosErr::TurnAborted),
+            Ok(Ok(event)) => event,
+            Ok(Err(chaos_epoll::CancelErr::Cancelled)) => break Err(ChaosErr::TurnAborted),
+            Err(_) => {
+                progress
+                    .emit_if_due(sess.as_ref(), turn_context.as_ref())
+                    .await;
+                continue;
+            }
         };
 
         let event = match event {
@@ -296,6 +385,10 @@ pub(super) async fn try_run_sampling_request(
                 });
             }
             ResponseEvent::OutputTextDelta(delta) => {
+                progress.observe_output_delta(&delta);
+                progress
+                    .emit_if_due(sess.as_ref(), turn_context.as_ref())
+                    .await;
                 // In review child threads, suppress assistant text deltas; the
                 // UI will show a selection popup from the final ReviewOutput.
                 //
@@ -345,6 +438,10 @@ pub(super) async fn try_run_sampling_request(
                 delta,
                 summary_index,
             } => {
+                progress.observe_reasoning_delta(&delta);
+                progress
+                    .emit_if_due(sess.as_ref(), turn_context.as_ref())
+                    .await;
                 if let Some(active) = active_item.as_ref() {
                     let event = crate::protocol::ReasoningContentDeltaEvent {
                         process_id: sess.conversation_id.to_string(),
@@ -380,6 +477,10 @@ pub(super) async fn try_run_sampling_request(
                 delta,
                 content_index,
             } => {
+                progress.observe_reasoning_delta(&delta);
+                progress
+                    .emit_if_due(sess.as_ref(), turn_context.as_ref())
+                    .await;
                 if let Some(active) = active_item.as_ref() {
                     let event = crate::protocol::ReasoningRawContentDeltaEvent {
                         process_id: sess.conversation_id.to_string(),

--- a/sys/kern/kern/src/chaos/turn/execution.rs
+++ b/sys/kern/kern/src/chaos/turn/execution.rs
@@ -45,7 +45,7 @@ const APPROX_CHARS_PER_TOKEN: usize = 4;
 const APPROX_SILENT_THINKING_TOKENS_PER_SECOND: u64 = 25;
 
 #[derive(Debug)]
-struct TurnProgressTracker {
+pub(super) struct TurnProgressTracker {
     output_chars: usize,
     reasoning_chars: usize,
     last_emitted_total_tokens: i64,
@@ -54,7 +54,7 @@ struct TurnProgressTracker {
 }
 
 impl TurnProgressTracker {
-    fn new() -> Self {
+    pub(super) fn new() -> Self {
         let now = Instant::now();
         // Allow the first non-zero observation to emit immediately.
         Self {
@@ -74,7 +74,7 @@ impl TurnProgressTracker {
         self.reasoning_chars = self.reasoning_chars.saturating_add(delta.chars().count());
     }
 
-    async fn emit_if_due(&mut self, sess: &Session, turn_context: &TurnContext) {
+    pub(super) async fn emit_if_due(&mut self, sess: &Session, turn_context: &TurnContext) {
         let now = Instant::now();
         if now.duration_since(self.last_emit_at) < TURN_PROGRESS_EMIT_INTERVAL {
             return;
@@ -131,6 +131,7 @@ pub(super) async fn try_run_sampling_request(
     client_session: &mut ModelClientSession,
     turn_metadata_header: Option<&str>,
     turn_diff_tracker: SharedTurnDiffTracker,
+    progress: &mut TurnProgressTracker,
     server_model_warning_emitted_for_turn: &mut bool,
     last_server_model: &mut Option<String>,
     prompt: &Prompt,
@@ -166,7 +167,6 @@ pub(super) async fn try_run_sampling_request(
     let mut last_agent_message: Option<String> = None;
     let mut active_item: Option<TurnItem> = None;
     let mut should_emit_turn_diff = false;
-    let mut progress = TurnProgressTracker::new();
     let plan_mode = turn_context.collaboration_mode.mode == ModeKind::Plan;
     let mut assistant_message_stream_parsers = AssistantMessageStreamParsers::new(plan_mode);
     let mut plan_mode_state = plan_mode.then(|| PlanModeStreamState::new(&turn_context.sub_id));

--- a/sys/kern/kern/src/chaos/turn/sampling.rs
+++ b/sys/kern/kern/src/chaos/turn/sampling.rs
@@ -17,6 +17,7 @@ use crate::util::backoff;
 use super::super::Session;
 use super::super::TurnContext;
 use super::SamplingRequestResult;
+use super::execution::TurnProgressTracker;
 use super::execution::try_run_sampling_request;
 
 pub(super) fn build_prompt(
@@ -65,6 +66,7 @@ pub(super) async fn run_sampling_request(
     turn_context: Arc<TurnContext>,
     turn_diff_tracker: SharedTurnDiffTracker,
     client_session: &mut ModelClientSession,
+    progress: &mut TurnProgressTracker,
     turn_metadata_header: Option<&str>,
     input: Vec<chaos_ipc::models::ResponseItem>,
     server_model_warning_emitted_for_turn: &mut bool,
@@ -102,6 +104,7 @@ pub(super) async fn run_sampling_request(
             client_session,
             turn_metadata_header,
             Arc::clone(&turn_diff_tracker),
+            progress,
             server_model_warning_emitted_for_turn,
             &mut last_server_model,
             &prompt,

--- a/sys/kern/kern/src/rollout/policy.rs
+++ b/sys/kern/kern/src/rollout/policy.rs
@@ -90,6 +90,7 @@ fn event_msg_persistence_mode(ev: &EventMsg) -> Option<EventPersistenceMode> {
         EventMsg::UserMessage(_)
         | EventMsg::Warning(_)
         | EventMsg::ModelReroute(_)
+        | EventMsg::TurnProgress(_)
         | EventMsg::AgentReasoningSectionBreak(_)
         | EventMsg::RawResponseItem(_)
         | EventMsg::SessionConfigured(_)
@@ -132,5 +133,26 @@ fn event_msg_persistence_mode(ev: &EventMsg) -> Option<EventPersistenceMode> {
         | EventMsg::CollabCloseBegin(_)
         | EventMsg::CollabResumeBegin(_)
         | EventMsg::ImageGenerationBegin(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chaos_ipc::protocol::TurnProgressEvent;
+
+    #[test]
+    fn turn_progress_is_not_persisted() {
+        let event = EventMsg::TurnProgress(TurnProgressEvent {
+            turn_id: "turn-1".to_string(),
+            approx_reasoning_tokens: 10,
+            approx_output_tokens: 5,
+            approx_total_tokens: 15,
+        });
+
+        assert!(!should_persist_event_msg(
+            &event,
+            EventPersistenceMode::Extended
+        ));
     }
 }


### PR DESCRIPTION
## What changed

Adds a transient `TurnProgress` event for in-flight model turns and renders it in the console status row as an approximate token counter such as `~1.2K tokens`.

The counter:

- emits while the stream is silent, so hidden thinking has visible progress
- incorporates streamed reasoning/output deltas when available
- is throttled to avoid UI/event spam
- is not persisted to rollout history
- stays separate from real provider token usage/accounting

## Why

Long-running turns can look stuck while the model is thinking silently. The approximate counter gives users a lightweight sense of liveness and task size without pretending to be accurate usage/billing data.

## How to verify

- [x] `cargo check -q`
- [x] `git diff --check`
- [x] `cargo test -q -p chaos-ipc turn_progress_event_serializes_as_approximate_progress`
- [x] `cargo test -q -p chaos-kern rollout::policy::tests::turn_progress_is_not_persisted`
- [x] `cargo test -q -p libui renders_inline_progress_message`
- [x] Builds on target hardware (`just install` completed locally)

Note: `just test` was attempted locally before pushing, but the macOS harness currently fails unrelated sandbox/integration tests (for example `CARGO_BIN_EXE_alcatraz-macos` unset). The focused tests for this change pass.
