### PR TITLE
feat: add xAI subscription authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1794,6 +1794,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tracing-test",
+ "url",
  "uuid",
  "walkdir",
  "which",

--- a/bin/chaos/README.md
+++ b/bin/chaos/README.md
@@ -6,6 +6,22 @@ sessions.
 
 ## Account management
 
+Connect a provider subscription account with device authorization:
+
+- ChatGPT:
+  - `chaos --provider openai accounts --device-auth`
+- xAI:
+  - `chaos --provider xai accounts --device-auth`
+
+The command prints a verification URL and one-time code, then stores the
+resulting provider-scoped OAuth credentials in Chaos's normal credential
+store (`auth.json` when file storage is configured). Existing API-key
+connections remain unchanged unless this command is run for that provider.
+
+xAI subscription auth uses xAI's public Grok CLI OAuth client and device-code
+endpoints. Authenticated model requests are sent to the Grok CLI subscription
+proxy; API-key requests continue to use `https://api.x.ai/v1`.
+
 Use the CLI to disconnect stored provider credentials:
 
 - disconnect the active provider:

--- a/bin/chaos/src/accounts.rs
+++ b/bin/chaos/src/accounts.rs
@@ -22,6 +22,10 @@ use chaos_pam::DeviceCode;
 use chaos_pam::LoginFlowMode;
 use chaos_pam::LoginFlowUpdate;
 use chaos_pam::ServerOptions;
+use chaos_pam::XaiDeviceCode;
+use chaos_pam::XaiDeviceCodeOptions;
+use chaos_pam::complete_xai_device_code_login;
+use chaos_pam::request_xai_device_code;
 use chaos_pam::spawn_login_flow;
 use std::io::IsTerminal;
 use std::io::Read;
@@ -34,6 +38,8 @@ use chaos_snitch::open_log_file_layer;
 
 const CHATGPT_LOGIN_DISABLED_MESSAGE: &str =
     "ChatGPT account connection is disabled. Use an API key connection instead.";
+const ACCOUNT_LOGIN_DISABLED_MESSAGE: &str =
+    "Subscription account connection is disabled. Use an API key connection instead.";
 const API_KEY_LOGIN_DISABLED_MESSAGE: &str =
     "API key connection is disabled. Use a ChatGPT account instead.";
 const DEBUG_LOG_FILTER: &str = "warn,chaos_kern=debug,chaos_coreboot=debug,chaos_boot=debug,chaos_fork=debug,\
@@ -124,6 +130,20 @@ fn print_device_code_prompt(device_code: &DeviceCode) {
             "\nDevice codes are a common phishing target. Never share this code.\n"
         ),
         device_code.verification_url, device_code.user_code
+    );
+}
+
+fn print_xai_device_code_prompt(device_code: &XaiDeviceCode) {
+    eprintln!(
+        concat!(
+            "\nFollow these steps to sign in with xAI using device authorization:\n",
+            "\n1. Open this link in your browser and sign in to your account\n   {}\n",
+            "\n2. If prompted, enter this one-time code (expires in {} minutes)\n   {}\n",
+            "\nDevice codes are a common phishing target. Never share this code.\n"
+        ),
+        device_code.verification_url,
+        device_code.expires_in.div_ceil(60),
+        device_code.user_code
     );
 }
 
@@ -279,7 +299,7 @@ pub fn read_api_key_from_stdin() -> String {
     api_key
 }
 
-/// Connect a ChatGPT account using the OAuth device-code flow.
+/// Connect a supported subscription account using its OAuth device-code flow.
 pub async fn run_connect_with_device_code(
     cli_config_overrides: CliConfigOverrides,
     issuer_base_url: Option<String>,
@@ -287,9 +307,59 @@ pub async fn run_connect_with_device_code(
 ) -> ! {
     let config = load_config_or_exit(cli_config_overrides).await;
     let _login_log_guards = init_accounts_file_logging(&config);
-    tracing::info!("starting device code account connection flow");
+    tracing::info!(
+        provider_id = %config.model_provider_id,
+        "starting device code account connection flow"
+    );
     if matches!(config.forced_login_method, Some(ForcedLoginMethod::Api)) {
-        eprintln!("{CHATGPT_LOGIN_DISABLED_MESSAGE}");
+        eprintln!("{ACCOUNT_LOGIN_DISABLED_MESSAGE}");
+        std::process::exit(1);
+    }
+    if config
+        .model_provider
+        .supports_auth_method(ProviderAuthMethod::XaiAccount)
+    {
+        let mut opts =
+            XaiDeviceCodeOptions::new(config.chaos_home, config.cli_auth_credentials_store_mode);
+        if let Some(issuer) = issuer_base_url {
+            opts.issuer = issuer;
+        }
+        if let Some(client_id) = client_id {
+            opts.client_id = client_id;
+        }
+        let device_code = match request_xai_device_code(&opts).await {
+            Ok(device_code) => device_code,
+            Err(err) => {
+                eprintln!("Error starting xAI device authorization: {err}");
+                std::process::exit(1);
+            }
+        };
+        print_xai_device_code_prompt(&device_code);
+        match complete_xai_device_code_login(opts, device_code).await {
+            Ok(()) => {
+                eprintln!(
+                    "Successfully connected {} using your xAI account",
+                    config.model_provider.name
+                );
+                std::process::exit(0);
+            }
+            Err(err) => {
+                eprintln!(
+                    "Error connecting {} with device authorization: {err}",
+                    config.model_provider.name
+                );
+                std::process::exit(1);
+            }
+        }
+    }
+    if !config
+        .model_provider
+        .supports_auth_method(ProviderAuthMethod::ChatgptAccount)
+    {
+        eprintln!(
+            "{} does not support subscription account connections. Use `chaos --provider {} accounts --with-api-key` instead.",
+            config.model_provider.name, config.model_provider_id
+        );
         std::process::exit(1);
     }
     let forced_chatgpt_workspace_id = config.forced_chatgpt_workspace_id.clone();
@@ -409,6 +479,16 @@ fn describe_provider_record(
         chaos_ipc::api::AuthMode::ChatgptAuthTokens => {
             format!("{provider_name}: externally managed ChatGPT tokens connected")
         }
+        chaos_ipc::api::AuthMode::Xai => {
+            let email = record
+                .tokens
+                .as_ref()
+                .and_then(|tokens| tokens.id_token.email.as_deref());
+            match email {
+                Some(email) => format!("{provider_name}: xAI account ({email})"),
+                None => format!("{provider_name}: xAI account connected"),
+            }
+        }
     }
 }
 
@@ -474,6 +554,9 @@ pub async fn run_accounts_status(cli_config_overrides: CliConfigOverrides) -> ! 
             },
             AuthMode::Chatgpt => {
                 eprintln!("Active connection: {active_provider_name} ChatGPT account")
+            }
+            AuthMode::Xai => {
+                eprintln!("Active connection: {active_provider_name} xAI account")
             }
         }
     } else {

--- a/bin/chaos/src/main.rs
+++ b/bin/chaos/src/main.rs
@@ -190,7 +190,10 @@ struct AccountsCommand {
     )]
     with_api_key: bool,
 
-    #[arg(long = "device-auth")]
+    #[arg(
+        long = "device-auth",
+        help = "Connect the selected provider with a subscription account using device authorization"
+    )]
     use_device_code: bool,
 
     /// EXPERIMENTAL: Use custom OAuth issuer base URL (advanced)

--- a/lib/libcontract/ipc/src/api.rs
+++ b/lib/libcontract/ipc/src/api.rs
@@ -41,7 +41,7 @@ impl GitSha {
     }
 }
 
