### PR TITLE
fix(parrot): preserve Gemini thought signatures

### DIFF
--- a/lib/libcontract/ipc/src/models.rs
+++ b/lib/libcontract/ipc/src/models.rs
@@ -401,6 +401,7 @@ mod tests {
                 namespace: Some("mcp__codex_apps__gmail".to_string()),
                 arguments: "{\"top_k\":5}".to_string(),
                 call_id: "call-1".to_string(),
+                provider_metadata: None,
             }
         );
     }

--- a/lib/libcontract/ipc/src/models/response.rs
+++ b/lib/libcontract/ipc/src/models/response.rs
@@ -137,6 +137,15 @@ pub enum ResponseItem {
         // Session::handle_function_call parse it into a Value.
         arguments: String,
         call_id: String,
+        /// Opaque metadata attached to a provider's tool call.
+        ///
+        /// Chat-completions-compatible providers may require this data to be
+        /// replayed verbatim with the assistant tool call. Gemini, for example,
+        /// returns `extra_content.google.thought_signature` and rejects the
+        /// follow-up tool result when that signature is missing.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        provider_metadata: Option<serde_json::Value>,
     },
     ToolSearchCall {
         #[serde(default, skip_serializing)]

--- a/sys/kern/kern/src/arc_monitor_tests.rs
+++ b/sys/kern/kern/src/arc_monitor_tests.rs
@@ -91,6 +91,7 @@ async fn build_arc_monitor_request_includes_relevant_history_and_null_policies()
                 namespace: None,
                 arguments: "{\"old\":true}".to_string(),
                 call_id: "call_old".to_string(),
+                provider_metadata: None,
             }],
             &turn_context,
         )

