### PR TITLE
Add invocation runtime usage telemetry

### DIFF
--- a/bin/xclient/src/lib.rs
+++ b/bin/xclient/src/lib.rs
@@ -623,21 +623,15 @@ mod tests {
             info: Some(TokenUsageInfo {
                 total_token_usage: TokenUsage {
                     input_tokens: 10,
-                    cached_input_tokens: 0,
                     output_tokens: 20,
-                    reasoning_output_tokens: 0,
                     total_tokens: 30,
+                    ..Default::default()
                 },
-                last_token_usage: TokenUsage {
-                    input_tokens: 0,
-                    cached_input_tokens: 0,
-                    output_tokens: 0,
-                    reasoning_output_tokens: 0,
-                    total_tokens: 0,
-                },
+                last_token_usage: TokenUsage::default(),
                 model_context_window: None,
             }),
             rate_limits: None,
+            provider_request_started: false,
         })));
         assert_eq!(
             app.frontend.transcript.len(),

--- a/lib/libcontract/ipc/src/protocol/events_token.rs
+++ b/lib/libcontract/ipc/src/protocol/events_token.rs
@@ -10,6 +10,13 @@ use ts_rs::TS;
 pub struct TokenUsage {
     #[ts(type = "number")]
     pub input_tokens: i64,
+    /// Input tokens written into the provider prompt cache.
+    ///
+    /// This is separate from [`Self::cached_input_tokens`], which is the
+    /// compatibility name for cache-read input tokens.
+    #[serde(default)]
+    #[ts(type = "number")]
+    pub cache_creation_input_tokens: i64,
     #[ts(type = "number")]
     pub cached_input_tokens: i64,
     #[ts(type = "number")]
@@ -18,6 +25,10 @@ pub struct TokenUsage {
     pub reasoning_output_tokens: i64,
     #[ts(type = "number")]
     pub total_tokens: i64,
+    /// Number of model-provider requests dispatched for this usage scope.
+    #[serde(default)]
+    #[ts(type = "number")]
+    pub provider_request_count: i64,
 }
 
 // Includes prompts, tools and space to call compact.
@@ -32,6 +43,23 @@ impl TokenUsage {
         self.cached_input_tokens.max(0)
     }
 
+    /// Compatibility-safe name for cache-read input.
+    pub fn cache_read_input(&self) -> i64 {
+        self.cached_input()
+    }
+
+    pub fn cache_creation_input(&self) -> i64 {
+        self.cache_creation_input_tokens.max(0)
+    }
+
+    /// Ordinary provider input, excluding cache writes and cache reads.
+    pub fn uncached_input(&self) -> i64 {
+        (self.input_tokens - self.cache_creation_input() - self.cached_input()).max(0)
+    }
+
+    /// Compatibility helper: input excluding cache reads, but including cache
+    /// creation. Prefer [`Self::uncached_input`] for a provider billing
+    /// breakdown.
     pub fn non_cached_input(&self) -> i64 {
         (self.input_tokens - self.cached_input()).max(0)
     }
@@ -81,10 +109,42 @@ impl TokenUsage {
     /// In-place element-wise sum of token counts.
     pub fn add_assign(&mut self, other: &TokenUsage) {
         self.input_tokens += other.input_tokens;
+        self.cache_creation_input_tokens += other.cache_creation_input_tokens;
         self.cached_input_tokens += other.cached_input_tokens;
         self.output_tokens += other.output_tokens;
         self.reasoning_output_tokens += other.reasoning_output_tokens;
         self.total_tokens += other.total_tokens;
+        self.provider_request_count += other.provider_request_count;
+    }
+
+    /// Saturating element-wise difference for cumulative provider accounting.
+    pub fn difference_since(&self, baseline: &TokenUsage) -> TokenUsage {
+        fn delta(current: i64, previous: i64) -> i64 {
+            if current >= previous {
+                current - previous
+            } else {
+                current.max(0)
+            }
+        }
+
+        TokenUsage {
+            input_tokens: delta(self.input_tokens, baseline.input_tokens),
+            cache_creation_input_tokens: delta(
+                self.cache_creation_input_tokens,
+                baseline.cache_creation_input_tokens,
+            ),
+            cached_input_tokens: delta(self.cached_input_tokens, baseline.cached_input_tokens),
+            output_tokens: delta(self.output_tokens, baseline.output_tokens),
+            reasoning_output_tokens: delta(
+                self.reasoning_output_tokens,
+                baseline.reasoning_output_tokens,
+            ),
+            total_tokens: delta(self.total_tokens, baseline.total_tokens),
+            provider_request_count: delta(
+                self.provider_request_count,
+                baseline.provider_request_count,
+            ),
+        }
     }
 }
 
@@ -127,6 +187,16 @@ impl TokenUsageInfo {
     pub fn append_last_usage(&mut self, last: &TokenUsage) {
         self.total_token_usage.add_assign(last);
         self.last_token_usage = last.clone();
+    }
+
+    /// Count one provider dispatch without disturbing the last provider usage,
+    /// which is also used for context-window calculations.
+    pub fn record_provider_request(&mut self) -> i64 {
+        self.total_token_usage.provider_request_count = self
+            .total_token_usage
+            .provider_request_count
+            .saturating_add(1);
+        self.total_token_usage.provider_request_count
     }
 
     pub fn fill_to_context_window(&mut self, context_window: i64) {
@@ -188,6 +258,9 @@ pub struct CreditsSnapshot {
 pub struct TokenCountEvent {
     pub info: Option<TokenUsageInfo>,
     pub rate_limits: Option<RateLimitSnapshot>,
+    /// True on the snapshot emitted immediately after a provider stream opens.
+    #[serde(default)]
+    pub provider_request_started: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]

--- a/lib/libcontract/ipc/src/protocol/events_token.rs
+++ b/lib/libcontract/ipc/src/protocol/events_token.rs
@@ -204,10 +204,10 @@ impl TokenUsageInfo {
         let delta = (context_window - previous_total).max(0);
 
         self.model_context_window = Some(context_window);
-        self.total_token_usage = TokenUsage {
-            total_tokens: context_window,
-            ..TokenUsage::default()
-        };
+        // This method substitutes an estimated context load after the provider
+        // reports that the context window is full. It must not erase the
+        // process-lifetime billing counters accumulated before that error.
+        self.total_token_usage.total_tokens = context_window;
         self.last_token_usage = TokenUsage {
             total_tokens: delta,
             ..TokenUsage::default()

--- a/lib/libcontract/ipc/src/protocol/tests/serde.rs
+++ b/lib/libcontract/ipc/src/protocol/tests/serde.rs
@@ -501,6 +501,36 @@ fn record_provider_request_preserves_last_usage_context_semantics() {
 }
 
 #[test]
+fn fill_to_context_window_preserves_process_usage_counters() {
+    let cumulative = TokenUsage {
+        input_tokens: 1_000,
+        cache_creation_input_tokens: 200,
+        cached_input_tokens: 700,
+        output_tokens: 100,
+        reasoning_output_tokens: 10,
+        total_tokens: 1_100,
+        provider_request_count: 4,
+    };
+    let mut info = TokenUsageInfo {
+        total_token_usage: cumulative.clone(),
+        last_token_usage: TokenUsage::default(),
+        model_context_window: Some(128_000),
+    };
+
+    info.fill_to_context_window(200_000);
+
+    assert_eq!(
+        info.total_token_usage,
+        TokenUsage {
+            total_tokens: 200_000,
+            ..cumulative
+        }
+    );
+    assert_eq!(info.last_token_usage.total_tokens, 198_900);
+    assert_eq!(info.model_context_window, Some(200_000));
+}
+
+#[test]
 fn rollout_item_accepts_legacy_turn_context() -> Result<()> {
     // Exact wire shape found in journal_1.sqlite rows persisted before the
     // sandbox split. RolloutItem must still load them.

--- a/lib/libcontract/ipc/src/protocol/tests/serde.rs
+++ b/lib/libcontract/ipc/src/protocol/tests/serde.rs
@@ -333,10 +333,12 @@ fn token_usage_info_new_or_append_updates_context_window_when_provided() {
     });
     let last = Some(TokenUsage {
         input_tokens: 10,
+        cache_creation_input_tokens: 0,
         cached_input_tokens: 0,
         output_tokens: 0,
         reasoning_output_tokens: 0,
         total_tokens: 10,
+        provider_request_count: 0,
     });
 
     let info = TokenUsageInfo::new_or_append(&initial, &last, Some(128_000))
@@ -354,16 +356,148 @@ fn token_usage_info_new_or_append_preserves_context_window_when_not_provided() {
     });
     let last = Some(TokenUsage {
         input_tokens: 10,
+        cache_creation_input_tokens: 0,
         cached_input_tokens: 0,
         output_tokens: 0,
         reasoning_output_tokens: 0,
         total_tokens: 10,
+        provider_request_count: 0,
     });
 
     let info = TokenUsageInfo::new_or_append(&initial, &last, None)
         .expect("new_or_append should return info");
 
     assert_eq!(info.model_context_window, Some(258_400));
+}
+
+#[test]
+fn token_usage_add_assign_sums_cache_creation_and_provider_requests() {
+    let mut total = TokenUsage {
+        input_tokens: 100,
+        cache_creation_input_tokens: 20,
+        cached_input_tokens: 30,
+        output_tokens: 10,
+        reasoning_output_tokens: 2,
+        total_tokens: 110,
+        provider_request_count: 1,
+    };
+    total.add_assign(&TokenUsage {
+        input_tokens: 200,
+        cache_creation_input_tokens: 40,
+        cached_input_tokens: 50,
+        output_tokens: 20,
+        reasoning_output_tokens: 3,
+        total_tokens: 220,
+        provider_request_count: 2,
+    });
+
+    assert_eq!(
+        total,
+        TokenUsage {
+            input_tokens: 300,
+            cache_creation_input_tokens: 60,
+            cached_input_tokens: 80,
+            output_tokens: 30,
+            reasoning_output_tokens: 5,
+            total_tokens: 330,
+            provider_request_count: 3,
+        }
+    );
+    assert_eq!(total.cache_read_input(), 80);
+    assert_eq!(total.uncached_input(), 160);
+}
+
+#[test]
+fn token_usage_difference_since_handles_process_resume_and_counter_resets() {
+    let baseline = TokenUsage {
+        input_tokens: 1_000,
+        cache_creation_input_tokens: 200,
+        cached_input_tokens: 700,
+        output_tokens: 100,
+        reasoning_output_tokens: 10,
+        total_tokens: 1_100,
+        provider_request_count: 4,
+    };
+    let cumulative = TokenUsage {
+        input_tokens: 1_100,
+        cache_creation_input_tokens: 220,
+        cached_input_tokens: 770,
+        output_tokens: 110,
+        reasoning_output_tokens: 12,
+        total_tokens: 1_210,
+        provider_request_count: 5,
+    };
+
+    assert_eq!(
+        cumulative.difference_since(&baseline),
+        TokenUsage {
+            input_tokens: 100,
+            cache_creation_input_tokens: 20,
+            cached_input_tokens: 70,
+            output_tokens: 10,
+            reasoning_output_tokens: 2,
+            total_tokens: 110,
+            provider_request_count: 1,
+        }
+    );
+
+    let reset = TokenUsage {
+        input_tokens: 50,
+        cache_creation_input_tokens: 10,
+        cached_input_tokens: 30,
+        output_tokens: 5,
+        reasoning_output_tokens: 0,
+        total_tokens: 55,
+        provider_request_count: 1,
+    };
+    assert_eq!(reset.difference_since(&baseline), reset);
+}
+
+#[test]
+fn token_usage_serialization_is_additive_and_legacy_defaults_are_safe() -> Result<()> {
+    let usage = TokenUsage {
+        input_tokens: 100,
+        cache_creation_input_tokens: 20,
+        cached_input_tokens: 30,
+        output_tokens: 10,
+        reasoning_output_tokens: 2,
+        total_tokens: 110,
+        provider_request_count: 3,
+    };
+    let value = serde_json::to_value(&usage)?;
+    assert_eq!(value["cache_creation_input_tokens"], 20);
+    assert_eq!(value["provider_request_count"], 3);
+
+    let legacy: TokenUsage = serde_json::from_value(json!({
+        "input_tokens": 100,
+        "cached_input_tokens": 30,
+        "output_tokens": 10,
+        "reasoning_output_tokens": 2,
+        "total_tokens": 110
+    }))?;
+    assert_eq!(legacy.cache_creation_input_tokens, 0);
+    assert_eq!(legacy.provider_request_count, 0);
+    Ok(())
+}
+
+#[test]
+fn record_provider_request_preserves_last_usage_context_semantics() {
+    let last = TokenUsage {
+        input_tokens: 100,
+        total_tokens: 110,
+        ..TokenUsage::default()
+    };
+    let mut info = TokenUsageInfo {
+        total_token_usage: last.clone(),
+        last_token_usage: last.clone(),
+        model_context_window: Some(128_000),
+    };
+
+    let request_count = info.record_provider_request();
+
+    assert_eq!(request_count, 1);
+    assert_eq!(info.total_token_usage.provider_request_count, 1);
+    assert_eq!(info.last_token_usage, last);
 }
 
 #[test]

--- a/lib/libui/chassis/reducer.rs
+++ b/lib/libui/chassis/reducer.rs
@@ -441,15 +441,15 @@ mod tests {
             info: Some(TokenUsageInfo {
                 total_token_usage: TokenUsage {
                     input_tokens: 1,
-                    cached_input_tokens: 0,
                     output_tokens: 2,
-                    reasoning_output_tokens: 0,
                     total_tokens: 3,
+                    ..Default::default()
                 },
                 last_token_usage: TokenUsage::default(),
                 model_context_window: None,
             }),
             rate_limits: None,
+            provider_request_started: false,
         }));
         assert_eq!(
             Some(3),

--- a/lib/libui/chatwidget/tests.rs
+++ b/lib/libui/chatwidget/tests.rs
@@ -1861,6 +1861,7 @@ async fn review_restores_context_window_indicator() {
         msg: EventMsg::TokenCount(TokenCountEvent {
             info: Some(make_token_info(pre_review_tokens, context_window)),
             rate_limits: None,
+            provider_request_started: false,
         }),
     });
     assert_eq!(chat.bottom_pane.context_window_percent(), Some(30));
@@ -1881,6 +1882,7 @@ async fn review_restores_context_window_indicator() {
         msg: EventMsg::TokenCount(TokenCountEvent {
             info: Some(make_token_info(review_tokens, context_window)),
             rate_limits: None,
+            provider_request_started: false,
         }),
     });
     assert_eq!(chat.bottom_pane.context_window_percent(), Some(97));
@@ -1910,6 +1912,7 @@ async fn token_count_none_resets_context_indicator() {
         msg: EventMsg::TokenCount(TokenCountEvent {
             info: Some(make_token_info(pre_compact_tokens, context_window)),
             rate_limits: None,
+            provider_request_started: false,
         }),
     });
     assert_eq!(chat.bottom_pane.context_window_percent(), Some(30));
@@ -1919,6 +1922,7 @@ async fn token_count_none_resets_context_indicator() {
         msg: EventMsg::TokenCount(TokenCountEvent {
             info: None,
             rate_limits: None,
+            provider_request_started: false,
         }),
     });
     assert_eq!(chat.bottom_pane.context_window_percent(), None);