-/// Authentication mode for OpenAI-backed providers.
+/// Authentication mode for managed model-provider credentials.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Display, JsonSchema, TS)]
 #[serde(rename_all = "lowercase")]
 pub enum AuthMode {
@@ -49,6 +49,8 @@ pub enum AuthMode {
     ApiKey,
     /// ChatGPT OAuth managed by Chaos (tokens persisted and refreshed by Chaos).
     Chatgpt,
+    /// xAI OAuth managed by Chaos (tokens persisted and refreshed by Chaos).
+    Xai,
     /// [UNSTABLE] FOR OPENAI INTERNAL USE ONLY - DO NOT USE.
     ///
     /// ChatGPT auth tokens are supplied by an external host app and are only

--- a/lib/libmisc/pam/src/lib.rs
+++ b/lib/libmisc/pam/src/lib.rs
@@ -2,6 +2,7 @@ mod device_code_auth;
 mod login_flow_machine;
 mod pkce;
 mod server;
+mod xai_device_code_auth;
 
 pub use codex_client::BuildCustomCaTransportError as BuildLoginHttpClientError;
 pub use device_code_auth::DeviceCode;
@@ -17,6 +18,12 @@ pub use server::LoginServer;
 pub use server::ServerOptions;
 pub use server::ShutdownHandle;
 pub use server::run_login_server;
+pub use xai_device_code_auth::XAI_OAUTH_CLIENT_ID;
+pub use xai_device_code_auth::XAI_OAUTH_ISSUER;
+pub use xai_device_code_auth::XaiDeviceCode;
+pub use xai_device_code_auth::XaiDeviceCodeOptions;
+pub use xai_device_code_auth::complete_xai_device_code_login;
+pub use xai_device_code_auth::request_xai_device_code;
 
 // Re-export commonly used auth types and helpers from chaos-kern for compatibility
 pub use chaos_ipc::api::AuthMode;

--- a/lib/libmisc/pam/src/xai_device_code_auth.rs
+++ b/lib/libmisc/pam/src/xai_device_code_auth.rs
@@ -1,0 +1,283 @@
+use chaos_kern::auth::AuthCredentialsStoreMode;
+use chaos_kern::auth::login_with_xai_oauth_tokens;
+use codex_client::ChaosHttpClient;
+use serde::Deserialize;
+use std::io;
+use std::path::PathBuf;
+use std::time::Duration;
+use std::time::Instant;
+use url::Url;
+
+pub const XAI_OAUTH_ISSUER: &str = "https://auth.x.ai";
+pub const XAI_OAUTH_CLIENT_ID: &str = "b1a00492-073a-47ea-816f-4c329264a828";
+pub const XAI_OAUTH_SCOPE: &str = "openid profile email offline_access grok-cli:access api:access \
+conversations:read conversations:write workspaces:read workspaces:write";
+const XAI_OAUTH_REFERRER: &str = "chaos";
+const DEFAULT_POLL_INTERVAL_SECS: u64 = 5;
+
+#[derive(Debug, Clone)]
+pub struct XaiDeviceCodeOptions {
+    pub chaos_home: PathBuf,
+    pub issuer: String,
+    pub client_id: String,
+    pub auth_credentials_store_mode: AuthCredentialsStoreMode,
+}
+
+impl XaiDeviceCodeOptions {
+    pub fn new(chaos_home: PathBuf, auth_credentials_store_mode: AuthCredentialsStoreMode) -> Self {
+        Self {
+            chaos_home,
+            issuer: XAI_OAUTH_ISSUER.to_string(),
+            client_id: XAI_OAUTH_CLIENT_ID.to_string(),
+            auth_credentials_store_mode,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct XaiDeviceCode {
+    pub verification_url: String,
+    pub user_code: String,
+    pub expires_in: u64,
+    device_code: String,
+    interval: u64,
+    token_endpoint: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DiscoveryDocument {
+    token_endpoint: String,
+    device_authorization_endpoint: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeviceCodeResponse {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    expires_in: u64,
+    interval: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    refresh_token: String,
+    id_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OAuthErrorResponse {
+    error: Option<String>,
+    error_description: Option<String>,
+}
+
+fn form_body(fields: &[(&str, &str)]) -> String {
+    let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+    for (key, value) in fields {
+        serializer.append_pair(key, value);
+    }
+    serializer.finish()
+}
+
+fn validated_endpoint(issuer: &str, endpoint: &str, field: &str) -> io::Result<String> {
+    let issuer = Url::parse(issuer).map_err(io::Error::other)?;
+    let endpoint = Url::parse(endpoint).map_err(io::Error::other)?;
+    if issuer.scheme() != endpoint.scheme()
+        || issuer.host_str() != endpoint.host_str()
+        || issuer.port_or_known_default() != endpoint.port_or_known_default()
+    {
+        return Err(io::Error::other(format!(
+            "xAI OAuth discovery returned {field} on a different origin"
+        )));
+    }
+    if issuer.scheme() == "https" && endpoint.scheme() != "https" {
+        return Err(io::Error::other(format!(
+            "xAI OAuth discovery returned a non-HTTPS {field}"
+        )));
+    }
+    Ok(endpoint.to_string())
+}
+
+fn validated_verification_url(issuer: &str, verification_url: &str) -> io::Result<String> {
+    let issuer = Url::parse(issuer).map_err(io::Error::other)?;
+    let verification_url = Url::parse(verification_url).map_err(io::Error::other)?;
+    let production_accounts_app = issuer.host_str() == Some("auth.x.ai")
+        && verification_url.host_str() == Some("accounts.x.ai")
+        && verification_url.scheme() == "https";
+    let same_origin = issuer.scheme() == verification_url.scheme()
+        && issuer.host_str() == verification_url.host_str()
+        && issuer.port_or_known_default() == verification_url.port_or_known_default();
+    if !production_accounts_app && !same_origin {
+        return Err(io::Error::other(
+            "xAI device authorization returned a verification URL on an unexpected origin",
+        ));
+    }
+    if issuer.scheme() == "https" && verification_url.scheme() != "https" {
+        return Err(io::Error::other(
+            "xAI device authorization returned a non-HTTPS verification URL",
+        ));
+    }
+    Ok(verification_url.to_string())
+}
+
+async fn discover(opts: &XaiDeviceCodeOptions) -> io::Result<DiscoveryDocument> {
+    let issuer = opts.issuer.trim_end_matches('/');
+    let url = format!("{issuer}/.well-known/openid-configuration");
+    let response = ChaosHttpClient::default_client()
+        .get(&url)
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .map_err(io::Error::other)?;
+    if !response.status().is_success() {
+        return Err(io::Error::other(format!(
+            "xAI OIDC discovery failed with status {}",
+            response.status()
+        )));
+    }
+    let mut discovery: DiscoveryDocument = response.json().await.map_err(io::Error::other)?;
+    discovery.token_endpoint =
+        validated_endpoint(issuer, &discovery.token_endpoint, "token endpoint")?;
+    if let Some(endpoint) = discovery.device_authorization_endpoint.as_deref() {
+        discovery.device_authorization_endpoint = Some(validated_endpoint(
+            issuer,
+            endpoint,
+            "device authorization endpoint",
+        )?);
+    }
+    Ok(discovery)
+}
+
+pub async fn request_xai_device_code(opts: &XaiDeviceCodeOptions) -> io::Result<XaiDeviceCode> {
+    let discovery = discover(opts).await?;
+    let endpoint = discovery.device_authorization_endpoint.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "xAI OIDC discovery did not advertise device authorization",
+        )
+    })?;
+    let body = form_body(&[
+        ("client_id", &opts.client_id),
+        ("scope", XAI_OAUTH_SCOPE),
+        ("referrer", XAI_OAUTH_REFERRER),
+    ]);
+    let response = ChaosHttpClient::default_client()
+        .post(&endpoint)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .header("Accept", "application/json")
+        .body(body)
+        .send()
+        .await
+        .map_err(io::Error::other)?;
+    if !response.status().is_success() {
+        return Err(io::Error::other(format!(
+            "xAI device code request failed with status {}",
+            response.status()
+        )));
+    }
+    let response: DeviceCodeResponse = response.json().await.map_err(io::Error::other)?;
+    if response.device_code.is_empty() {
+        return Err(io::Error::other(
+            "xAI device authorization returned an empty device code",
+        ));
+    }
+    if response.user_code.is_empty()
+        || !response
+            .user_code
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '-')
+    {
+        return Err(io::Error::other(
+            "xAI device authorization returned an invalid user-code format",
+        ));
+    }
+    Ok(XaiDeviceCode {
+        // Keep the one-time code out of the URL. xAI also returns a
+        // verification_uri_complete value with the code embedded, but callers
+        // such as hosted-agent shims may safely log or display this plain URL
+        // while transporting the user code through a separate secret field.
+        verification_url: validated_verification_url(&opts.issuer, &response.verification_uri)?,
+        user_code: response.user_code,
+        expires_in: response.expires_in,
+        device_code: response.device_code,
+        interval: response
+            .interval
+            .unwrap_or(DEFAULT_POLL_INTERVAL_SECS)
+            .max(1),
+        token_endpoint: discovery.token_endpoint,
+    })
+}
+
+pub async fn complete_xai_device_code_login(
+    opts: XaiDeviceCodeOptions,
+    device_code: XaiDeviceCode,
+) -> io::Result<()> {
+    let client = ChaosHttpClient::default_client();
+    let started = Instant::now();
+    let max_wait = Duration::from_secs(device_code.expires_in);
+    let mut poll_interval = device_code.interval;
+
+    let tokens = loop {
+        let remaining = max_wait.saturating_sub(started.elapsed());
+        tokio::time::sleep(Duration::from_secs(poll_interval).min(remaining)).await;
+        if started.elapsed() >= max_wait {
+            return Err(io::Error::other(
+                "xAI device authorization expired before it was completed",
+            ));
+        }
+
+        let body = form_body(&[
+            ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+            ("client_id", &opts.client_id),
+            ("device_code", &device_code.device_code),
+        ]);
+        let response = client
+            .post(&device_code.token_endpoint)
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .header("Accept", "application/json")
+            .body(body)
+            .send()
+            .await
+            .map_err(io::Error::other)?;
+        let status = response.status();
+        if status.is_success() {
+            let tokens = response
+                .json::<TokenResponse>()
+                .await
+                .map_err(io::Error::other)?;
+            if tokens.access_token.is_empty() || tokens.refresh_token.is_empty() {
+                return Err(io::Error::other(
+                    "xAI device token exchange returned incomplete credentials",
+                ));
+            }
+            break tokens;
+        }
+
+        let body = response.text().await.unwrap_or_default();
+        let error = serde_json::from_str::<OAuthErrorResponse>(&body).ok();
+        match error.as_ref().and_then(|error| error.error.as_deref()) {
+            Some("authorization_pending") => {}
+            Some("slow_down") => poll_interval = (poll_interval + 5).min(30),
+            Some("access_denied" | "expired_token") => {
+                let message = error
+                    .and_then(|error| error.error_description.or(error.error))
+                    .unwrap_or_else(|| "xAI device authorization was denied".to_string());
+                return Err(io::Error::new(io::ErrorKind::PermissionDenied, message));
+            }
+            _ => {
+                return Err(io::Error::other(format!(
+                    "xAI device token exchange failed with status {status}"
+                )));
+            }
+        }
+    };
+
+    login_with_xai_oauth_tokens(
+        &opts.chaos_home,
+        tokens.id_token.as_deref(),
+        &tokens.access_token,
+        &tokens.refresh_token,
+        opts.auth_credentials_store_mode,
+    )
+}

--- a/lib/libmisc/pam/tests/suite/mod.rs
+++ b/lib/libmisc/pam/tests/suite/mod.rs
@@ -5,3 +5,5 @@ mod auth_test_support;
 mod device_code_login;
 #[path = "login_server_e2e.rs"]
 mod login_server_e2e;
+#[path = "xai_device_code_login.rs"]
+mod xai_device_code_login;

--- a/lib/libmisc/pam/tests/suite/xai_device_code_login.rs
+++ b/lib/libmisc/pam/tests/suite/xai_device_code_login.rs
@@ -1,0 +1,210 @@
+#![allow(clippy::unwrap_used)]
+
+use chaos_ipc::api::AuthMode;
+use chaos_kern::auth::AuthCredentialsStoreMode;
+use chaos_kern::auth::load_auth_dot_json;
+use chaos_pam::XaiDeviceCodeOptions;
+use chaos_pam::complete_xai_device_code_login;
+use chaos_pam::request_xai_device_code;
+use serde_json::json;
+use tempfile::TempDir;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::body_string_contains;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
+
+use super::auth_test_support::make_jwt;
+
+struct XaiDeviceCodeHarness {
+    chaos_home: TempDir,
+    mock_server: MockServer,
+}
+
+impl XaiDeviceCodeHarness {
+    async fn start() -> Self {
+        Self {
+            chaos_home: tempfile::tempdir().unwrap(),
+            mock_server: MockServer::start().await,
+        }
+    }
+
+    fn options(&self) -> XaiDeviceCodeOptions {
+        let mut options = XaiDeviceCodeOptions::new(
+            self.chaos_home.path().to_path_buf(),
+            AuthCredentialsStoreMode::File,
+        );
+        options.issuer = self.mock_server.uri();
+        options.client_id = "xai-test-client".to_string();
+        options
+    }
+
+    async fn mock_discovery(&self) {
+        Mock::given(method("GET"))
+            .and(path("/.well-known/openid-configuration"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "token_endpoint": format!("{}/oauth2/token", self.mock_server.uri()),
+                "device_authorization_endpoint": format!(
+                    "{}/oauth2/device/code",
+                    self.mock_server.uri()
+                )
+            })))
+            .mount(&self.mock_server)
+            .await;
+    }
+
+    async fn mock_device_code(&self) {
+        let verification_uri = format!("{}/oauth2/device", self.mock_server.uri());
+        Mock::given(method("POST"))
+            .and(path("/oauth2/device/code"))
+            .and(body_string_contains("client_id=xai-test-client"))
+            .and(body_string_contains("grok-cli%3Aaccess"))
+            .and(body_string_contains("conversations%3Aread"))
+            .and(body_string_contains("workspaces%3Awrite"))
+            .and(body_string_contains("referrer=chaos"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "device_code": "device-secret",
+                "user_code": "GROK-CODE",
+                "verification_uri": verification_uri,
+                "verification_uri_complete": format!(
+                    "{}/oauth2/device?user_code=GROK-CODE",
+                    self.mock_server.uri()
+                ),
+                "expires_in": 900,
+                "interval": 0
+            })))
+            .mount(&self.mock_server)
+            .await;
+    }
+}
+
+#[tokio::test]
+async fn xai_device_code_login_persists_provider_scoped_oauth() {
+    let harness = XaiDeviceCodeHarness::start().await;
+    harness.mock_discovery().await;
+    harness.mock_device_code().await;
+    let id_token = make_jwt(json!({
+        "sub": "xai-user-123",
+        "email": "grok@example.com"
+    }));
+    Mock::given(method("POST"))
+        .and(path("/oauth2/token"))
+        .and(body_string_contains(
+            "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code",
+        ))
+        .and(body_string_contains("device_code=device-secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "xai-access-token",
+            "refresh_token": "xai-refresh-token",
+            "id_token": id_token
+        })))
+        .mount(&harness.mock_server)
+        .await;
+
+    let options = harness.options();
+    let device_code = request_xai_device_code(&options).await.unwrap();
+    assert_eq!(device_code.user_code, "GROK-CODE");
+    assert_eq!(
+        device_code.verification_url,
+        format!("{}/oauth2/device", harness.mock_server.uri())
+    );
+    complete_xai_device_code_login(options, device_code)
+        .await
+        .unwrap();
+
+    let auth = load_auth_dot_json(harness.chaos_home.path(), AuthCredentialsStoreMode::File)
+        .unwrap()
+        .unwrap();
+    let record = auth.provider_record("xai").unwrap();
+    assert_eq!(record.auth_mode, Some(AuthMode::Xai));
+    assert!(record.api_key.is_none());
+    let tokens = record.tokens.unwrap();
+    assert_eq!(tokens.access_token, "xai-access-token");
+    assert_eq!(tokens.refresh_token, "xai-refresh-token");
+    assert_eq!(tokens.account_id.as_deref(), Some("xai-user-123"));
+    assert_eq!(tokens.id_token.email.as_deref(), Some("grok@example.com"));
+}
+
+#[tokio::test]
+async fn xai_device_code_login_uses_access_token_identity_when_id_token_is_omitted() {
+    let harness = XaiDeviceCodeHarness::start().await;
+    harness.mock_discovery().await;
+    harness.mock_device_code().await;
+    let access_token = make_jwt(json!({
+        "sub": "xai-access-user",
+        "email": "access-token@example.com"
+    }));
+    Mock::given(method("POST"))
+        .and(path("/oauth2/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": access_token,
+            "refresh_token": "xai-refresh-token"
+        })))
+        .mount(&harness.mock_server)
+        .await;
+
+    let options = harness.options();
+    let device_code = request_xai_device_code(&options).await.unwrap();
+    complete_xai_device_code_login(options, device_code)
+        .await
+        .unwrap();
+
+    let auth = load_auth_dot_json(harness.chaos_home.path(), AuthCredentialsStoreMode::File)
+        .unwrap()
+        .unwrap();
+    let tokens = auth.provider_record("xai").unwrap().tokens.unwrap();
+    assert_eq!(tokens.account_id.as_deref(), Some("xai-access-user"));
+    assert_eq!(
+        tokens.id_token.email.as_deref(),
+        Some("access-token@example.com")
+    );
+}
+
+#[tokio::test]
+async fn xai_device_code_login_rejects_untrusted_verification_origin() {
+    let harness = XaiDeviceCodeHarness::start().await;
+    harness.mock_discovery().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth2/device/code"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "device_code": "device-secret",
+            "user_code": "GROK-CODE",
+            "verification_uri": "https://attacker.example/device",
+            "expires_in": 900
+        })))
+        .mount(&harness.mock_server)
+        .await;
+
+    let error = request_xai_device_code(&harness.options())
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("unexpected origin"));
+}
+
+#[tokio::test]
+async fn xai_device_code_login_does_not_persist_denied_authorization() {
+    let harness = XaiDeviceCodeHarness::start().await;
+    harness.mock_discovery().await;
+    harness.mock_device_code().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth2/token"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "error": "access_denied",
+            "error_description": "The user denied the request"
+        })))
+        .mount(&harness.mock_server)
+        .await;
+
+    let options = harness.options();
+    let device_code = request_xai_device_code(&options).await.unwrap();
+    let error = complete_xai_device_code_login(options, device_code)
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+    assert!(
+        load_auth_dot_json(harness.chaos_home.path(), AuthCredentialsStoreMode::File)
+            .unwrap()
+            .is_none()
+    );
+}