--- a/sys/kern/kern/src/clamp_bridge.rs
+++ b/sys/kern/kern/src/clamp_bridge.rs
@@ -271,6 +271,7 @@ async fn dispatch_tool_call(
             arguments: serde_json::to_string(&arguments)
                 .map_err(|err| format!("failed to encode tool arguments: {err}"))?,
             call_id,
+            provider_metadata: None,
         },
         ToolSpec::Freeform(_) => ResponseItem::CustomToolCall {
             id: None,

--- a/sys/kern/kern/src/client_common_tests.rs
+++ b/sys/kern/kern/src/client_common_tests.rs
@@ -147,6 +147,7 @@ fn reserializes_shell_outputs_for_function_and_custom_tool_calls() {
             namespace: None,
             arguments: "{}".to_string(),
             call_id: "call-1".to_string(),
+            provider_metadata: None,
         },
         ResponseItem::FunctionCallOutput {
             call_id: "call-1".to_string(),
@@ -178,6 +179,7 @@ fn reserializes_shell_outputs_for_function_and_custom_tool_calls() {
                 namespace: None,
                 arguments: "{}".to_string(),
                 call_id: "call-1".to_string(),
+                provider_metadata: None,
             },
             ResponseItem::FunctionCallOutput {
                 call_id: "call-1".to_string(),
@@ -212,6 +214,7 @@ fn prompt_get_formatted_input_reserializes_shell_outputs_without_apply_patch_too
                 namespace: None,
                 arguments: "{}".to_string(),
                 call_id: "call-1".to_string(),
+                provider_metadata: None,
             },
             ResponseItem::FunctionCallOutput {
                 call_id: "call-1".to_string(),
@@ -233,6 +236,7 @@ fn prompt_get_formatted_input_reserializes_shell_outputs_without_apply_patch_too
                 namespace: None,
                 arguments: "{}".to_string(),
                 call_id: "call-1".to_string(),
+                provider_metadata: None,
             },
             ResponseItem::FunctionCallOutput {
                 call_id: "call-1".to_string(),

--- a/sys/kern/kern/src/client_tests.rs
+++ b/sys/kern/kern/src/client_tests.rs
@@ -236,6 +236,7 @@ fn render_clamp_full_prompt_preserves_prior_messages_and_tool_outputs() {
                 namespace: None,
                 arguments: "{\"command\":[\"pwd\"]}".into(),
                 call_id: "call_123".into(),
+                provider_metadata: None,
             },
             ResponseItem::FunctionCallOutput {
                 call_id: "call_123".into(),

--- a/sys/kern/kern/src/context_manager/history_tests.rs
+++ b/sys/kern/kern/src/context_manager/history_tests.rs
@@ -263,6 +263,7 @@ fn for_prompt_strips_images_when_model_does_not_support_images() {
             namespace: None,
             arguments: "{}".to_string(),
             call_id: "call-1".to_string(),
+            provider_metadata: None,
         },
         ResponseItem::FunctionCallOutput {
             call_id: "call-1".to_string(),
@@ -327,6 +328,7 @@ fn for_prompt_strips_images_when_model_does_not_support_images() {
             namespace: None,
             arguments: "{}".to_string(),
             call_id: "call-1".to_string(),
+            provider_metadata: None,
         },
         ResponseItem::FunctionCallOutput {
             call_id: "call-1".to_string(),
@@ -516,6 +518,7 @@ fn remove_first_item_removes_matching_output_for_function_call() {
             namespace: None,
             arguments: "{}".to_string(),
             call_id: "call-1".to_string(),
+            provider_metadata: None,
         },
         ResponseItem::FunctionCallOutput {
             call_id: "call-1".to_string(),
@@ -542,6 +545,7 @@ fn remove_first_item_removes_matching_call_for_output() {
             namespace: None,
             arguments: "{}".to_string(),
             call_id: "call-2".to_string(),
+            provider_metadata: None,
         },
     ];
     let mut h = create_history_with_items(items);
@@ -989,6 +993,7 @@ fn normalize_adds_missing_output_for_function_call() {
         namespace: None,
         arguments: "{}".to_string(),
         call_id: "call-x".to_string(),
+        provider_metadata: None,
     }];
     let mut h = create_history_with_items(items);
 
@@ -1003,6 +1008,7 @@ fn normalize_adds_missing_output_for_function_call() {
                 namespace: None,
                 arguments: "{}".to_string(),
                 call_id: "call-x".to_string(),
+                provider_metadata: None,
             },
             ResponseItem::FunctionCallOutput {
                 call_id: "call-x".to_string(),
@@ -1130,6 +1136,7 @@ fn normalize_mixed_inserts_and_removals() {
             namespace: None,
             arguments: "{}".to_string(),
             call_id: "c1".to_string(),
+            provider_metadata: None,
         },
         // Orphan output that should be removed
         ResponseItem::FunctionCallOutput {
@@ -1172,6 +1179,7 @@ fn normalize_mixed_inserts_and_removals() {
                 namespace: None,
                 arguments: "{}".to_string(),
                 call_id: "c1".to_string(),
+                provider_metadata: None,
             },
             ResponseItem::FunctionCallOutput {
                 call_id: "c1".to_string(),
@@ -1219,6 +1227,7 @@ fn normalize_adds_missing_output_for_function_call_inserts_output() {
         namespace: None,
         arguments: "{}".to_string(),
         call_id: "call-x".to_string(),
+        provider_metadata: None,
     }];
     let mut h = create_history_with_items(items);
     h.normalize_history(&default_input_modalities());
@@ -1231,6 +1240,7 @@ fn normalize_adds_missing_output_for_function_call_inserts_output() {
                 namespace: None,
                 arguments: "{}".to_string(),
                 call_id: "call-x".to_string(),
+                provider_metadata: None,
             },
             ResponseItem::FunctionCallOutput {
                 call_id: "call-x".to_string(),
@@ -1399,6 +1409,7 @@ fn normalize_mixed_inserts_and_removals_panics_in_debug() {
             namespace: None,
             arguments: "{}".to_string(),
             call_id: "c1".to_string(),
+            provider_metadata: None,
         },
         ResponseItem::FunctionCallOutput {
             call_id: "c2".to_string(),

--- a/sys/kern/kern/src/minions/control_tests.rs
+++ b/sys/kern/kern/src/minions/control_tests.rs
@@ -385,6 +385,7 @@ async fn spawn_agent_can_fork_parent_thread_history() {
         namespace: None,
         arguments: "{}".to_string(),
         call_id: parent_spawn_call_id.clone(),
+        provider_metadata: None,
     };
     parent_thread
         .chaos
@@ -468,6 +469,7 @@ async fn spawn_agent_fork_injects_output_for_parent_spawn_call() {
         namespace: None,
         arguments: "{}".to_string(),
         call_id: parent_spawn_call_id.clone(),
+        provider_metadata: None,
     };
     parent_thread
         .chaos
@@ -542,6 +544,7 @@ async fn spawn_agent_fork_flushes_parent_rollout_before_loading_history() {
         namespace: None,
         arguments: "{}".to_string(),
         call_id: parent_spawn_call_id.clone(),
+        provider_metadata: None,
     };
     parent_thread
         .chaos
@@ -1123,6 +1126,7 @@ fn sanitize_forked_history_keeps_conversation_and_spawn_call() {
             namespace: None,
             arguments: "{}".to_string(),
             call_id: call_id.to_string(),
+            provider_metadata: None,
         })
     };
 

--- a/sys/kern/kern/src/process_table_tests.rs
+++ b/sys/kern/kern/src/process_table_tests.rs
@@ -36,6 +36,7 @@ fn drops_from_last_user_only() {
             name: "tool".to_string(),
             namespace: None,
             arguments: "{}".to_string(),
+            provider_metadata: None,
         },
         assistant_msg("a4"),
     ];

--- a/sys/kern/kern/src/tools/router_tests.rs
+++ b/sys/kern/kern/src/tools/router_tests.rs
@@ -20,6 +20,7 @@ async fn build_tool_call_uses_namespace_for_registry_name() -> anyhow::Result<()
             namespace: Some("mcp__codex_apps__calendar".to_string()),
             arguments: "{}".to_string(),
             call_id: "call-namespace".to_string(),
+            provider_metadata: None,
         },
     )
     .await?

--- a/sys/kern/kern/src/turn_timing_tests.rs
+++ b/sys/kern/kern/src/turn_timing_tests.rs
@@ -83,6 +83,7 @@ fn response_item_records_turn_ttft_for_first_output_signals() {
             namespace: None,
             arguments: "{}".to_string(),
             call_id: "call-1".to_string(),
+            provider_metadata: None,
         }
     ));
     assert!(response_item_records_turn_ttft(

--- a/sys/kern/providers/parrot/src/anthropic.rs
+++ b/sys/kern/providers/parrot/src/anthropic.rs
@@ -663,6 +663,7 @@ fn parse_sse_event(
                         },
                         call_id: acc.id,
                         namespace: None,
+                        provider_metadata: None,
                     },
                 )])
             } else if let Some(acc) = text_acc.take() {

--- a/sys/kern/providers/parrot/src/chat_completions.rs
+++ b/sys/kern/providers/parrot/src/chat_completions.rs
@@ -972,9 +972,10 @@ mod tests {
             Some(&Value::String(signature.to_string())),
             "Gemini requires the original thought signature on the replayed assistant tool call"
         );
-        assert_eq!(body.pointer("/messages/1/tool_call_id"), Some(&Value::String(
-            "call_exec".to_string()
-        )));
+        assert_eq!(
+            body.pointer("/messages/1/tool_call_id"),
+            Some(&Value::String("call_exec".to_string()))
+        );
     }
 
     #[tokio::test]