@@ -1949,6 +1953,7 @@ async fn context_indicator_shows_used_tokens_when_window_unknown() {
         msg: EventMsg::TokenCount(TokenCountEvent {
             info: Some(token_info),
             rate_limits: None,
+            provider_request_started: false,
         }),
     });
 

--- a/lib/libui/status/tests.rs
+++ b/lib/libui/status/tests.rs
@@ -137,6 +137,7 @@ async fn status_snapshot_includes_reasoning_details() {
         output_tokens: 900,
         reasoning_output_tokens: 150,
         total_tokens: 2_250,
+        ..Default::default()
     };
 
     let captured_at = local_ts(2024, 1, 2, 3, 4, 5);
@@ -259,6 +260,7 @@ async fn status_snapshot_includes_forked_from() {
         output_tokens: 400,
         reasoning_output_tokens: 0,
         total_tokens: 1_200,
+        ..Default::default()
     };
 
     let captured_at = local_ts(2024, 8, 9, 10, 11, 12);
@@ -305,6 +307,7 @@ async fn status_snapshot_includes_monthly_limit() {
         output_tokens: 400,
         reasoning_output_tokens: 0,
         total_tokens: 1_200,
+        ..Default::default()
     };
 
     let captured_at = local_ts(2024, 5, 6, 7, 8, 9);