--- a/lib/libnet/services/thirdparty.toml
+++ b/lib/libnet/services/thirdparty.toml
@@ -37,6 +37,7 @@ base_url             = "https://api.x.ai/v1"
 env_key              = "XAI_API_KEY"
 env_key_instructions = "Get an API key at https://console.x.ai and export it as XAI_API_KEY."
 wire_api             = "responses"
+auth.methods         = ["api_key", "xai_account"]
 
 [zai]
 name                 = "Z.ai"

--- a/lib/libtrace/snitch/src/lib.rs
+++ b/lib/libtrace/snitch/src/lib.rs
@@ -56,6 +56,7 @@ pub enum ToolDecisionSource {
 pub enum TelemetryAuthMode {
     ApiKey,
     Chatgpt,
+    Xai,
 }
 
 /// Start a metrics timer using the globally installed metrics client.

--- a/lib/libui/status/helpers.rs
+++ b/lib/libui/status/helpers.rs
@@ -55,6 +55,11 @@ pub fn compose_account_display(
                 plan,
             })
         }
+        CoreAuthMode::Xai => Some(StatusAccountDisplay::ChatGpt {
+            provider_label,
+            email: auth.get_account_email(),
+            plan: None,
+        }),
     }
 }
 

--- a/sys/kern/kern/Cargo.toml
+++ b/sys/kern/kern/Cargo.toml
@@ -118,6 +118,7 @@ rama = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
+url = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4", "v5"] }
 which = { workspace = true }
 wildmatch = { workspace = true }

--- a/sys/kern/kern/src/api_bridge.rs
+++ b/sys/kern/kern/src/api_bridge.rs
@@ -18,6 +18,7 @@ use crate::error::UsageLimitReachedError;
 use crate::model_provider_info::ANTHROPIC_PROVIDER_ID;
 use crate::model_provider_info::ModelProviderInfo;
 use crate::model_provider_info::OPENAI_PROVIDER_ID;
+use crate::model_provider_info::XAI_PROVIDER_ID;
 use crate::model_provider_info::is_anthropic_wire;
 
 pub(crate) fn map_api_error(err: ApiError) -> ChaosErr {
@@ -199,6 +200,18 @@ pub(crate) fn auth_provider_from_auth(
         });
     }
 