--- a/sys/kern/providers/parrot/src/chat_completions.rs
+++ b/sys/kern/providers/parrot/src/chat_completions.rs
@@ -293,20 +293,25 @@ fn convert_input_to_messages(input: &[ResponseItem]) -> Vec<ChatMessage> {
                 name,
                 arguments,
                 call_id,
+                provider_metadata,
                 ..
             } => {
                 // Assistant turn that issued a tool call.
+                let mut tool_call = serde_json::json!({
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "arguments": arguments,
+                    }
+                });
+                if let Some(metadata) = provider_metadata {
+                    tool_call["extra_content"] = metadata.clone();
+                }
                 messages.push(ChatMessage {
                     role: "assistant".to_string(),
                     content: None,
-                    tool_calls: Some(serde_json::json!([{
-                        "id": call_id,
-                        "type": "function",
-                        "function": {
-                            "name": name,
-                            "arguments": arguments,
-                        }
-                    }])),
+                    tool_calls: Some(Value::Array(vec![tool_call])),
                     tool_call_id: None,
                     name: None,
                 });
@@ -404,6 +409,7 @@ struct ToolCallAccumulator {
     id: String,
     name: String,
     arguments: String,
+    provider_metadata: Option<Value>,
 }
 
 /// In-flight text accumulator so we can finalize the assistant message.
@@ -522,6 +528,10 @@ fn parse_chunk(
                 if let Some(chunk) = tc.pointer("/function/arguments").and_then(Value::as_str) {
                     acc.arguments.push_str(chunk);
                 }
+
+                if let Some(extra_content) = tc.get("extra_content") {
+                    acc.provider_metadata = Some(extra_content.clone());
+                }
             }
         }
 
@@ -548,6 +558,7 @@ fn parse_chunk(
                     },
                     call_id: acc.id,
                     namespace: None,
+                    provider_metadata: acc.provider_metadata,
                 }));
             }
 
@@ -859,6 +870,111 @@ mod tests {
                 ..
             }) if name == "second" && arguments == "{\"b\":2}" && call_id == "call_2"
         ));