@@ -538,6 +541,7 @@ async fn status_card_token_usage_excludes_cached_tokens() {
         output_tokens: 900,
         reasoning_output_tokens: 0,
         total_tokens: 2_100,
+        ..Default::default()
     };
 
     let now = local_ts(2024, 1, 1, 0, 0, 0);
@@ -583,6 +587,7 @@ async fn status_snapshot_truncates_in_narrow_terminal() {
         output_tokens: 900,
         reasoning_output_tokens: 150,
         total_tokens: 2_250,
+        ..Default::default()
     };
 
     let captured_at = local_ts(2024, 1, 2, 3, 4, 5);
@@ -638,6 +643,7 @@ async fn status_snapshot_shows_missing_limits_message() {
         output_tokens: 250,
         reasoning_output_tokens: 0,
         total_tokens: 750,
+        ..Default::default()
     };
 
     let now = local_ts(2024, 2, 3, 4, 5, 6);
@@ -678,6 +684,7 @@ async fn status_snapshot_includes_credits_and_limits() {
         output_tokens: 600,
         reasoning_output_tokens: 0,
         total_tokens: 2_200,
+        ..Default::default()
     };
 
     let captured_at = local_ts(2024, 7, 8, 9, 10, 11);
@@ -739,6 +746,7 @@ async fn status_snapshot_shows_empty_limits_message() {
         output_tokens: 250,
         reasoning_output_tokens: 0,
         total_tokens: 750,
+        ..Default::default()
     };
 
     let snapshot = RateLimitSnapshot {
@@ -788,6 +796,7 @@ async fn status_snapshot_shows_stale_limits_message() {
         output_tokens: 900,
         reasoning_output_tokens: 150,
         total_tokens: 2_250,
+        ..Default::default()
     };
 
     let captured_at = local_ts(2024, 1, 2, 3, 4, 5);
@@ -846,6 +855,7 @@ async fn status_snapshot_cached_limits_hide_credits_without_flag() {
         output_tokens: 350,
         reasoning_output_tokens: 0,
         total_tokens: 1_450,
+        ..Default::default()
     };
 
     let captured_at = local_ts(2024, 9, 10, 11, 12, 13);
@@ -907,6 +917,7 @@ async fn status_context_window_uses_last_usage() {
         output_tokens: 879,
         reasoning_output_tokens: 0,
         total_tokens: 102_000,
+        ..Default::default()
     };
     let last_usage = TokenUsage {
         input_tokens: 12_800,
@@ -914,6 +925,7 @@ async fn status_context_window_uses_last_usage() {
         output_tokens: 879,
         reasoning_output_tokens: 0,
         total_tokens: 13_679,
+        ..Default::default()
     };
 
     let now = local_ts(2024, 6, 1, 12, 0, 0);

--- a/sys/exec/fork/src/event_processor_with_jsonl_output.rs
+++ b/sys/exec/fork/src/event_processor_with_jsonl_output.rs
@@ -66,6 +66,7 @@ pub struct EventProcessorWithJsonOutput {
     // Tracks the todo list for the current turn (at most one per turn).
     running_todo_list: Option<RunningTodoList>,
     last_total_token_usage: Option<chaos_ipc::protocol::TokenUsage>,
+    invocation_usage_baseline: Option<chaos_ipc::protocol::TokenUsage>,
     running_mcp_tool_calls: HashMap<String, RunningMcpToolCall>,
     running_collab_tool_calls: HashMap<String, RunningCollabToolCall>,
     running_web_search_calls: HashMap<String, String>,
@@ -109,6 +110,7 @@ impl EventProcessorWithJsonOutput {
             running_patch_applies: HashMap::new(),
             running_todo_list: None,
             last_total_token_usage: None,
+            invocation_usage_baseline: None,
             running_mcp_tool_calls: HashMap::new(),
             running_collab_tool_calls: HashMap::new(),
             running_web_search_calls: HashMap::new(),
@@ -155,6 +157,12 @@ impl EventProcessorWithJsonOutput {
             protocol::EventMsg::WebSearchEnd(ev) => self.handle_web_search_end(ev),
             protocol::EventMsg::TokenCount(ev) => {
                 if let Some(info) = &ev.info {
+                    if ev.provider_request_started && self.invocation_usage_baseline.is_none() {
+                        let mut baseline = info.total_token_usage.clone();
+                        baseline.provider_request_count =
+                            baseline.provider_request_count.saturating_sub(1);
+                        self.invocation_usage_baseline = Some(baseline);
+                    }
                     self.last_total_token_usage = Some(info.total_token_usage.clone());
                 }
                 Vec::new()
@@ -749,19 +757,40 @@ impl EventProcessorWithJsonOutput {
 
     fn handle_task_started(&mut self, _: &protocol::TurnStartedEvent) -> Vec<ProcessEvent> {
         self.last_critical_error = None;
+        self.invocation_usage_baseline = None;
         vec![ProcessEvent::TurnStarted(TurnStartedEvent {})]
     }
 
     fn handle_task_complete(&mut self) -> Vec<ProcessEvent> {
-        let usage = if let Some(u) = &self.last_total_token_usage {
-            Usage {
-                input_tokens: u.input_tokens,
-                cached_input_tokens: u.cached_input_tokens,
-                output_tokens: u.output_tokens,
-            }
-        } else {
-            Usage::default()
+        const TELEMETRY_SCHEMA_VERSION: u32 = 1;
+        let cumulative = self.last_total_token_usage.clone().unwrap_or_default();
+        let (invocation, scope, complete) = match &self.invocation_usage_baseline {
+            Some(baseline) => (
+                cumulative.difference_since(baseline),
+                crate::exec_events::UsageScope::Invocation,
+                true,
+            ),
+            None if cumulative == chaos_ipc::protocol::TokenUsage::default() => (
+                chaos_ipc::protocol::TokenUsage::default(),
+                crate::exec_events::UsageScope::Invocation,
+                true,
+            ),
+            // A producer or persisted event stream predating provider-start
+            // markers can still give us useful cumulative usage. Preserve it
+            // rather than emitting fabricated zero invocation usage, but mark
+            // the scope and completeness honestly.
+            None => (
+                cumulative.clone(),
+                crate::exec_events::UsageScope::ProcessCumulative,
+                false,
+            ),
         };
+        let usage = usage_from_tokens(&invocation, scope, complete);
+        let session_usage = usage_from_tokens(
+            &cumulative,
+            crate::exec_events::UsageScope::ProcessCumulative,
+            true,
+        );
 
         let mut items = Vec::new();
 
@@ -793,10 +822,34 @@ impl EventProcessorWithJsonOutput {
         if let Some(error) = self.last_critical_error.take() {
             items.push(ProcessEvent::TurnFailed(TurnFailedEvent { error }));
         } else {
-            items.push(ProcessEvent::TurnCompleted(TurnCompletedEvent { usage }));
+            items.push(ProcessEvent::TurnCompleted(TurnCompletedEvent {
+                telemetry_schema_version: TELEMETRY_SCHEMA_VERSION,
+                usage,
+                session_usage: Some(session_usage),
+            }));
         }
 
         items
+    }
+}
+
+fn usage_from_tokens(
+    tokens: &chaos_ipc::protocol::TokenUsage,
+    scope: crate::exec_events::UsageScope,
+    complete: bool,
+) -> Usage {
+    Usage {
+        scope,
+        input_tokens: tokens.input_tokens,
+        uncached_input_tokens: tokens.uncached_input(),
+        cache_creation_input_tokens: tokens.cache_creation_input_tokens,
+        cache_read_input_tokens: tokens.cached_input_tokens,
+        cached_input_tokens: tokens.cached_input_tokens,
+        output_tokens: tokens.output_tokens,
+        reasoning_output_tokens: (tokens.reasoning_output_tokens > 0)
+            .then_some(tokens.reasoning_output_tokens),
+        provider_request_count: tokens.provider_request_count,
+        complete,
     }
 }
 

--- a/sys/exec/fork/src/exec_events.rs
+++ b/sys/exec/fork/src/exec_events.rs
@@ -48,7 +48,11 @@ pub struct TurnStartedEvent {}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, TS)]
 pub struct TurnCompletedEvent {
+    #[serde(default)]
+    pub telemetry_schema_version: u32,
     pub usage: Usage,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_usage: Option<Usage>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, TS)]
@@ -56,15 +60,34 @@ pub struct TurnFailedEvent {
     pub error: ProcessErrorEvent,
 }
 
-/// Describes the usage of tokens during a turn.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, TS, Default)]
 pub struct Usage {
-    /// The number of input tokens used during the turn.
+    #[serde(default)]
+    pub scope: UsageScope,
     pub input_tokens: i64,
-    /// The number of cached input tokens used during the turn.
+    #[serde(default)]
+    pub uncached_input_tokens: i64,
+    #[serde(default)]
+    pub cache_creation_input_tokens: i64,
+    #[serde(default)]
+    pub cache_read_input_tokens: i64,
+    /// Compatibility alias for `cache_read_input_tokens`.
     pub cached_input_tokens: i64,
-    /// The number of output tokens used during the turn.
     pub output_tokens: i64,
+    #[serde(default)]
+    pub reasoning_output_tokens: Option<i64>,
+    #[serde(default)]
+    pub provider_request_count: i64,
+    #[serde(default)]
+    pub complete: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, TS, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum UsageScope {
+    #[default]
+    Invocation,
+    ProcessCumulative,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, TS)]

--- a/sys/exec/fork/tests/suite/event_processor_with_json_output.rs
+++ b/sys/exec/fork/tests/suite/event_processor_with_json_output.rs
@@ -29,6 +29,7 @@ use chaos_fork::exec_events::TurnCompletedEvent;
 use chaos_fork::exec_events::TurnFailedEvent;
 use chaos_fork::exec_events::TurnStartedEvent;
 use chaos_fork::exec_events::Usage;
+use chaos_fork::exec_events::UsageScope;
 use chaos_fork::exec_events::WebSearchItem;
 use chaos_ipc::ProcessId;
 use chaos_ipc::config_types::ModeKind;
@@ -460,7 +461,16 @@ fn plan_update_emits_todo_list_started_updated_and_completed() {
                 },
             }),
             ProcessEvent::TurnCompleted(TurnCompletedEvent {
-                usage: Usage::default(),
+                telemetry_schema_version: 1,
+                usage: Usage {
+                    complete: true,
+                    ..Usage::default()
+                },
+                session_usage: Some(Usage {
+                    scope: UsageScope::ProcessCumulative,
+                    complete: true,
+                    ..Usage::default()
+                }),
             }),
         ]
     );
@@ -1273,14 +1283,39 @@ fn patch_apply_failure_produces_item_completed_patchapply_failed() {
 #[test]
 fn task_complete_produces_turn_completed_with_usage() {
     let mut ep = EventProcessorWithJsonOutput::new(None);
+    let _ = ep.collect_process_events(&event(
+        "started",
+        EventMsg::TurnStarted(chaos_ipc::protocol::TurnStartedEvent {
+            turn_id: "turn-1".to_string(),
+            model_context_window: None,
+            collaboration_mode_kind: Default::default(),
+        }),
+    ));
 
-    // First, feed a TokenCount event with known totals.
+    let _ = ep.collect_process_events(&event(
+        "provider-started",
+        EventMsg::TokenCount(chaos_ipc::protocol::TokenCountEvent {
+            info: Some(chaos_ipc::protocol::TokenUsageInfo {
+                total_token_usage: chaos_ipc::protocol::TokenUsage {
+                    provider_request_count: 1,
+                    ..Default::default()
+                },
+                last_token_usage: Default::default(),
+                model_context_window: None,
+            }),
+            rate_limits: None,
+            provider_request_started: true,
+        }),
+    ));
+
     let usage = chaos_ipc::protocol::TokenUsage {
         input_tokens: 1200,
+        cache_creation_input_tokens: 300,
         cached_input_tokens: 200,
         output_tokens: 345,
-        reasoning_output_tokens: 0,
-        total_tokens: 0,
+        reasoning_output_tokens: 20,
+        total_tokens: 1565,
+        provider_request_count: 3,
     };
     let info = chaos_ipc::protocol::TokenUsageInfo {
         total_token_usage: usage.clone(),
@@ -1292,11 +1327,11 @@ fn task_complete_produces_turn_completed_with_usage() {
         EventMsg::TokenCount(chaos_ipc::protocol::TokenCountEvent {
             info: Some(info),
             rate_limits: None,
+            provider_request_started: false,
         }),
     );
     assert!(ep.collect_process_events(&token_count_event).is_empty());
 
-    // Then TurnComplete should produce turn.completed with the captured usage.
     let complete_event = event(
         "e2",
         EventMsg::TurnComplete(chaos_ipc::protocol::TurnCompleteEvent {
@@ -1308,11 +1343,196 @@ fn task_complete_produces_turn_completed_with_usage() {
     assert_eq!(
         out,
         vec![ProcessEvent::TurnCompleted(TurnCompletedEvent {
+            telemetry_schema_version: 1,
+            usage: Usage {
+                scope: UsageScope::Invocation,
+                input_tokens: 1200,
+                uncached_input_tokens: 700,
+                cache_creation_input_tokens: 300,
+                cache_read_input_tokens: 200,
+                cached_input_tokens: 200,
+                output_tokens: 345,
+                reasoning_output_tokens: Some(20),
+                provider_request_count: 3,
+                complete: true,
+            },
+            session_usage: Some(Usage {
+                scope: UsageScope::ProcessCumulative,
+                input_tokens: 1200,
+                uncached_input_tokens: 700,
+                cache_creation_input_tokens: 300,
+                cache_read_input_tokens: 200,
+                cached_input_tokens: 200,
+                output_tokens: 345,
+                reasoning_output_tokens: Some(20),
+                provider_request_count: 3,
+                complete: true,
+            }),
+        })]
+    );
+}
+
+#[test]
+fn resumed_exec_reports_invocation_delta_and_process_cumulative_usage() {
+    let mut ep = EventProcessorWithJsonOutput::new(None);
+    let _ = ep.collect_process_events(&event(
+        "started",
+        EventMsg::TurnStarted(chaos_ipc::protocol::TurnStartedEvent {
+            turn_id: "resumed-turn".to_string(),
+            model_context_window: None,
+            collaboration_mode_kind: Default::default(),
+        }),
+    ));
+
+    let baseline = chaos_ipc::protocol::TokenUsage {
+        input_tokens: 49_500,
+        cache_creation_input_tokens: 1_950,
+        cached_input_tokens: 39_600,
+        output_tokens: 4_975,
+        reasoning_output_tokens: 500,
+        total_tokens: 54_475,
+        provider_request_count: 9,
+    };
+    let _ = ep.collect_process_events(&event(
+        "provider-started",
+        EventMsg::TokenCount(chaos_ipc::protocol::TokenCountEvent {
+            info: Some(chaos_ipc::protocol::TokenUsageInfo {
+                total_token_usage: baseline,
+                last_token_usage: Default::default(),
+                model_context_window: None,
+            }),
+            rate_limits: None,
+            provider_request_started: true,
+        }),
+    ));
+
+    let cumulative = chaos_ipc::protocol::TokenUsage {
+        input_tokens: 50_000,
+        cache_creation_input_tokens: 2_000,
+        cached_input_tokens: 40_000,
+        output_tokens: 5_000,
+        reasoning_output_tokens: 500,
+        total_tokens: 55_000,
+        provider_request_count: 9,
+    };
+    let _ = ep.collect_process_events(&event(
+        "usage",
+        EventMsg::TokenCount(chaos_ipc::protocol::TokenCountEvent {
+            info: Some(chaos_ipc::protocol::TokenUsageInfo {
+                total_token_usage: cumulative.clone(),
+                last_token_usage: chaos_ipc::protocol::TokenUsage {
+                    input_tokens: 500,
+                    cache_creation_input_tokens: 50,
+                    cached_input_tokens: 400,
+                    output_tokens: 25,
+                    reasoning_output_tokens: 0,
+                    total_tokens: 525,
+                    provider_request_count: 1,
+                },
+                model_context_window: None,
+            }),
+            rate_limits: None,
+            provider_request_started: false,
+        }),
+    ));
+    let completed = ep.collect_process_events(&event(
+        "done",
+        EventMsg::TurnComplete(chaos_ipc::protocol::TurnCompleteEvent {
+            turn_id: "resumed-turn".to_string(),
+            last_agent_message: None,
+        }),
+    ));
+    let ProcessEvent::TurnCompleted(completed) = &completed[0] else {
+        panic!("expected turn.completed");
+    };
+    assert_eq!(completed.telemetry_schema_version, 1);
+    assert_eq!(completed.usage.scope, UsageScope::Invocation);
+    assert_eq!(completed.usage.input_tokens, 500);
+    assert_eq!(completed.usage.cache_creation_input_tokens, 50);
+    assert_eq!(completed.usage.cache_read_input_tokens, 400);
+    assert_eq!(completed.usage.output_tokens, 25);
+    assert_eq!(completed.usage.provider_request_count, 1);
+    assert!(completed.usage.complete);
+    let session_usage = completed.session_usage.as_ref().expect("session usage");
+    assert_eq!(session_usage.scope, UsageScope::ProcessCumulative);
+    assert_eq!(session_usage.input_tokens, cumulative.input_tokens);
+    assert_eq!(
+        session_usage.cache_creation_input_tokens,
+        cumulative.cache_creation_input_tokens
+    );
+    assert_eq!(
+        session_usage.provider_request_count,
+        cumulative.provider_request_count
+    );
+}
+
+#[test]
+fn usage_without_provider_start_marker_preserves_cumulative_counters_as_incomplete() {
+    let mut ep = EventProcessorWithJsonOutput::new(None);
+    let usage = chaos_ipc::protocol::TokenUsage {
+        input_tokens: 1_200,
+        cache_creation_input_tokens: 300,
+        cached_input_tokens: 200,
+        output_tokens: 345,
+        reasoning_output_tokens: 20,
+        total_tokens: 1_565,
+        provider_request_count: 0,
+    };
+    let _ = ep.collect_process_events(&event(
+        "usage",
+        EventMsg::TokenCount(chaos_ipc::protocol::TokenCountEvent {
+            info: Some(chaos_ipc::protocol::TokenUsageInfo {
+                total_token_usage: usage.clone(),
+                last_token_usage: usage,
+                model_context_window: None,
+            }),
+            rate_limits: None,
+            provider_request_started: false,
+        }),
+    ));
+
+    let completed = ep.collect_process_events(&event(
+        "done",
+        EventMsg::TurnComplete(chaos_ipc::protocol::TurnCompleteEvent {
+            turn_id: "legacy-turn".to_string(),
+            last_agent_message: None,
+        }),
+    ));
+    let ProcessEvent::TurnCompleted(completed) = &completed[0] else {
+        panic!("expected turn.completed");
+    };
+
+    assert_eq!(completed.usage.scope, UsageScope::ProcessCumulative);
+    assert_eq!(completed.usage.input_tokens, 1_200);
+    assert_eq!(completed.usage.cache_creation_input_tokens, 300);
+    assert_eq!(completed.usage.cache_read_input_tokens, 200);
+    assert_eq!(completed.usage.output_tokens, 345);
+    assert!(!completed.usage.complete);
+}
+
+#[test]
+fn usage_deserializes_legacy_turn_completed_shape_with_safe_defaults() {
+    let event: ProcessEvent = serde_json::from_value(json!({
+        "type": "turn.completed",
+        "usage": {
+            "input_tokens": 1200,
+            "cached_input_tokens": 200,
+            "output_tokens": 345
+        }
+    }))
+    .expect("legacy turn.completed should remain readable");
+
+    assert_eq!(
+        event,
+        ProcessEvent::TurnCompleted(TurnCompletedEvent {
+            telemetry_schema_version: 0,
             usage: Usage {
                 input_tokens: 1200,
                 cached_input_tokens: 200,
                 output_tokens: 345,
+                ..Usage::default()
             },
-        })]
+            session_usage: None,
+        })
     );
 }

--- a/sys/kern/kern/src/chaos/session/tokens.rs
+++ b/sys/kern/kern/src/chaos/session/tokens.rs
@@ -89,10 +89,12 @@ impl Session {
 
             info.last_token_usage = TokenUsage {
                 input_tokens: 0,
+                cache_creation_input_tokens: 0,
                 cached_input_tokens: 0,
                 output_tokens: 0,
                 reasoning_output_tokens: 0,
                 total_tokens: estimated_total_tokens.max(0),
+                provider_request_count: 0,
             };
 
             if let Some(model_context_window) = turn_context.model_context_window() {
@@ -164,8 +166,48 @@ impl Session {
             let state = self.state.lock().await;
             state.token_info_and_rate_limits()
         };
-        let event =
-            chaos_ipc::protocol::EventMsg::TokenCount(TokenCountEvent { info, rate_limits });
+        let event = chaos_ipc::protocol::EventMsg::TokenCount(TokenCountEvent {
+            info,
+            rate_limits,
+            provider_request_started: false,
+        });
+        self.send_event(turn_context, event).await;
+    }
+
+    /// Record one model-provider request dispatch for this turn.
+    ///
+    /// Call this immediately before invoking the provider client. It therefore
+    /// counts tool continuations, lifecycle-hook continuations, and dispatched
+    /// requests that fail while opening or consuming the response stream.
+    pub(crate) async fn record_provider_request_started(&self, turn_context: &TurnContext) {
+        let provider_request_count = {
+            let mut state = self.state.lock().await;
+            let mut info = state.token_info().unwrap_or(TokenUsageInfo {
+                total_token_usage: TokenUsage::default(),
+                last_token_usage: TokenUsage::default(),
+                model_context_window: turn_context.model_context_window(),
+            });
+            let provider_request_count = info.record_provider_request();
+            state.set_token_info(Some(info));
+            provider_request_count
+        };
+        tracing::debug!(
+            process_id = %self.conversation_id,
+            turn_id = %turn_context.sub_id,
+            provider = %turn_context.provider.name,
+            model = %turn_context.model_info.slug,
+            provider_request_count,
+            "provider request dispatched"
+        );
+        let (info, rate_limits) = {
+            let state = self.state.lock().await;
+            state.token_info_and_rate_limits()
+        };
+        let event = chaos_ipc::protocol::EventMsg::TokenCount(TokenCountEvent {
+            info,
+            rate_limits,
+            provider_request_started: true,
+        });
         self.send_event(turn_context, event).await;
     }
 

--- a/sys/kern/kern/src/chaos/turn/execution.rs
+++ b/sys/kern/kern/src/chaos/turn/execution.rs
@@ -70,6 +70,7 @@ pub(super) async fn try_run_sampling_request(
         effort = turn_context.reasoning_effort,
         auth_mode = sess.services.auth_manager.auth_mode(),
     );
+    sess.record_provider_request_started(&turn_context).await;
     let mut stream = client_session
         .stream(
             prompt,

--- a/sys/kern/kern/src/chaos_tests/early_session.rs
+++ b/sys/kern/kern/src/chaos_tests/early_session.rs
@@ -217,41 +217,49 @@ async fn resumed_history_injects_initial_context_on_first_context_update_only() 
 }
 
 #[tokio::test]
-async fn record_initial_history_seeds_token_info_from_rollout() {
+async fn resumed_history_restores_process_cumulative_usage_and_continues_accumulating() {
     let (session, turn_context) = make_session_and_context().await;
     let (mut rollout_items, _expected) = sample_rollout(&session, &turn_context).await;
 
     let info1 = TokenUsageInfo {
         total_token_usage: TokenUsage {
             input_tokens: 10,
+            cache_creation_input_tokens: 2,
             cached_input_tokens: 0,
             output_tokens: 20,
             reasoning_output_tokens: 0,
             total_tokens: 30,
+            provider_request_count: 1,
         },
         last_token_usage: TokenUsage {
             input_tokens: 3,
+            cache_creation_input_tokens: 1,
             cached_input_tokens: 0,
             output_tokens: 4,
             reasoning_output_tokens: 0,
             total_tokens: 7,
+            provider_request_count: 1,
         },
         model_context_window: Some(1_000),
     };
     let info2 = TokenUsageInfo {
         total_token_usage: TokenUsage {
             input_tokens: 100,
+            cache_creation_input_tokens: 20,
             cached_input_tokens: 50,
             output_tokens: 200,
             reasoning_output_tokens: 25,
             total_tokens: 375,
+            provider_request_count: 4,
         },
         last_token_usage: TokenUsage {
             input_tokens: 10,
+            cache_creation_input_tokens: 3,
             cached_input_tokens: 0,
             output_tokens: 20,
             reasoning_output_tokens: 5,
             total_tokens: 35,
+            provider_request_count: 1,
         },
         model_context_window: Some(2_000),
     };
@@ -260,24 +268,28 @@ async fn record_initial_history_seeds_token_info_from_rollout() {
         TokenCountEvent {
             info: Some(info1),
             rate_limits: None,
+            provider_request_started: false,
         },
     )));
     rollout_items.push(RolloutItem::EventMsg(EventMsg::TokenCount(
         TokenCountEvent {
             info: None,
             rate_limits: None,
+            provider_request_started: false,
         },
     )));
     rollout_items.push(RolloutItem::EventMsg(EventMsg::TokenCount(
         TokenCountEvent {
             info: Some(info2.clone()),
             rate_limits: None,
+            provider_request_started: false,
         },
     )));
     rollout_items.push(RolloutItem::EventMsg(EventMsg::TokenCount(
         TokenCountEvent {
             info: None,
             rate_limits: None,
+            provider_request_started: false,
         },
     )));
 
@@ -289,7 +301,48 @@ async fn record_initial_history_seeds_token_info_from_rollout() {
         .await;
 
     let actual = session.state.lock().await.token_info();
-    assert_eq!(actual, Some(info2));
+    assert_eq!(actual, Some(info2.clone()));
+
+    session.record_provider_request_started(&turn_context).await;
+    session
+        .update_token_usage_info(
+            &turn_context,
+            Some(&TokenUsage {
+                input_tokens: 25,
+                cache_creation_input_tokens: 5,
+                cached_input_tokens: 15,
+                output_tokens: 7,
+                reasoning_output_tokens: 2,
+                total_tokens: 32,
+                provider_request_count: 0,
+            }),
+        )
+        .await;
+
+    let after_resumed_turn = session
+        .state
+        .lock()
+        .await
+        .token_info()
+        .expect("resumed token info");
+    assert_eq!(after_resumed_turn.total_token_usage.input_tokens, 125);
+    assert_eq!(
+        after_resumed_turn
+            .total_token_usage
+            .cache_creation_input_tokens,
+        25
+    );
+    assert_eq!(after_resumed_turn.total_token_usage.cached_input_tokens, 65);
+    assert_eq!(after_resumed_turn.total_token_usage.output_tokens, 207);
+    assert_eq!(
+        after_resumed_turn.total_token_usage.reasoning_output_tokens,
+        27
+    );
+    assert_eq!(after_resumed_turn.total_token_usage.total_tokens, 407);
+    assert_eq!(
+        after_resumed_turn.total_token_usage.provider_request_count,
+        5
+    );
 }
 
 #[tokio::test]

--- a/sys/kern/kern/src/distill.rs
+++ b/sys/kern/kern/src/distill.rs
@@ -225,6 +225,7 @@ async fn drain_to_completed(
     turn_metadata_header: Option<&str>,
     prompt: &Prompt,
 ) -> ChaosResult<()> {
+    sess.record_provider_request_started(turn_context).await;
     let mut stream = client_session
         .stream(
             prompt,

--- a/sys/kern/kern/src/tasks.rs
+++ b/sys/kern/kern/src/tasks.rs
@@ -335,6 +335,9 @@ impl Session {
                 input_tokens: (total_token_usage.input_tokens
                     - token_usage_at_turn_start.input_tokens)
                     .max(0),
+                cache_creation_input_tokens: (total_token_usage.cache_creation_input_tokens
+                    - token_usage_at_turn_start.cache_creation_input_tokens)
+                    .max(0),
                 cached_input_tokens: (total_token_usage.cached_input_tokens
                     - token_usage_at_turn_start.cached_input_tokens)
                     .max(0),
@@ -346,6 +349,9 @@ impl Session {
                     .max(0),
                 total_tokens: (total_token_usage.total_tokens
                     - token_usage_at_turn_start.total_tokens)
+                    .max(0),
+                provider_request_count: (total_token_usage.provider_request_count
+                    - token_usage_at_turn_start.provider_request_count)
                     .max(0),
             };
             self.services.session_telemetry.histogram(

--- a/sys/kern/kern/tests/suite/otel.rs
+++ b/sys/kern/kern/tests/suite/otel.rs
@@ -676,7 +676,7 @@ async fn handle_response_item_records_tool_result_for_custom_tool_call() {
         .await
         .unwrap();
 
-    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TokenCount(_))).await;
+    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
 
     logs_assert(|lines: &[&str]| {
         let line = lines
@@ -738,7 +738,7 @@ async fn handle_response_item_records_tool_result_for_function_call() {
         .await
         .unwrap();
 
-    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TokenCount(_))).await;
+    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
 
     logs_assert(|lines: &[&str]| {
         let line = lines
@@ -810,7 +810,16 @@ async fn handle_response_item_records_tool_result_for_local_shell_missing_ids() 
         .await
         .unwrap();
 
-    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TokenCount(_))).await;
+    // This malformed item is not guaranteed to reach TurnComplete on every
+    // platform. Wait for a completed provider usage snapshot, explicitly
+    // excluding the provider-dispatch marker that caused the original race.
+    wait_for_event(&chaos, |ev| {
+        matches!(
+            ev,
+            EventMsg::TokenCount(event) if !event.provider_request_started
+        )
+    })
+    .await;
 
     logs_assert(|lines: &[&str]| {
         let line = lines
@@ -866,7 +875,7 @@ async fn handle_response_item_records_tool_result_for_local_shell_call() {
         .await
         .unwrap();
 
-    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TokenCount(_))).await;
+    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
 
     logs_assert(|lines: &[&str]| {
         let line = lines
@@ -1039,7 +1048,7 @@ async fn handle_container_exec_user_approved_records_tool_decision() {
         .await
         .unwrap();
 
-    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TokenCount(_))).await;
+    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
 
     logs_assert(tool_decision_assertion(
         "user_approved_call",
@@ -1104,7 +1113,7 @@ async fn handle_container_exec_user_approved_for_session_records_tool_decision()
         .await
         .unwrap();
 
-    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TokenCount(_))).await;
+    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
 
     logs_assert(tool_decision_assertion(
         "user_approved_session_call",
@@ -1169,7 +1178,7 @@ async fn handle_sandbox_error_user_approves_retry_records_tool_decision() {
         .await
         .unwrap();
 
-    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TokenCount(_))).await;
+    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
 
     logs_assert(tool_decision_assertion(
         "sandbox_retry_call",
@@ -1234,7 +1243,7 @@ async fn handle_container_exec_user_denies_records_tool_decision() {
         .await
         .unwrap();
 
-    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TokenCount(_))).await;
+    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
 
     logs_assert(tool_decision_assertion(
         "user_denied_call",
@@ -1299,7 +1308,7 @@ async fn handle_sandbox_error_user_approves_for_session_records_tool_decision() 
         .await
         .unwrap();
 
-    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TokenCount(_))).await;
+    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
 
     logs_assert(tool_decision_assertion(
         "sandbox_session_call",
@@ -1365,7 +1374,7 @@ async fn handle_sandbox_error_user_denies_records_tool_decision() {
         .await
         .unwrap();
 
-    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TokenCount(_))).await;
+    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
 
     logs_assert(tool_decision_assertion(
         "sandbox_deny_call",

--- a/sys/kern/kern/tests/suite/otel.rs
+++ b/sys/kern/kern/tests/suite/otel.rs
@@ -81,6 +81,16 @@ async fn setup_test_chaos_with_server() -> (MockServer, Arc<Process>) {
     (server, chaos)
 }
 
+async fn wait_for_completed_provider_usage(chaos: &Process) {
+    wait_for_event(chaos, |event| {
+        matches!(
+            event,
+            EventMsg::TokenCount(event) if !event.provider_request_started
+        )
+    })
+    .await;
+}
+
 fn get_buffer_logs(buffer: &Mutex<Vec<u8>>) -> String {
     let bytes = buffer.lock().expect("log buffer poisoned").clone();
     String::from_utf8(bytes).expect("log buffer not utf-8")
@@ -676,7 +686,7 @@ async fn handle_response_item_records_tool_result_for_custom_tool_call() {
         .await
         .unwrap();
 
-    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+    wait_for_completed_provider_usage(&chaos).await;
 
     logs_assert(|lines: &[&str]| {
         let line = lines
@@ -738,7 +748,7 @@ async fn handle_response_item_records_tool_result_for_function_call() {
         .await
         .unwrap();
 
-    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+    wait_for_completed_provider_usage(&chaos).await;
 
     logs_assert(|lines: &[&str]| {
         let line = lines
@@ -810,16 +820,7 @@ async fn handle_response_item_records_tool_result_for_local_shell_missing_ids() 
         .await
         .unwrap();
 
-    // This malformed item is not guaranteed to reach TurnComplete on every
-    // platform. Wait for a completed provider usage snapshot, explicitly
-    // excluding the provider-dispatch marker that caused the original race.
-    wait_for_event(&chaos, |ev| {
-        matches!(
-            ev,
-            EventMsg::TokenCount(event) if !event.provider_request_started
-        )
-    })
-    .await;
+    wait_for_completed_provider_usage(&chaos).await;
 
     logs_assert(|lines: &[&str]| {
         let line = lines
@@ -875,7 +876,7 @@ async fn handle_response_item_records_tool_result_for_local_shell_call() {
         .await
         .unwrap();
 
-    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+    wait_for_completed_provider_usage(&chaos).await;
 
     logs_assert(|lines: &[&str]| {
         let line = lines
@@ -1048,7 +1049,7 @@ async fn handle_container_exec_user_approved_records_tool_decision() {
         .await
         .unwrap();
 
-    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+    wait_for_completed_provider_usage(&chaos).await;
 
     logs_assert(tool_decision_assertion(
         "user_approved_call",
@@ -1113,7 +1114,7 @@ async fn handle_container_exec_user_approved_for_session_records_tool_decision()
         .await
         .unwrap();
 
-    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+    wait_for_completed_provider_usage(&chaos).await;
 
     logs_assert(tool_decision_assertion(
         "user_approved_session_call",
@@ -1178,7 +1179,7 @@ async fn handle_sandbox_error_user_approves_retry_records_tool_decision() {
         .await
         .unwrap();
 
-    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+    wait_for_completed_provider_usage(&chaos).await;
 
     logs_assert(tool_decision_assertion(
         "sandbox_retry_call",
@@ -1243,7 +1244,7 @@ async fn handle_container_exec_user_denies_records_tool_decision() {
         .await
         .unwrap();
 
-    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+    wait_for_completed_provider_usage(&chaos).await;
 
     logs_assert(tool_decision_assertion(
         "user_denied_call",
@@ -1308,7 +1309,7 @@ async fn handle_sandbox_error_user_approves_for_session_records_tool_decision() 
         .await
         .unwrap();
 
-    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+    wait_for_completed_provider_usage(&chaos).await;
 
     logs_assert(tool_decision_assertion(
         "sandbox_session_call",
@@ -1374,7 +1375,7 @@ async fn handle_sandbox_error_user_denies_records_tool_decision() {
         .await
         .unwrap();
 
-    wait_for_event(&chaos, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+    wait_for_completed_provider_usage(&chaos).await;
 
     logs_assert(tool_decision_assertion(
         "sandbox_deny_call",

--- a/sys/kern/providers/parrot/src/anthropic.rs
+++ b/sys/kern/providers/parrot/src/anthropic.rs
@@ -526,6 +526,7 @@ impl UsageAccumulator {
             .saturating_add(self.cache_read_input_tokens);
         TokenUsage {
             input_tokens: prompt_tokens as i64,
+            cache_creation_input_tokens: self.cache_creation_input_tokens as i64,
             cached_input_tokens: self.cache_read_input_tokens as i64,
             output_tokens: self.output_tokens as i64,
             total_tokens: prompt_tokens.saturating_add(self.output_tokens) as i64,
@@ -1164,6 +1165,7 @@ mod tests {
         };
         assert!(response_id.is_empty());
         assert_eq!(usage.input_tokens, 41);
+        assert_eq!(usage.cache_creation_input_tokens, 13);
         assert_eq!(usage.cached_input_tokens, 17);
         assert_eq!(usage.output_tokens, 19);
         assert_eq!(usage.total_tokens, 60);

--- a/sys/kern/providers/parrot/src/sse/responses.rs
+++ b/sys/kern/providers/parrot/src/sse/responses.rs
@@ -152,6 +152,9 @@ impl From<ResponseCompletedUsage> for TokenUsage {
     fn from(val: ResponseCompletedUsage) -> Self {
         TokenUsage {
             input_tokens: val.input_tokens,
+            // The Responses API currently exposes cache reads but not a
+            // separate cache-write category.
+            cache_creation_input_tokens: 0,
             cached_input_tokens: val
                 .input_tokens_details
                 .map(|d| d.cached_tokens)
@@ -162,6 +165,7 @@ impl From<ResponseCompletedUsage> for TokenUsage {
                 .map(|d| d.reasoning_tokens)
                 .unwrap_or(0),
             total_tokens: val.total_tokens,
+            provider_request_count: 0,
         }
     }
 }

--- a/var/proc/src/runtime/processes.rs
+++ b/var/proc/src/runtime/processes.rs
@@ -1062,16 +1062,14 @@ mod tests {
             chaos_ipc::protocol::TokenCountEvent {
                 info: Some(chaos_ipc::protocol::TokenUsageInfo {
                     total_token_usage: chaos_ipc::protocol::TokenUsage {
-                        input_tokens: 0,
-                        cached_input_tokens: 0,
-                        output_tokens: 0,
-                        reasoning_output_tokens: 0,
                         total_tokens: 321,
+                        ..Default::default()
                     },
                     last_token_usage: chaos_ipc::protocol::TokenUsage::default(),
                     model_context_window: None,
                 }),
                 rate_limits: None,
+                provider_request_started: false,
             },
         ))];
         let override_updated_at = jiff::Timestamp::new(1_700_001_234, 0).expect("timestamp");


### PR DESCRIPTION
## Summary

- preserve Anthropic cache-creation tokens separately from cache reads
- count actual provider dispatches across tool and Stop-hook continuations
- emit versioned invocation-local usage plus optional process-cumulative usage from `chaos exec --json`
- keep old serialized event shapes readable with additive defaults
- add deterministic tests for accumulation, resume deltas, JSONL scope, and provider accounting

This is the Chaos producer half of HelixKit hosted-agent runtime observability. HelixKit records the versioned invocation usage directly and does not reconstruct historical session usage.

## Contract

`turn.completed` now includes:

- `telemetry_schema_version: 1`
- `usage.scope: "invocation"`
- ordinary input, cache creation, cache read, output, optional reasoning output
- `provider_request_count`
- `complete`
- optional `session_usage.scope: "process_cumulative"`

## Tests

Passed locally with Rust 1.97.0:

- `cargo fmt --all -- --check`
- `cargo test -p chaos-ipc` (107 passed)
- `cargo test -p chaos-parrot` (90 passed; 2 live-credit tests ignored)
- `cargo test -p chaos-proc` (90 passed)
- `cargo test -p chaos-fork --test all event_processor_with_json_output` (28 passed)
- `cargo test -p chaos-kern resumed_history_restores_process_cumulative_usage_and_continues_accumulating`

Broader-suite notes unrelated to this patch:

- `chaos-kern` otherwise reaches 969 passing tests, then two existing `review_prompts` tests fail because git diff output contains ANSI color escapes.
- the full `chaos-fork` suite has one environment-dependent `auth_env` failure because its configured baseline working directory is absent.