+    if let Some(auth) = auth.as_ref()
+        && !auth.is_api_key_auth()
+    {
+        return Ok(CoreAuthProvider {
+            token: Some(auth.get_token()?),
+            account_id: auth
+                .is_chatgpt_auth()
+                .then(|| auth.get_account_id())
+                .flatten(),
+        });
+    }
+
     match provider.api_key() {
         Ok(Some(api_key)) => {
             return Ok(CoreAuthProvider {
@@ -251,7 +264,7 @@ pub(crate) fn provider_auth_missing(provider: &ModelProviderInfo) -> ChaosErr {
         provider_name: provider.name.clone(),
         env_key: provider.env_key.clone(),
         env_key_instructions: provider.env_key_instructions.clone(),
-        supports_oauth: provider.supports_chatgpt_account_auth(),
+        supports_oauth: provider.supports_account_auth(),
     })
 }
 
@@ -261,6 +274,9 @@ pub(crate) fn provider_auth_missing(provider: &ModelProviderInfo) -> ChaosErr {
 fn stable_provider_id(provider: &ModelProviderInfo) -> String {
     if provider.is_openai() {
         return OPENAI_PROVIDER_ID.to_string();
+    }
+    if provider.supports_xai_account_auth() {
+        return XAI_PROVIDER_ID.to_string();
     }
     if is_anthropic_wire(provider.base_url.as_deref()) {
         return ANTHROPIC_PROVIDER_ID.to_string();

--- a/sys/kern/kern/src/api_bridge_tests.rs
+++ b/sys/kern/kern/src/api_bridge_tests.rs
@@ -225,6 +225,27 @@ fn auth_provider_from_auth_preflight_matrix() {
     assert!(!info.supports_oauth);
     assert!(info.to_string().contains(xai_var));
 
+    let xai_oauth = ModelProviderInfo {
+        auth: Some(crate::model_provider_info::ProviderAuthCapabilities {
+            methods: vec![
+                crate::model_provider_info::ProviderAuthMethod::ApiKey,
+                crate::model_provider_info::ProviderAuthMethod::XaiAccount,
+            ],
+        }),
+        ..xai_missing.clone()
+    };
+    let Err(err) = auth_provider_from_auth(None, &xai_oauth) else {
+        panic!("xAI without OAuth or API-key credentials must fail preflight");
+    };
+    let ChaosErr::ProviderAuthMissing(info) = err else {
+        panic!("expected ProviderAuthMissing, got {err:?}");
+    };
+    assert_eq!(
+        info.provider_id,
+        crate::model_provider_info::XAI_PROVIDER_ID
+    );
+    assert!(info.supports_oauth, "xAI should offer OAuth fallback");
+
     unsafe {
         std::env::set_var(xai_var, "live-key");
     }

--- a/sys/kern/kern/src/auth.rs
+++ b/sys/kern/kern/src/auth.rs
@@ -40,6 +40,7 @@ pub use permissions::enforce_login_restrictions;
 pub use permissions::login_with_api_key;
 pub use permissions::login_with_chatgpt_auth_tokens;
 pub use permissions::login_with_provider_api_key;
+pub use permissions::login_with_xai_oauth_tokens;
 pub use policies::UnauthorizedRecovery;
 pub use policies::UnauthorizedRecoveryStepResult;
 pub use tokens::AuthManager;
@@ -56,6 +57,7 @@ pub const DEFAULT_AUTH_PROVIDER_ID: &str = "openai";
 pub enum AuthMode {
     ApiKey,
     Chatgpt,
+    Xai,
 }
 
 impl From<AuthMode> for TelemetryAuthMode {
@@ -63,6 +65,7 @@ impl From<AuthMode> for TelemetryAuthMode {
         match mode {
             AuthMode::ApiKey => TelemetryAuthMode::ApiKey,
             AuthMode::Chatgpt => TelemetryAuthMode::Chatgpt,
+            AuthMode::Xai => TelemetryAuthMode::Xai,
         }
     }
 }
@@ -72,6 +75,7 @@ impl From<AuthMode> for TelemetryAuthMode {
 pub enum ChaosAuth {
     ApiKey(ApiKeyAuth),
     Chatgpt(ChatgptAuth),
+    Xai(ChatgptAuth),
     ChatgptAuthTokens(ChatgptAuthTokens),
 }
 
@@ -106,6 +110,7 @@ impl PartialEq for ChaosAuth {
 }
 
 pub const REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR: &str = "CHAOS_REFRESH_TOKEN_URL_OVERRIDE";
+pub const XAI_REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR: &str = "CHAOS_XAI_REFRESH_TOKEN_URL_OVERRIDE";
 
 #[derive(Debug, Error)]
 pub enum RefreshTokenError {
@@ -191,6 +196,10 @@ impl ChaosAuth {
                 let storage = create_auth_storage(chaos_home.to_path_buf(), storage_mode);
                 Ok(Self::Chatgpt(ChatgptAuth { state, storage }))
             }
+            ApiAuthMode::Xai => {
+                let storage = create_auth_storage(chaos_home.to_path_buf(), storage_mode);
+                Ok(Self::Xai(ChatgptAuth { state, storage }))
+            }
             ApiAuthMode::ChatgptAuthTokens => {
                 Ok(Self::ChatgptAuthTokens(ChatgptAuthTokens { state }))
             }
@@ -214,6 +223,7 @@ impl ChaosAuth {
         match self {
             Self::ApiKey(_) => AuthMode::ApiKey,
             Self::Chatgpt(_) | Self::ChatgptAuthTokens(_) => AuthMode::Chatgpt,
+            Self::Xai(_) => AuthMode::Xai,
         }
     }
 
@@ -221,6 +231,7 @@ impl ChaosAuth {
         match self {
             Self::ApiKey(_) => ApiAuthMode::ApiKey,
             Self::Chatgpt(_) => ApiAuthMode::Chatgpt,
+            Self::Xai(_) => ApiAuthMode::Xai,
             Self::ChatgptAuthTokens(_) => ApiAuthMode::ChatgptAuthTokens,
         }
     }
@@ -233,6 +244,14 @@ impl ChaosAuth {
         self.auth_mode() == AuthMode::Chatgpt
     }
 
+    pub fn is_managed_oauth_auth(&self) -> bool {
+        matches!(self, Self::Chatgpt(_) | Self::Xai(_))
+    }
+
+    fn supports_unauthorized_recovery(&self) -> bool {
+        self.is_managed_oauth_auth() || self.is_external_chatgpt_tokens()
+    }
+
     pub fn is_external_chatgpt_tokens(&self) -> bool {
         matches!(self, Self::ChatgptAuthTokens(_))
     }
@@ -241,7 +260,7 @@ impl ChaosAuth {
     pub fn api_key(&self) -> Option<&str> {
         match self {
             Self::ApiKey(auth) => Some(auth.api_key.as_str()),
-            Self::Chatgpt(_) | Self::ChatgptAuthTokens(_) => None,
+            Self::Chatgpt(_) | Self::Xai(_) | Self::ChatgptAuthTokens(_) => None,
         }
     }
 
@@ -255,7 +274,7 @@ impl ChaosAuth {
     pub fn get_token(&self) -> Result<String, std::io::Error> {
         match self {
             Self::ApiKey(auth) => Ok(auth.api_key.clone()),
-            Self::Chatgpt(_) | Self::ChatgptAuthTokens(_) => {
+            Self::Chatgpt(_) | Self::Xai(_) | Self::ChatgptAuthTokens(_) => {
                 let access_token = self.get_token_data()?.access_token;
                 Ok(access_token)
             }
@@ -306,6 +325,7 @@ impl ChaosAuth {
     pub(crate) fn get_current_auth_json(&self) -> Option<AuthDotJson> {
         let state = match self {
             Self::Chatgpt(auth) => &auth.state,
+            Self::Xai(auth) => &auth.state,
             Self::ChatgptAuthTokens(auth) => &auth.state,
             Self::ApiKey(_) => return None,
         };
@@ -317,6 +337,7 @@ impl ChaosAuth {
     fn get_current_token_data(&self) -> Option<TokenData> {
         let provider_id = match self {
             Self::Chatgpt(auth) => auth.state.provider_id.as_str(),
+            Self::Xai(auth) => auth.state.provider_id.as_str(),
             Self::ChatgptAuthTokens(auth) => auth.state.provider_id.as_str(),
             Self::ApiKey(_) => return None,
         };
@@ -378,6 +399,7 @@ impl ChaosAuth {
         match self {
             Self::ApiKey(auth) => auth.provider_id.as_str(),
             Self::Chatgpt(auth) => auth.state.provider_id.as_str(),
+            Self::Xai(auth) => auth.state.provider_id.as_str(),
             Self::ChatgptAuthTokens(auth) => auth.state.provider_id.as_str(),
         }
     }

--- a/sys/kern/kern/src/auth/permissions.rs
+++ b/sys/kern/kern/src/auth/permissions.rs
@@ -10,7 +10,9 @@ use crate::auth::logout;
 use crate::auth::storage::AuthDotJson;
 use crate::auth::storage::ProviderAuthRecord;
 use crate::config::Config;
+use crate::model_provider_info::XAI_PROVIDER_ID;
 use chaos_ipc::config_types::ForcedLoginMethod;
+use jiff::Timestamp;
 
 /// Enforce login method and workspace restrictions from the current config.
 ///
@@ -30,11 +32,11 @@ pub fn enforce_login_restrictions(config: &Config) -> std::io::Result<()> {
         let method_violation = match (required_method, auth.auth_mode()) {
             (ForcedLoginMethod::Api, AuthMode::ApiKey) => None,
             (ForcedLoginMethod::Chatgpt, AuthMode::Chatgpt) => None,
-            (ForcedLoginMethod::Api, AuthMode::Chatgpt) => Some(
+            (ForcedLoginMethod::Api, AuthMode::Chatgpt | AuthMode::Xai) => Some(
                 "API key login is required, but ChatGPT is currently being used. Logging out."
                     .to_string(),
             ),
-            (ForcedLoginMethod::Chatgpt, AuthMode::ApiKey) => Some(
+            (ForcedLoginMethod::Chatgpt, AuthMode::ApiKey | AuthMode::Xai) => Some(
                 "ChatGPT login is required, but an API key is currently being used. Logging out."
                     .to_string(),
             ),
@@ -203,6 +205,46 @@ pub fn login_with_provider_api_key(
             api_key: Some(api_key.to_string()),
             tokens: None,
             last_refresh: None,
+        },
+    );
+    super::save_auth(chaos_home, &auth_dot_json, auth_credentials_store_mode)
+}
+
+/// Writes or updates the xAI OAuth record inside `auth.json`.
+pub fn login_with_xai_oauth_tokens(
+    chaos_home: &Path,
+    id_token: Option<&str>,
+    access_token: &str,
+    refresh_token: &str,
+    auth_credentials_store_mode: AuthCredentialsStoreMode,
+) -> std::io::Result<()> {
+    use chaos_ipc::api::AuthMode as ApiAuthMode;
+
+    // xAI normally returns an ID token for the requested `openid` scope, but
+    // the field is optional in the token response. Its access token is also a
+    // JWT, so retain provider identity and status metadata if the ID token is
+    // omitted rather than rejecting an otherwise valid login.
+    let identity_token = id_token.unwrap_or(access_token);
+    let account_id =
+        crate::token_data::parse_jwt_subject(identity_token).map_err(std::io::Error::other)?;
+    let id_token = crate::token_data::parse_chatgpt_jwt_claims(identity_token)
+        .map_err(std::io::Error::other)?;
+    let mut auth_dot_json = super::load_auth_dot_json(chaos_home, auth_credentials_store_mode)?
+        .unwrap_or(AuthDotJson {
+            providers: Default::default(),
+        });
+    auth_dot_json.set_provider_record(
+        XAI_PROVIDER_ID,
+        ProviderAuthRecord {
+            auth_mode: Some(ApiAuthMode::Xai),
+            api_key: None,
+            tokens: Some(crate::token_data::TokenData {
+                id_token,
+                access_token: access_token.to_string(),
+                refresh_token: refresh_token.to_string(),
+                account_id,
+            }),
+            last_refresh: Some(Timestamp::now()),
         },
     );
     super::save_auth(chaos_home, &auth_dot_json, auth_credentials_store_mode)

--- a/sys/kern/kern/src/auth/policies.rs
+++ b/sys/kern/kern/src/auth/policies.rs
@@ -16,7 +16,7 @@ const REFRESH_TOKEN_ACCOUNT_MISMATCH_MESSAGE: &str = "Your access token could no
 
 // UnauthorizedRecovery is a state machine that handles 401 recovery.
 //
-// Managed mode (ChatGPT auth):
+// Managed mode (ChatGPT or xAI auth):
 //   Reload → RefreshToken → Done
 // External mode (external ChatGPT auth tokens):
 //   ExternalRefresh → Done
@@ -98,7 +98,7 @@ impl UnauthorizedRecovery {
             .manager
             .auth_cached()
             .as_ref()
-            .is_some_and(ChaosAuth::is_chatgpt_auth)
+            .is_some_and(ChaosAuth::supports_unauthorized_recovery)
         {
             return false;
         }
@@ -119,9 +119,9 @@ impl UnauthorizedRecovery {
             .manager
             .auth_cached()
             .as_ref()
-            .is_some_and(ChaosAuth::is_chatgpt_auth)
+            .is_some_and(ChaosAuth::supports_unauthorized_recovery)
         {
-            return "not_chatgpt_auth";
+            return "unsupported_auth";
         }
 
         if let RecoveryMachine::External(_) = &self.machine

--- a/sys/kern/kern/src/auth/tokens.rs
+++ b/sys/kern/kern/src/auth/tokens.rs
@@ -1,7 +1,7 @@
 //! Token storage, rotation, and validation logic.
 //!
 //! This module owns the `AuthManager` type and the low-level helpers for
-//! persisting and refreshing ChatGPT OAuth tokens.
+//! persisting and refreshing managed provider OAuth tokens.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -25,6 +25,7 @@ use crate::error::RefreshTokenFailedReason;
 use crate::token_data::TokenData;
 use crate::token_data::parse_chatgpt_jwt_claims;
 use crate::util::try_parse_error_message;
+use base64::Engine;
 use codex_client::ChaosHttpClient;
 use jiff::Timestamp;
 use rama::http::StatusCode;
@@ -40,10 +41,25 @@ const REFRESH_TOKEN_UNKNOWN_MESSAGE: &str =
     "Your access token could not be refreshed. Please log out and sign in again.";
 const REFRESH_TOKEN_ACCOUNT_MISMATCH_MESSAGE: &str = "Your access token could not be refreshed because you have since logged out or signed in to another account. Please sign in again.";
 const REFRESH_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+const XAI_REFRESH_TOKEN_URL: &str = "https://auth.x.ai/oauth2/token";
+const XAI_CLIENT_ID: &str = "b1a00492-073a-47ea-816f-4c329264a828";
+const XAI_REFRESH_SKEW_SECONDS: i64 = 60;
+const XAI_OPAQUE_TOKEN_REFRESH_INTERVAL_MINUTES: i64 = 5;
 pub(super) use super::REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR;
+pub(super) use super::XAI_REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR;
 
 // Shared constant for token refresh (client id used for oauth token refresh flow)
 pub const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+
+fn jwt_expiration(token: &str) -> Option<Timestamp> {
+    let payload = token.split('.').nth(1)?;
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()?;
+    let claims = serde_json::from_slice::<serde_json::Value>(&payload).ok()?;
+    let expires_at = claims.get("exp")?.as_i64()?;
+    Timestamp::from_second(expires_at).ok()
+}
 
 #[derive(Serialize)]
 pub(super) struct RefreshRequest {
@@ -57,6 +73,13 @@ pub(super) struct RefreshResponse {
     pub(super) id_token: Option<String>,
     pub(super) access_token: Option<String>,
     pub(super) refresh_token: Option<String>,
+}
+
+#[derive(Serialize)]
+struct XaiRefreshRequest {
+    client_id: &'static str,
+    grant_type: &'static str,
+    refresh_token: String,
 }
 
 pub(super) fn refresh_token_endpoint() -> String {
@@ -136,6 +159,60 @@ pub(super) async fn request_chatgpt_token_refresh(
             )))
         }
     }
+}
+
+async fn request_xai_token_refresh(
+    refresh_token: String,
+    client: &ChaosHttpClient,
+) -> Result<RefreshResponse, RefreshTokenError> {
+    let request = XaiRefreshRequest {
+        client_id: XAI_CLIENT_ID,
+        grant_type: "refresh_token",
+        refresh_token,
+    };
+    let body = url::form_urlencoded::Serializer::new(String::new())
+        .extend_pairs([
+            ("client_id", request.client_id),
+            ("grant_type", request.grant_type),
+            ("refresh_token", request.refresh_token.as_str()),
+        ])
+        .finish();
+    let endpoint = std::env::var(XAI_REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR)
+        .unwrap_or_else(|_| XAI_REFRESH_TOKEN_URL.to_string());
+    let response = client
+        .post(&endpoint)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .header("Accept", "application/json")
+        .body(body)
+        .send()
+        .await
+        .map_err(|err| RefreshTokenError::Transient(std::io::Error::other(err)))?;
+    let status = response.status();
+    if status.is_success() {
+        return response
+            .json::<RefreshResponse>()
+            .await
+            .map_err(|err| RefreshTokenError::Transient(std::io::Error::other(err)));
+    }
+
+    let body = response.text().await.unwrap_or_default();
+    let message = try_parse_error_message(&body);
+    let error_code = serde_json::from_str::<serde_json::Value>(&body)
+        .ok()
+        .and_then(|value| value.get("error")?.as_str().map(str::to_owned));
+    if matches!(
+        error_code.as_deref(),
+        Some("invalid_grant" | "invalid_client")
+    ) || matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN)
+    {
+        return Err(RefreshTokenError::Permanent(RefreshTokenFailedError::new(
+            RefreshTokenFailedReason::Other,
+            format!("Your xAI connection could not be refreshed: {message}. Please sign in again."),
+        )));
+    }
+    Err(RefreshTokenError::Transient(std::io::Error::other(
+        format!("Failed to refresh xAI token: {status}: {message}"),
+    )))
 }
 
 pub(super) fn classify_refresh_token_failure(body: &str) -> RefreshTokenFailedError {
@@ -239,12 +316,13 @@ pub(super) enum ReloadOutcome {
 #[derive(Debug)]
 pub struct AuthManager {
     pub(super) chaos_home: PathBuf,
+    pub(super) provider_id: String,
     pub(super) inner: RwLock<CachedAuth>,
     pub(super) enable_codex_api_key_env: bool,
     pub(super) auth_credentials_store_mode: AuthCredentialsStoreMode,
     pub(super) forced_chatgpt_workspace_id: RwLock<Option<String>>,
     /// Single-flights `refresh_token_from_authority`.
-    pub(super) refresh_lock: tokio::sync::Mutex<()>,
+    pub(super) refresh_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl AuthManager {
@@ -266,6 +344,7 @@ impl AuthManager {
         .flatten();
         Self {
             chaos_home,
+            provider_id: DEFAULT_AUTH_PROVIDER_ID.to_string(),
             inner: RwLock::new(CachedAuth {
                 auth: managed_auth,
                 external_refresher: None,
@@ -273,12 +352,13 @@ impl AuthManager {
             enable_codex_api_key_env,
             auth_credentials_store_mode,
             forced_chatgpt_workspace_id: RwLock::new(None),
-            refresh_lock: tokio::sync::Mutex::new(()),
+            refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 
     /// Create an AuthManager with a specific ChaosAuth, for testing only.
     pub(crate) fn from_auth_for_testing(auth: ChaosAuth) -> Arc<Self> {
+        let provider_id = auth.provider_id().to_string();
         let cached = CachedAuth {
             auth: Some(auth),
             external_refresher: None,
@@ -286,11 +366,12 @@ impl AuthManager {
 
         Arc::new(Self {
             chaos_home: PathBuf::from("non-existent"),
+            provider_id,
             inner: RwLock::new(cached),
             enable_codex_api_key_env: false,
             auth_credentials_store_mode: AuthCredentialsStoreMode::File,
             forced_chatgpt_workspace_id: RwLock::new(None),
-            refresh_lock: tokio::sync::Mutex::new(()),
+            refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
         })
     }
 
@@ -299,17 +380,19 @@ impl AuthManager {
         auth: ChaosAuth,
         chaos_home: PathBuf,
     ) -> Arc<Self> {
+        let provider_id = auth.provider_id().to_string();
         let cached = CachedAuth {
             auth: Some(auth),
             external_refresher: None,
         };
         Arc::new(Self {
             chaos_home,
+            provider_id,
             inner: RwLock::new(cached),
             enable_codex_api_key_env: false,
             auth_credentials_store_mode: AuthCredentialsStoreMode::File,
             forced_chatgpt_workspace_id: RwLock::new(None),
-            refresh_lock: tokio::sync::Mutex::new(()),
+            refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
         })
     }
 
@@ -319,7 +402,7 @@ impl AuthManager {
     }
 
     /// Current cached auth (clone). May be `None` if not logged in or load failed.
-    /// Refreshes cached ChatGPT tokens if they are stale before returning.
+    /// Refreshes cached managed OAuth tokens if they are stale before returning.
     pub async fn auth(&self) -> Option<ChaosAuth> {
         let auth = self.auth_cached()?;
         if let Err(err) = self.refresh_if_stale(&auth).await {
@@ -379,6 +462,7 @@ impl AuthManager {
             (Some(a), Some(b)) => match (a.api_auth_mode(), b.api_auth_mode()) {
                 (ApiAuthMode::ApiKey, ApiAuthMode::ApiKey) => a.api_key() == b.api_key(),
                 (ApiAuthMode::Chatgpt, ApiAuthMode::Chatgpt)
+                | (ApiAuthMode::Xai, ApiAuthMode::Xai)
                 | (ApiAuthMode::ChatgptAuthTokens, ApiAuthMode::ChatgptAuthTokens) => {
                     a.get_current_auth_json() == b.get_current_auth_json()
                 }
@@ -397,17 +481,28 @@ impl AuthManager {
     }
 
     fn load_auth_from_storage(&self) -> Option<ChaosAuth> {
-        load_auth(
-            &self.chaos_home,
-            self.enable_codex_api_key_env,
-            self.auth_credentials_store_mode,
-        )
-        .ok()
-        .flatten()
+        if self.provider_id == DEFAULT_AUTH_PROVIDER_ID {
+            load_auth(
+                &self.chaos_home,
+                self.enable_codex_api_key_env,
+                self.auth_credentials_store_mode,
+            )
+            .ok()
+            .flatten()
+        } else {
+            load_auth_for_provider(
+                &self.chaos_home,
+                &self.provider_id,
+                /*enable_codex_api_key_env*/ false,
+                self.auth_credentials_store_mode,
+            )
+            .ok()
+            .flatten()
+        }
     }
 
     pub fn auth_for_provider(&self, provider_id: &str) -> Option<ChaosAuth> {
-        if provider_id == DEFAULT_AUTH_PROVIDER_ID {
+        if provider_id == self.provider_id {
             return self.auth_cached();
         }
 
@@ -419,6 +514,41 @@ impl AuthManager {
         )
         .ok()
         .flatten()
+    }
+
+    /// Resolve provider-scoped auth and refresh managed OAuth credentials when stale.
+    pub async fn fresh_auth_for_provider(self: &Arc<Self>, provider_id: &str) -> Option<ChaosAuth> {
+        if provider_id == self.provider_id {
+            return self.auth().await;
+        }
+        self.for_provider(provider_id).auth().await
+    }
+
+    /// Create a provider-scoped manager sharing this manager's credential store settings.
+    pub fn for_provider(self: &Arc<Self>, provider_id: &str) -> Arc<Self> {
+        if provider_id == self.provider_id {
+            return Arc::clone(self);
+        }
+        let managed_auth = load_auth_for_provider(
+            &self.chaos_home,
+            provider_id,
+            /*enable_codex_api_key_env*/ false,
+            self.auth_credentials_store_mode,
+        )
+        .ok()
+        .flatten();
+        Arc::new(Self {
+            chaos_home: self.chaos_home.clone(),
+            provider_id: provider_id.to_string(),
+            inner: RwLock::new(CachedAuth {
+                auth: managed_auth,
+                external_refresher: None,
+            }),
+            enable_codex_api_key_env: false,
+            auth_credentials_store_mode: self.auth_credentials_store_mode,
+            forced_chatgpt_workspace_id: RwLock::new(None),
+            refresh_lock: Arc::clone(&self.refresh_lock),
+        })
     }
 
     fn set_cached_auth(&self, new_auth: Option<ChaosAuth>) -> bool {
@@ -548,6 +678,16 @@ impl AuthManager {
                     .await?;
                 Ok(())
             }
+            ChaosAuth::Xai(xai_auth) => {
+                let token_data = xai_auth.current_token_data().ok_or_else(|| {
+                    RefreshTokenError::Transient(std::io::Error::other(
+                        "Token data is not available.",
+                    ))
+                })?;
+                self.refresh_and_persist_xai_token(&xai_auth, token_data.refresh_token)
+                    .await?;
+                Ok(())
+            }
             ChaosAuth::ApiKey(_) => unreachable!("returned above"),
         }
     }
@@ -574,16 +714,16 @@ impl AuthManager {
     ) -> Result<bool, RefreshTokenError> {
         use jiff::ToSpan;
 
-        let chatgpt_auth = match auth {
-            ChaosAuth::Chatgpt(chatgpt_auth) => chatgpt_auth,
+        let managed_auth = match auth {
+            ChaosAuth::Chatgpt(auth) | ChaosAuth::Xai(auth) => auth,
             _ => return Ok(false),
         };
 
-        let auth_dot_json = match chatgpt_auth.current_auth_json() {
+        let auth_dot_json = match managed_auth.current_auth_json() {
             Some(auth_dot_json) => auth_dot_json,
             None => return Ok(false),
         };
-        let Some(record) = auth_dot_json.provider_record(chatgpt_auth.provider_id()) else {
+        let Some(record) = auth_dot_json.provider_record(managed_auth.provider_id()) else {
             return Ok(false);
         };
         let tokens = match record.tokens {
@@ -595,14 +735,28 @@ impl AuthManager {
             None => return Ok(false),
         };
 
-        const TOKEN_REFRESH_INTERVAL: i64 = 8;
-        if last_refresh
-            >= Timestamp::now()
-                .checked_sub(TOKEN_REFRESH_INTERVAL.saturating_mul(24).hours())
-                .unwrap_or(Timestamp::now())
-        {
+        let now = Timestamp::now();
+        let should_refresh = match auth {
+            ChaosAuth::Xai(_) => {
+                let refresh_deadline = now
+                    .checked_add(XAI_REFRESH_SKEW_SECONDS.seconds())
+                    .unwrap_or(now);
+                jwt_expiration(&tokens.access_token).map_or_else(
+                    || {
+                        last_refresh
+                            < now
+                                .checked_sub(XAI_OPAQUE_TOKEN_REFRESH_INTERVAL_MINUTES.minutes())
+                                .unwrap_or(now)
+                    },
+                    |expires_at| expires_at <= refresh_deadline,
+                )
+            }
+            _ => last_refresh < now.checked_sub((8 * 24).hours()).unwrap_or(now),
+        };
+        if !should_refresh {
             return Ok(false);
         }
+        let _guard = self.refresh_lock.lock().await;
         let expected_account_id = tokens.account_id.clone();
         let refresh_token = tokens.refresh_token;
         if let Some(expected_account_id) = expected_account_id.as_deref() {
@@ -623,8 +777,17 @@ impl AuthManager {
             }
         }
 
-        self.refresh_and_persist_chatgpt_token(chatgpt_auth, refresh_token)
-            .await?;
+        match auth {
+            ChaosAuth::Chatgpt(_) => {
+                self.refresh_and_persist_chatgpt_token(managed_auth, refresh_token)
+                    .await?;
+            }
+            ChaosAuth::Xai(_) => {
+                self.refresh_and_persist_xai_token(managed_auth, refresh_token)
+                    .await?;
+            }
+            _ => unreachable!("managed auth was matched above"),
+        }
         Ok(true)
     }
 
@@ -714,6 +877,24 @@ impl AuthManager {
         .map_err(RefreshTokenError::from)?;
         self.reload();
 
+        Ok(())
+    }
+
+    async fn refresh_and_persist_xai_token(
+        &self,
+        auth: &ChatgptAuth,
+        refresh_token: String,
+    ) -> Result<(), RefreshTokenError> {
+        let refresh_response = request_xai_token_refresh(refresh_token, auth.client()).await?;
+        persist_tokens(
+            auth.storage(),
+            auth.provider_id(),
+            refresh_response.id_token,
+            refresh_response.access_token,
+            refresh_response.refresh_token,
+        )
+        .map_err(RefreshTokenError::from)?;
+        self.reload();
         Ok(())
     }
 }

--- a/sys/kern/kern/src/auth_tests.rs
+++ b/sys/kern/kern/src/auth_tests.rs
@@ -4,6 +4,7 @@ use crate::config::ConfigBuilder;
 use crate::test_support::EnvVarGuard;
 use crate::token_data::KnownPlan as InternalKnownPlan;
 use crate::token_data::PlanType as InternalPlanType;
+use base64::Engine;
 use chaos_ipc::account::PlanType as AccountPlanType;
 
 use chaos_ipc::config_types::ForcedLoginMethod;
@@ -18,6 +19,55 @@ mod auth_test_fixtures;
 use auth_test_fixtures::build_fake_jwt;
 use auth_test_fixtures::openai_auth;
 use auth_test_fixtures::parse_id_token;
+
+fn access_token_with_expiration(expiration: i64) -> String {
+    let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"alg":"none"}"#);
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(serde_json::json!({ "exp": expiration }).to_string());
+    format!("{header}.{payload}.signature")
+}
+
+#[test]
+fn unauthorized_recovery_supports_external_chatgpt_and_managed_xai_auth() {
+    let chaos_home = tempdir().unwrap();
+    let external_access_token = build_fake_jwt(None, None);
+    login_with_chatgpt_auth_tokens(
+        chaos_home.path(),
+        &external_access_token,
+        "workspace-123",
+        Some("pro"),
+    )
+    .expect("external ChatGPT auth should persist");
+    let external = load_auth(
+        chaos_home.path(),
+        false,
+        AuthCredentialsStoreMode::Ephemeral,
+    )
+    .expect("external ChatGPT auth should load")
+    .expect("external ChatGPT auth should exist");
+    assert!(external.supports_unauthorized_recovery());
+
+    let xai_home = tempdir().unwrap();
+    login_with_xai_oauth_tokens(
+        xai_home.path(),
+        Some(&build_fake_jwt(None, None)),
+        "xai-access",
+        "xai-refresh",
+        AuthCredentialsStoreMode::File,
+    )
+    .expect("xAI auth should persist");
+    let xai = load_auth_for_provider(
+        xai_home.path(),
+        "xai",
+        false,
+        AuthCredentialsStoreMode::File,
+    )
+    .expect("xAI auth should load")
+    .expect("xAI auth should exist");
+    assert!(xai.supports_unauthorized_recovery());
+
+    assert!(!ChaosAuth::from_api_key("api-key").supports_unauthorized_recovery());
+}
 
 #[tokio::test]
 async fn refresh_without_id_token() {
@@ -113,6 +163,64 @@ async fn concurrent_refresh_single_flights_to_one_request() {
     );
     first.expect("first refresh should succeed");
     second.expect("second refresh should succeed");
+
+    server.verify().await;
+}
+
+#[tokio::test]
+#[serial(xai_refresh_token_url_override)]
+async fn provider_scoped_xai_auth_refreshes_and_preserves_identity() {
+    core_test_support::skip_if_no_network!();
+
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::body_string_contains;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    let chaos_home = tempdir().unwrap();
+    let identity_token = build_fake_jwt(None, None);
+    login_with_xai_oauth_tokens(
+        chaos_home.path(),
+        Some(&identity_token),
+        &access_token_with_expiration(0),
+        "initial-xai-refresh",
+        AuthCredentialsStoreMode::File,
+    )
+    .expect("xAI login should persist");
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth2/token"))
+        .and(body_string_contains("grant_type=refresh_token"))
+        .and(body_string_contains("refresh_token=initial-xai-refresh"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "refreshed-xai-access",
+            "refresh_token": "refreshed-xai-refresh"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let _guard = EnvVarGuard::set(
+        crate::auth::XAI_REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR,
+        format!("{}/oauth2/token", server.uri()),
+    );
+
+    let manager = AuthManager::shared(
+        chaos_home.path().to_path_buf(),
+        false,
+        AuthCredentialsStoreMode::File,
+    );
+    let auth = manager
+        .fresh_auth_for_provider("xai")
+        .await
+        .expect("xAI auth should load");
+    assert_eq!(auth.auth_mode(), AuthMode::Xai);
+    let tokens = auth.get_token_data().expect("xAI tokens should exist");
+    assert_eq!(tokens.id_token.raw_jwt, identity_token);
+    assert_eq!(tokens.access_token, "refreshed-xai-access");
+    assert_eq!(tokens.refresh_token, "refreshed-xai-refresh");
 
     server.verify().await;
 }

--- a/sys/kern/kern/src/client.rs
+++ b/sys/kern/kern/src/client.rs
@@ -176,6 +176,7 @@ impl AuthRequestTelemetryContext {
             auth_mode: auth_mode.map(|mode| match mode {
                 AuthMode::ApiKey => "ApiKey",
                 AuthMode::Chatgpt => "Chatgpt",
+                AuthMode::Xai => "Xai",
             }),
             auth_header_attached: api_auth.auth_header_attached(),
             auth_header_name: api_auth.auth_header_name(),

--- a/sys/kern/kern/src/client/state.rs
+++ b/sys/kern/kern/src/client/state.rs
@@ -353,7 +353,11 @@ impl ModelClient {
                 {
                     manager.auth().await
                 }
-                Some(manager) => manager.auth_for_provider(&self.state.provider_id),
+                Some(manager) => {
+                    manager
+                        .fresh_auth_for_provider(&self.state.provider_id)
+                        .await
+                }
                 None => None,
             }
         };

--- a/sys/kern/kern/src/client/streaming.rs
+++ b/sys/kern/kern/src/client/streaming.rs
@@ -519,7 +519,8 @@ impl ModelClientSession {
         let auth_manager = self.client.state.auth_manager.clone();
         let mut auth_recovery = auth_manager
             .as_ref()
-            .map(crate::auth::AuthManager::unauthorized_recovery);
+            .map(|manager| manager.for_provider(&self.client.state.provider_id))
+            .map(|manager| manager.unauthorized_recovery());
         let mut pending_retry = PendingUnauthorizedRetry::default();
         loop {
             let client_setup = self.client.current_client_setup().await?;

--- a/sys/kern/kern/src/model_provider_info.rs
+++ b/sys/kern/kern/src/model_provider_info.rs
@@ -24,6 +24,9 @@ use std::time::Duration;
 const DEFAULT_STREAM_IDLE_TIMEOUT_MS: u64 = 300_000;
 const DEFAULT_STREAM_MAX_RETRIES: u64 = 5;
 const DEFAULT_REQUEST_MAX_RETRIES: u64 = 4;
+const XAI_TOKEN_AUTH_HEADER: &str = "x-xai-token-auth";
+const XAI_TOKEN_AUTH_VALUE: &str = "xai-grok-cli";
+const XAI_ACCOUNT_DEFAULT_BASE_URL: &str = "https://cli-chat-proxy.grok.com/v1";
 /// Hard cap for user-configured `stream_max_retries`.
 const MAX_STREAM_MAX_RETRIES: u64 = 100;
 /// Hard cap for user-configured `request_max_retries`.
@@ -33,6 +36,8 @@ const OPENAI_PROVIDER_NAME: &str = "OpenAI";
 pub const OPENAI_PROVIDER_ID: &str = "openai";
 pub const OPENAI_DEFAULT_BASE_URL: &str = chaos_services::openai::OPENAI_API_BASE;
 const CHATGPT_DEFAULT_BASE_URL: &str = chaos_services::openai::CHATGPT_BACKEND_BASE;
+
+pub const XAI_PROVIDER_ID: &str = "xai";
 
 const ANTHROPIC_PROVIDER_NAME: &str = "Anthropic";
 pub const ANTHROPIC_PROVIDER_ID: &str = "anthropic";
@@ -92,6 +97,7 @@ impl<'de> Deserialize<'de> for WireApi {
 pub enum ProviderAuthMethod {
     ApiKey,
     ChatgptAccount,
+    XaiAccount,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -204,6 +210,10 @@ pub struct ModelProviderInfo {
 
 impl ModelProviderInfo {
     pub(crate) fn effective_base_url(&self, auth_mode: Option<AuthMode>) -> String {
+        if self.supports_xai_account_auth() && matches!(auth_mode, Some(AuthMode::Xai)) {
+            return XAI_ACCOUNT_DEFAULT_BASE_URL.to_string();
+        }
+
         // Only route to the ChatGPT backend when the provider actually uses
         // OpenAI auth.  Self-authenticated providers (env_key, bearer token)
         // must never be redirected to chatgpt.com.
@@ -253,7 +263,13 @@ impl ModelProviderInfo {
         &self,
         auth_mode: Option<AuthMode>,
     ) -> crate::error::Result<ApiProvider> {
-        let headers = self.build_header_map()?;
+        let mut headers = self.build_header_map()?;
+        if self.supports_xai_account_auth() && matches!(auth_mode, Some(AuthMode::Xai)) {
+            headers.insert(
+                HeaderName::from_static(XAI_TOKEN_AUTH_HEADER),
+                HeaderValue::from_static(XAI_TOKEN_AUTH_VALUE),
+            );
+        }
         let retry = ApiRetryConfig {
             max_attempts: self.request_max_retries(),
             base_delay: Duration::from_millis(200),
@@ -338,12 +354,20 @@ impl ModelProviderInfo {
         self.supports_auth_method(ProviderAuthMethod::ChatgptAccount)
     }
 
+    pub fn supports_xai_account_auth(&self) -> bool {
+        self.supports_auth_method(ProviderAuthMethod::XaiAccount)
+    }
+
+    pub fn supports_account_auth(&self) -> bool {
+        self.supports_chatgpt_account_auth() || self.supports_xai_account_auth()
+    }
+
     pub fn supports_api_key_auth(&self) -> bool {
         self.supports_auth_method(ProviderAuthMethod::ApiKey)
     }
 
     pub fn requires_managed_auth(&self) -> bool {
-        self.supports_chatgpt_account_auth() || self.supports_api_key_auth()
+        self.supports_account_auth() || self.supports_api_key_auth()
     }
 
     pub fn create_anthropic_provider() -> ModelProviderInfo {

--- a/sys/kern/kern/src/model_provider_info_tests.rs
+++ b/sys/kern/kern/src/model_provider_info_tests.rs
@@ -101,3 +101,31 @@ env_http_headers = { "X-Example-Env-Header" = "EXAMPLE_ENV_VAR" }
     let provider: ModelProviderInfo = toml::from_str(azure_provider_toml).unwrap();
     assert_eq!(expected_provider, provider);
 }
+
+#[test]
+fn xai_subscription_auth_adds_cli_token_header_only_for_oauth() {
+    let provider = built_in_model_providers()
+        .remove("xai")
+        .expect("xAI provider should be built in");
+
+    let oauth = provider
+        .to_api_provider(Some(AuthMode::Xai))
+        .expect("xAI OAuth provider should build");
+    assert_eq!(
+        oauth.base_url, "https://cli-chat-proxy.grok.com/v1",
+        "subscription auth must use xAI's CLI proxy rather than the API-key endpoint"
+    );
+    assert_eq!(
+        oauth
+            .headers
+            .get(XAI_TOKEN_AUTH_HEADER)
+            .and_then(|value| value.to_str().ok()),
+        Some(XAI_TOKEN_AUTH_VALUE)
+    );
+
+    let api_key = provider
+        .to_api_provider(Some(AuthMode::ApiKey))
+        .expect("xAI API-key provider should build");
+    assert_eq!(api_key.base_url, "https://api.x.ai/v1");
+    assert!(api_key.headers.get(XAI_TOKEN_AUTH_HEADER).is_none());
+}

--- a/sys/kern/kern/src/token_data.rs
+++ b/sys/kern/kern/src/token_data.rs
@@ -159,6 +159,23 @@ pub fn parse_chatgpt_jwt_claims(jwt: &str) -> Result<IdTokenInfo, IdTokenInfoErr
     }
 }
 
+pub(crate) fn parse_jwt_subject(jwt: &str) -> Result<Option<String>, IdTokenInfoError> {
+    #[derive(Deserialize)]
+    struct SubjectClaim {
+        #[serde(default)]
+        sub: Option<String>,
+    }
+
+    let mut parts = jwt.split('.');
+    let (_header_b64, payload_b64, _sig_b64) = match (parts.next(), parts.next(), parts.next()) {
+        (Some(h), Some(p), Some(s)) if !h.is_empty() && !p.is_empty() && !s.is_empty() => (h, p, s),
+        _ => return Err(IdTokenInfoError::InvalidFormat),
+    };
+    let payload_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload_b64)?;
+    let claims: SubjectClaim = serde_json::from_slice(&payload_bytes)?;
+    Ok(claims.sub)
+}
+
 fn deserialize_id_token<'de, D>(deserializer: D) -> Result<IdTokenInfo, D::Error>
 where
     D: serde::Deserializer<'de>,

--- a/sys/kern/providers/parrot/src/openai.rs
+++ b/sys/kern/providers/parrot/src/openai.rs
@@ -21,6 +21,12 @@ use crate::ResponsesOptions;
 use crate::SseTelemetry;
 use crate::requests::responses::Compression;
 
+const GROK_SUBSCRIPTION_PROXY_HOST: &str = "cli-chat-proxy.grok.com";
+const GROK_CLIENT_VERSION_HEADER: &str = "x-grok-client-version";
+const GROK_MODEL_OVERRIDE_HEADER: &str = "x-grok-model-override";
+const XAI_TOKEN_AUTH_HEADER: &str = "x-xai-token-auth";
+const XAI_TOKEN_AUTH_VALUE: &str = "xai-grok-cli";
+
 #[derive(Clone, Default)]
 pub struct StaticAuthProvider {
     token: Option<String>,
@@ -148,7 +154,12 @@ where
                 request.model = default_model.clone();
             }
 
-            let options = responses_options_from_turn_request(&request, self.options.clone());
+            let mut options = responses_options_from_turn_request(&request, self.options.clone());
+            insert_grok_subscription_headers(
+                &self.discovery_base_url,
+                &request.model,
+                &mut options.extra_headers,
+            );
             let api_request = crate::adapter::turn_request_to_api_request(
                 request,
                 self.representer.as_representer(),
@@ -233,6 +244,23 @@ fn parse_compression(value: Option<&Value>) -> Compression {
     }
 }
 
+fn is_grok_subscription_proxy(base_url: &str) -> bool {
+    url::Url::parse(base_url).is_ok_and(|url| url.host_str() == Some(GROK_SUBSCRIPTION_PROXY_HOST))
+}
+
+fn insert_grok_subscription_headers(base_url: &str, model: &str, headers: &mut HeaderMap) {
+    if !is_grok_subscription_proxy(base_url) {
+        return;
+    }
+    headers.insert(
+        HeaderName::from_static(GROK_CLIENT_VERSION_HEADER),
+        HeaderValue::from_static(env!("CARGO_PKG_VERSION")),
+    );
+    if let Ok(model) = HeaderValue::from_str(model) {
+        headers.insert(HeaderName::from_static(GROK_MODEL_OVERRIDE_HEADER), model);
+    }
+}
+
 // ── Model discovery ────────────────────────────────────────────────────────
 
 /// Detect native server-side tools a provider supports based on its base URL.
@@ -308,6 +336,11 @@ async fn fetch_openai_models(
     if let Some(token) = token {
         let bearer = format!("Bearer {token}");
         builder = builder.header(rama::http::header::AUTHORIZATION, bearer);
+    }
+    if is_grok_subscription_proxy(base_url) {
+        builder = builder
+            .header(XAI_TOKEN_AUTH_HEADER, XAI_TOKEN_AUTH_VALUE)
+            .header(GROK_CLIENT_VERSION_HEADER, env!("CARGO_PKG_VERSION"));
     }
     let request = builder
         .body(Body::empty())
@@ -457,6 +490,55 @@ mod tests {
                 .turn_state
                 .as_ref()
                 .is_some_and(|state| Arc::ptr_eq(state, &turn_state))
+        );
+    }
+
+    #[test]
+    fn identifies_only_the_official_grok_subscription_proxy() {
+        assert!(is_grok_subscription_proxy(
+            "https://cli-chat-proxy.grok.com/v1"
+        ));
+        assert!(!is_grok_subscription_proxy("https://api.x.ai/v1"));
+        assert!(!is_grok_subscription_proxy(
+            "https://cli-chat-proxy.grok.com.attacker.example/v1"
+        ));
+    }
+
+    #[test]
+    fn grok_subscription_requests_route_by_model_header() {
+        let request = TurnRequest {
+            model: "grok-4.3".to_string(),
+            instructions: String::new(),
+            input: vec![],
+            tools: vec![],
+            parallel_tool_calls: false,
+            reasoning: None,
+            output_schema: None,
+            verbosity: None,
+            turn_state: None,
+            extensions: serde_json::Map::new(),
+        };
+        let mut options =
+            responses_options_from_turn_request(&request, ResponsesOptions::default());
+        insert_grok_subscription_headers(
+            "https://cli-chat-proxy.grok.com/v1",
+            &request.model,
+            &mut options.extra_headers,
+        );
+
+        assert_eq!(
+            options
+                .extra_headers
+                .get(GROK_MODEL_OVERRIDE_HEADER)
+                .and_then(|value| value.to_str().ok()),
+            Some("grok-4.3")
+        );
+        assert_eq!(
+            options
+                .extra_headers
+                .get(GROK_CLIENT_VERSION_HEADER)
+                .and_then(|value| value.to_str().ok()),
+            Some(env!("CARGO_PKG_VERSION"))
         );
     }
 }


### PR DESCRIPTION
## What changed

- add provider-scoped xAI device authorization to `chaos --provider xai accounts --device-auth`
- persist xAI OAuth credentials in the existing per-provider auth store and refresh them in place
- route xAI subscription-authenticated traffic through the Grok CLI subscription proxy, including its required client-version header, while leaving `XAI_API_KEY` traffic on the existing API endpoint
- add xAI auth-mode, provider capability, telemetry, status, and unauthorized-recovery plumbing
- document the CLI behavior and add device-flow, persistence, refresh, capability, and request-routing tests

## Why

Chaos currently supports ChatGPT subscription accounts but rejects account authentication for xAI. Hosted/headless agents need an explicit per-provider option to use a SuperGrok / X Premium+ subscription without moving OAuth token custody outside the agent's Chaos home.

This is additive capability only: existing API-key connections are unchanged unless the xAI device-auth flow is explicitly run.

Closes #16.

## How to verify

```sh
chaos --provider xai accounts --device-auth
chaos --provider xai accounts
```

Automated checks run locally with Rust 1.97.0:

- `just fmt`
- `just check` — passed
- focused xAI device-code, persistence, refresh, capability, and proxy-routing tests — passed
- targeted clippy for changed libraries and the PAM test target — passed
- `just test` — 2,690/2,691 passed; the unrelated `undo_restores_untracked_file_edit` test fails reproducibly before the changed provider code is involved because its temporary repository does not report `notes.txt` as untracked
- full `just clippy` is blocked on existing macOS-only warnings in `seatbelt_tests.rs`, `debug_sandbox.rs`, and `sandbox.rs`; the changed targets pass when those unrelated targets are excluded

The live xAI OIDC discovery document and device-code endpoint were also checked against the client ID and frozen ten-scope contract in xAI's official Grok Build source. Generated device and user codes were not printed or retained during that verification.

A live local smoke test completed the real xAI device flow in an isolated `CHAOS_HOME` and received the exact Grok response `xAI subscription auth works` with exit code 0. That test exposed and verified the fix for the proxy's required `x-grok-client-version` header. OAuth tokens remain redacted and are not included in this PR.

- [ ] Tests pass
- [ ] Builds on target hardware

---
_Opened as a draft pending maintainer alignment on #16 and CI confirmation._