+    }
+
+    #[test]
+    fn gemini_thought_signature_survives_tool_call_round_trip() {
+        let signature = "opaque-gemini-thought-signature";
+        let mut tool_acc = BTreeMap::new();
+        let mut text_acc = None;
+        let mut response_id = String::new();
+        let mut server_model = None;
+
+        parse_chunk(
+            &serde_json::json!({
+                "id": "chatcmpl-gemini-1",
+                "model": "gemini-2.5-pro",
+                "choices": [{
+                    "delta": {
+                        "tool_calls": [{
+                            "index": 0,
+                            "id": "call_exec",
+                            "type": "function",
+                            "function": {
+                                "name": "default_api:exec_command",
+                                "arguments": "{\"cmd\":\"ls\"}"
+                            },
+                            "extra_content": {
+                                "google": {
+                                    "thought_signature": signature
+                                }
+                            }
+                        }]
+                    },
+                    "finish_reason": null
+                }]
+            }),
+            &mut tool_acc,
+            &mut text_acc,
+            &mut response_id,
+            &mut server_model,
+        )
+        .expect("Gemini tool-call chunk should parse");
+
+        let events = parse_chunk(
+            &serde_json::json!({
+                "id": "chatcmpl-gemini-1",
+                "model": "gemini-2.5-pro",
+                "choices": [{
+                    "delta": {},
+                    "finish_reason": "tool_calls"
+                }]
+            }),
+            &mut tool_acc,
+            &mut text_acc,
+            &mut response_id,
+            &mut server_model,
+        )
+        .expect("Gemini tool call should finalize");
+
+        let tool_call = events
+            .into_iter()
+            .find_map(|event| match event {
+                TurnEvent::OutputItemDone(item @ ResponseItem::FunctionCall { .. }) => Some(item),
+                _ => None,
+            })
+            .expect("finalized tool call should be emitted");
+
+        // The provider adapter crosses the ABI/IPC boundary before the next
+        // request, so exercise serde as well as the in-memory conversion.
+        let tool_call: ResponseItem = serde_json::from_value(
+            serde_json::to_value(tool_call).expect("tool call should serialize"),
+        )
+        .expect("tool call should deserialize");
+
+        let request = TurnRequest {
+            model: "gemini-2.5-pro".to_string(),
+            instructions: String::new(),
+            input: vec![
+                tool_call,
+                ResponseItem::FunctionCallOutput {
+                    call_id: "call_exec".to_string(),
+                    output: chaos_ipc::models::FunctionCallOutputPayload::from_text(
+                        "command output".to_string(),
+                    ),
+                    tool_name: Some("default_api:exec_command".to_string()),
+                },
+            ],
+            tools: vec![],
+            parallel_tool_calls: false,
+            reasoning: None,
+            output_schema: None,
+            verbosity: None,
+            turn_state: None,
+            extensions: serde_json::Map::new(),
+        };
+
+        let body =
+            build_request_body(&request, "gemini-2.5-pro").expect("follow-up body should build");
+
+        assert_eq!(
+            body.pointer("/messages/0/tool_calls/0/extra_content/google/thought_signature"),
+            Some(&Value::String(signature.to_string())),
+            "Gemini requires the original thought signature on the replayed assistant tool call"
+        );
+        assert_eq!(body.pointer("/messages/1/tool_call_id"), Some(&Value::String(
+            "call_exec".to_string()
+        )));
     }
 
     #[tokio::test]

--- a/sys/kern/providers/parrot/src/lsd.rs
+++ b/sys/kern/providers/parrot/src/lsd.rs
@@ -601,6 +601,7 @@ fn parse_chunk(
                 },
                 call_id: acc.id,
                 namespace: None,
+                provider_metadata: None,
             }));
         }
 

--- a/sys/kern/providers/parrot/src/representer.rs
+++ b/sys/kern/providers/parrot/src/representer.rs
@@ -78,6 +78,7 @@ fn base_represent(item: ResponseItem) -> Option<ResponseItem> {
             namespace: None,
             arguments: input,
             call_id,
+            provider_metadata: None,
         }),
 
         // LocalShellCall → FunctionCall so the matching FunctionCallOutput
@@ -96,6 +97,7 @@ fn base_represent(item: ResponseItem) -> Option<ResponseItem> {
                 namespace: None,
                 arguments,
                 call_id,
+                provider_metadata: None,
             })
         }
 


### PR DESCRIPTION
## Summary
- retain provider-specific tool-call metadata in the Chaos ABI
- capture Gemini `extra_content.google.thought_signature` from streamed chat-completions tool calls
- replay that metadata on follow-up assistant tool-call messages
- add a regression test covering stream parsing, ABI serialization, and request reconstruction

## Test plan
- `~/.cargo/bin/cargo test -p chaos-parrot chat_completions --no-fail-fast`
- `~/.cargo/bin/cargo fmt --all -- --check`