### PR TITLE
feat: report clamp usage telemetry

### DIFF
--- a/sys/kern/kern/src/client/streaming.rs
+++ b/sys/kern/kern/src/client/streaming.rs
@@ -70,22 +70,38 @@ use super::{
 
 // ── Response stream helpers ───────────────────────────────────────────────────
 
-fn clamp_usage_to_token_usage(usage: chaos_clamp::Usage) -> TokenUsage {
+fn clamp_usage_to_token_usage(
+    aggregate_usage: chaos_clamp::Usage,
+    context_usage: Option<&chaos_clamp::Usage>,
+) -> TokenUsage {
     fn saturating_i64(value: u64) -> i64 {
         i64::try_from(value).unwrap_or(i64::MAX)
     }
 
-    let input_tokens = usage
+    let input_tokens = aggregate_usage
         .input_tokens
-        .saturating_add(usage.cache_creation_input_tokens)
-        .saturating_add(usage.cache_read_input_tokens);
-    let total_tokens = input_tokens.saturating_add(usage.output_tokens);
+        .saturating_add(aggregate_usage.cache_creation_input_tokens)
+        .saturating_add(aggregate_usage.cache_read_input_tokens);
+    // Claude Code's result usage aggregates every provider call in its tool
+    // loop. Keep those counters for activity reporting, but derive the context
+    // load from the final raw assistant message, whose usage is per-call.
+    let total_tokens = context_usage
+        .map(|usage| {
+            usage
+                .input_tokens
+                .saturating_add(usage.cache_creation_input_tokens)
+                .saturating_add(usage.cache_read_input_tokens)
+                .saturating_add(usage.output_tokens)
+        })
+        // Missing per-call usage is safer as an unknown/zero context load than
+        // as the confidently wrong aggregate that drives auto-compaction.
+        .unwrap_or(0);
 
     TokenUsage {
         input_tokens: saturating_i64(input_tokens),
-        cache_creation_input_tokens: saturating_i64(usage.cache_creation_input_tokens),
-        cached_input_tokens: saturating_i64(usage.cache_read_input_tokens),
-        output_tokens: saturating_i64(usage.output_tokens),
+        cache_creation_input_tokens: saturating_i64(aggregate_usage.cache_creation_input_tokens),
+        cached_input_tokens: saturating_i64(aggregate_usage.cache_read_input_tokens),
+        output_tokens: saturating_i64(aggregate_usage.output_tokens),
         reasoning_output_tokens: 0,
         total_tokens: saturating_i64(total_tokens),
         provider_request_count: 0,
@@ -837,9 +853,21 @@ impl ModelClientSession {
             }
 
             let mut full_text = String::new();
+            let mut last_assistant_usage = None;
             loop {
                 match transport.next_message().await {
                     Ok(Some(ClampMessage::Assistant { message })) => {
+                        if let Some(raw_usage) = message.get("usage").cloned() {
+                            match serde_json::from_value::<chaos_clamp::Usage>(raw_usage) {
+                                Ok(usage) => last_assistant_usage = Some(usage),
+                                Err(error) => {
+                                    tracing::warn!(
+                                        %error,
+                                        "failed to parse clamp assistant usage"
+                                    );
+                                }
+                            }
+                        }
                         if let Some(content) = message.get("content").and_then(|c| c.as_array()) {
                             for block in content {
                                 if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
@@ -867,7 +895,9 @@ impl ModelClientSession {
                         let _ = tx_event
                             .send(Ok(ResponseEvent::Completed {
                                 response_id,
-                                token_usage: usage.map(clamp_usage_to_token_usage),
+                                token_usage: usage.map(|usage| {
+                                    clamp_usage_to_token_usage(usage, last_assistant_usage.as_ref())
+                                }),
                             }))
                             .await;
                         break;
@@ -1306,31 +1336,40 @@ mod tests {
     use chaos_clamp::Usage;
 
     #[test]
-    fn clamp_usage_matches_anthropic_accounting_semantics() {
-        let usage = clamp_usage_to_token_usage(Usage {
-            input_tokens: 11,
-            cache_creation_input_tokens: 13,
-            cache_read_input_tokens: 17,
-            output_tokens: 19,
-        });
+    fn clamp_usage_uses_aggregate_counters_and_last_call_context() {
+        let usage = clamp_usage_to_token_usage(
+            Usage {
+                input_tokens: 8,
+                cache_creation_input_tokens: 45_558,
+                cache_read_input_tokens: 136_189,
+                output_tokens: 233,
+            },
+            Some(&Usage {
+                input_tokens: 3,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 45_700,
+                output_tokens: 47,
+            }),
+        );
 
-        assert_eq!(usage.input_tokens, 41);
-        assert_eq!(usage.cache_creation_input_tokens, 13);
-        assert_eq!(usage.cached_input_tokens, 17);
-        assert_eq!(usage.output_tokens, 19);
+        assert_eq!(usage.input_tokens, 181_755);
+        assert_eq!(usage.cache_creation_input_tokens, 45_558);
+        assert_eq!(usage.cached_input_tokens, 136_189);
+        assert_eq!(usage.output_tokens, 233);
         assert_eq!(usage.reasoning_output_tokens, 0);
-        assert_eq!(usage.total_tokens, 60);
+        assert_eq!(usage.total_tokens, 45_750);
         assert_eq!(usage.provider_request_count, 0);
     }
 
     #[test]
     fn clamp_usage_saturates_on_overflow() {
-        let usage = clamp_usage_to_token_usage(Usage {
+        let max_usage = Usage {
             input_tokens: u64::MAX,
             cache_creation_input_tokens: u64::MAX,
             cache_read_input_tokens: u64::MAX,
             output_tokens: u64::MAX,
-        });
+        };
+        let usage = clamp_usage_to_token_usage(max_usage.clone(), Some(&max_usage));
 
         assert_eq!(usage.input_tokens, i64::MAX);
         assert_eq!(usage.cache_creation_input_tokens, i64::MAX);
@@ -1339,5 +1378,22 @@ mod tests {
         assert_eq!(usage.reasoning_output_tokens, 0);
         assert_eq!(usage.total_tokens, i64::MAX);
         assert_eq!(usage.provider_request_count, 0);
+    }
+
+    #[test]
+    fn clamp_usage_leaves_context_unknown_without_assistant_usage() {
+        let usage = clamp_usage_to_token_usage(
+            Usage {
+                input_tokens: 11,
+                cache_creation_input_tokens: 13,
+                cache_read_input_tokens: 17,
+                output_tokens: 19,
+            },
+            None,
+        );
+
+        assert_eq!(usage.input_tokens, 41);
+        assert_eq!(usage.output_tokens, 19);
+        assert_eq!(usage.total_tokens, 0);
     }
 }

--- a/sys/kern/kern/src/client/streaming.rs
+++ b/sys/kern/kern/src/client/streaming.rs
@@ -19,6 +19,7 @@ use chaos_ipc::models::ContentItem;
 use chaos_ipc::models::ResponseItem;
 use chaos_ipc::openai_models::ModelInfo;
 use chaos_ipc::openai_models::ReasoningEffort as ReasoningEffortConfig;
+use chaos_ipc::protocol::TokenUsage;
 use chaos_parrot::RamaTransport;
 use chaos_parrot::RequestTelemetry;
 use chaos_parrot::ResponsesOptions as ApiResponsesOptions;
@@ -68,6 +69,28 @@ use super::{
 };
 
 // ── Response stream helpers ───────────────────────────────────────────────────
+
+fn clamp_usage_to_token_usage(usage: chaos_clamp::Usage) -> TokenUsage {
+    fn saturating_i64(value: u64) -> i64 {
+        i64::try_from(value).unwrap_or(i64::MAX)
+    }
+
+    let input_tokens = usage
+        .input_tokens
+        .saturating_add(usage.cache_creation_input_tokens)
+        .saturating_add(usage.cache_read_input_tokens);
+    let total_tokens = input_tokens.saturating_add(usage.output_tokens);
+
+    TokenUsage {
+        input_tokens: saturating_i64(input_tokens),
+        cache_creation_input_tokens: saturating_i64(usage.cache_creation_input_tokens),
+        cached_input_tokens: saturating_i64(usage.cache_read_input_tokens),
+        output_tokens: saturating_i64(usage.output_tokens),
+        reasoning_output_tokens: 0,
+        total_tokens: saturating_i64(total_tokens),
+        provider_request_count: 0,
+    }
+}
 
 /// Parses per-turn metadata into an HTTP header value.
 pub(super) fn parse_turn_metadata_header(
@@ -828,7 +851,9 @@ impl ModelClientSession {
                             }
                         }
                     }
-                    Ok(Some(ClampMessage::Result { session_id, .. })) => {
+                    Ok(Some(ClampMessage::Result {
+                        session_id, usage, ..
+                    })) => {
                         let _ = tx_event
                             .send(Ok(ResponseEvent::OutputItemDone(ResponseItem::Message {
                                 id: None,
@@ -842,7 +867,7 @@ impl ModelClientSession {
                         let _ = tx_event
                             .send(Ok(ResponseEvent::Completed {
                                 response_id,
-                                token_usage: None,
+                                token_usage: usage.map(clamp_usage_to_token_usage),
                             }))
                             .await;
                         break;
@@ -1272,5 +1297,47 @@ fn clamp_wiretap_mode() -> WiretapMode {
         }
         "trace" | "tracing" => WiretapMode::File(None),
         path => WiretapMode::File(Some(std::path::PathBuf::from(path))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::clamp_usage_to_token_usage;
+    use chaos_clamp::Usage;
+
+    #[test]
+    fn clamp_usage_matches_anthropic_accounting_semantics() {
+        let usage = clamp_usage_to_token_usage(Usage {
+            input_tokens: 11,
+            cache_creation_input_tokens: 13,
+            cache_read_input_tokens: 17,
+            output_tokens: 19,
+        });
+
+        assert_eq!(usage.input_tokens, 41);
+        assert_eq!(usage.cache_creation_input_tokens, 13);
+        assert_eq!(usage.cached_input_tokens, 17);
+        assert_eq!(usage.output_tokens, 19);
+        assert_eq!(usage.reasoning_output_tokens, 0);
+        assert_eq!(usage.total_tokens, 60);
+        assert_eq!(usage.provider_request_count, 0);
+    }
+
+    #[test]
+    fn clamp_usage_saturates_on_overflow() {
+        let usage = clamp_usage_to_token_usage(Usage {
+            input_tokens: u64::MAX,
+            cache_creation_input_tokens: u64::MAX,
+            cache_read_input_tokens: u64::MAX,
+            output_tokens: u64::MAX,
+        });
+
+        assert_eq!(usage.input_tokens, i64::MAX);
+        assert_eq!(usage.cache_creation_input_tokens, i64::MAX);
+        assert_eq!(usage.cached_input_tokens, i64::MAX);
+        assert_eq!(usage.output_tokens, i64::MAX);
+        assert_eq!(usage.reasoning_output_tokens, 0);
+        assert_eq!(usage.total_tokens, i64::MAX);
+        assert_eq!(usage.provider_request_count, 0);
     }
 }

--- a/sys/modules/clamp/src/lib.rs
+++ b/sys/modules/clamp/src/lib.rs
@@ -15,6 +15,7 @@ mod transport;
 pub use protocol::ControlRequest;
 pub use protocol::ControlResponse;
 pub use protocol::Message;
+pub use protocol::Usage;
 pub use proxy::FileWiretapSink;
 pub use proxy::WiretapExchange;
 pub use proxy::WiretapProxy;

--- a/sys/modules/clamp/src/protocol.rs
+++ b/sys/modules/clamp/src/protocol.rs
@@ -140,8 +140,6 @@ pub enum Message {
         session_id: Option<String>,
         #[serde(default)]
         usage: Option<Usage>,
-        #[serde(default, rename = "modelUsage")]
-        model_usage: Option<Value>,
     },
 
     /// A system message (e.g., init, rate limit, error).
@@ -201,7 +199,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn result_preserves_usage_and_model_usage() {
+    fn result_preserves_usage() {
         let message: Message = serde_json::from_value(json!({
             "type": "result",
             "subtype": "success",
@@ -226,10 +224,7 @@ mod tests {
         }))
         .expect("result should deserialize");
 
-        let Message::Result {
-            usage, model_usage, ..
-        } = message
-        else {
+        let Message::Result { usage, .. } = message else {
             panic!("expected result message");
         };
 
@@ -238,17 +233,6 @@ mod tests {
         assert_eq!(usage.cache_creation_input_tokens, 13);
         assert_eq!(usage.cache_read_input_tokens, 17);
         assert_eq!(usage.output_tokens, 19);
-        assert_eq!(
-            model_usage,
-            Some(json!({
-                "claude-test": {
-                    "inputTokens": 11,
-                    "cacheCreationInputTokens": 13,
-                    "cacheReadInputTokens": 17,
-                    "outputTokens": 19
-                }
-            }))
-        );
     }
 
     #[test]
@@ -261,15 +245,11 @@ mod tests {
         }))
         .expect("historical result should deserialize");
 
-        let Message::Result {
-            usage, model_usage, ..
-        } = message
-        else {
+        let Message::Result { usage, .. } = message else {
             panic!("expected result message");
         };
 
         assert_eq!(usage, None);
-        assert_eq!(model_usage, None);
     }
 
     #[test]

--- a/sys/modules/clamp/src/protocol.rs
+++ b/sys/modules/clamp/src/protocol.rs
@@ -105,6 +105,19 @@ impl ControlResponse {
 // Parsed message from Claude Code's stdout
 // ---------------------------------------------------------------------------
 
+/// Token usage reported by Claude Code for the primary result model.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+pub struct Usage {
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub cache_creation_input_tokens: u64,
+    #[serde(default)]
+    pub cache_read_input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+}
+
 /// A parsed message from Claude Code's stream-json output.
 ///
 /// The `type` field is used for tag-based deserialization but some message
@@ -125,6 +138,10 @@ pub enum Message {
         total_cost_usd: Option<f64>,
         #[serde(default)]
         session_id: Option<String>,
+        #[serde(default)]
+        usage: Option<Usage>,
+        #[serde(default, rename = "modelUsage")]
+        model_usage: Option<Value>,
     },
 
     /// A system message (e.g., init, rate limit, error).
@@ -176,4 +193,130 @@ pub fn control_request_envelope(request_id: &str, request: Value) -> Value {
         "request_id": request_id,
         "request": request
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Message;
+    use serde_json::json;
+
+    #[test]
+    fn result_preserves_usage_and_model_usage() {
+        let message: Message = serde_json::from_value(json!({
+            "type": "result",
+            "subtype": "success",
+            "result": "ok",
+            "session_id": "session-1",
+            "total_cost_usd": 0.0,
+            "usage": {
+                "input_tokens": 11,
+                "cache_creation_input_tokens": 13,
+                "cache_read_input_tokens": 17,
+                "output_tokens": 19,
+                "service_tier": "standard"
+            },
+            "modelUsage": {
+                "claude-test": {
+                    "inputTokens": 11,
+                    "cacheCreationInputTokens": 13,
+                    "cacheReadInputTokens": 17,
+                    "outputTokens": 19
+                }
+            }
+        }))
+        .expect("result should deserialize");
+
+        let Message::Result {
+            usage, model_usage, ..
+        } = message
+        else {
+            panic!("expected result message");
+        };
+
+        let usage = usage.expect("usage should be present");
+        assert_eq!(usage.input_tokens, 11);
+        assert_eq!(usage.cache_creation_input_tokens, 13);
+        assert_eq!(usage.cache_read_input_tokens, 17);
+        assert_eq!(usage.output_tokens, 19);
+        assert_eq!(
+            model_usage,
+            Some(json!({
+                "claude-test": {
+                    "inputTokens": 11,
+                    "cacheCreationInputTokens": 13,
+                    "cacheReadInputTokens": 17,
+                    "outputTokens": 19
+                }
+            }))
+        );
+    }
+
+    #[test]
+    fn result_without_usage_remains_unknown() {
+        let message: Message = serde_json::from_value(json!({
+            "type": "result",
+            "result": "ok",
+            "session_id": "session-1",
+            "total_cost_usd": 0.0
+        }))
+        .expect("historical result should deserialize");
+
+        let Message::Result {
+            usage, model_usage, ..
+        } = message
+        else {
+            panic!("expected result message");
+        };
+
+        assert_eq!(usage, None);
+        assert_eq!(model_usage, None);
+    }
+
+    #[test]
+    fn result_usage_ignores_unknown_nested_fields() {
+        let message: Message = serde_json::from_value(json!({
+            "type": "result",
+            "result": "ok",
+            "usage": {
+                "input_tokens": 11,
+                "cache_creation_input_tokens": 13,
+                "cache_read_input_tokens": 17,
+                "output_tokens": 19,
+                "cache_creation": {
+                    "ephemeral_5m_input_tokens": 13,
+                    "ephemeral_1h_input_tokens": 0
+                },
+                "server_tool_use": {
+                    "web_search_requests": 1,
+                    "web_fetch_requests": 0
+                },
+                "service_tier": "standard"
+            }
+        }))
+        .expect("future usage fields should not break deserialization");
+
+        let Message::Result { usage, .. } = message else {
+            panic!("expected result message");
+        };
+
+        assert!(usage.is_some());
+    }
+
+    #[test]
+    fn error_result_remains_parseable_without_usage() {
+        let message: Message = serde_json::from_value(json!({
+            "type": "result",
+            "subtype": "error_during_execution",
+            "is_error": true,
+            "result": "execution failed",
+            "session_id": "session-1"
+        }))
+        .expect("error result should deserialize");
+
+        let Message::Result { usage, .. } = message else {
+            panic!("expected result message");
+        };
+
+        assert_eq!(usage, None);
+    }
 }

--- a/sys/modules/clamp/src/transport.rs
+++ b/sys/modules/clamp/src/transport.rs
@@ -584,12 +584,16 @@ impl ClampTransport {
                 session_id: Some(session_id),
                 result,
                 total_cost_usd,
+                usage,
+                model_usage,
             } => {
                 self.session_id = session_id.clone();
                 Ok(Some(Message::Result {
                     result,
                     total_cost_usd,
                     session_id: Some(session_id),
+                    usage,
+                    model_usage,
                 }))
             }
             msg @ (Message::Assistant { .. } | Message::Result { .. } | Message::System { .. }) => {

--- a/sys/modules/clamp/src/transport.rs
+++ b/sys/modules/clamp/src/transport.rs
@@ -585,7 +585,6 @@ impl ClampTransport {
                 result,
                 total_cost_usd,
                 usage,
-                model_usage,
             } => {
                 self.session_id = session_id.clone();
                 Ok(Some(Message::Result {
@@ -593,7 +592,6 @@ impl ClampTransport {
                     total_cost_usd,
                     session_id: Some(session_id),
                     usage,
-                    model_usage,
                 }))
             }
             msg @ (Message::Assistant { .. } | Message::Result { .. } | Message::System { .. }) => {

--- a/sys/modules/clamp/tests/smoke.rs
+++ b/sys/modules/clamp/tests/smoke.rs
@@ -36,8 +36,8 @@ async fn clamp_round_trip() {
     let mut got_result = false;
     while let Ok(Some(msg)) = transport.next_message().await {
         match &msg {
-            Message::Assistant { .. } => {
-                eprintln!("[test] assistant message received");
+            Message::Assistant { message } => {
+                eprintln!("[test] assistant: {message}");
             }
             Message::Result { usage, .. } => {
                 let usage = usage.as_ref().expect("result did not include usage");
@@ -59,8 +59,8 @@ async fn clamp_round_trip() {
                 got_result = true;
                 break;
             }
-            Message::System { .. } => {
-                eprintln!("[test] system message received");
+            Message::System { message, .. } => {
+                eprintln!("[test] system: {message:?}");
             }
             _ => {}
         }

--- a/sys/modules/clamp/tests/smoke.rs
+++ b/sys/modules/clamp/tests/smoke.rs
@@ -23,11 +23,8 @@ async fn clamp_round_trip() {
     let mut transport = ClampTransport::spawn(config).await.expect("spawn failed");
 
     eprintln!("[test] initializing control protocol...");
-    let init = transport.initialize().await.expect("init failed");
-    eprintln!(
-        "[test] initialized: {}",
-        serde_json::to_string_pretty(&init).unwrap_or_default()
-    );
+    transport.initialize().await.expect("init failed");
+    eprintln!("[test] initialized");
 
     eprintln!("[test] sending prompt...");
     transport
@@ -39,16 +36,31 @@ async fn clamp_round_trip() {
     let mut got_result = false;
     while let Ok(Some(msg)) = transport.next_message().await {
         match &msg {
-            Message::Assistant { message } => {
-                eprintln!("[test] assistant: {message}");
+            Message::Assistant { .. } => {
+                eprintln!("[test] assistant message received");
             }
-            Message::Result { total_cost_usd, .. } => {
-                eprintln!("[test] turn complete (cost: {total_cost_usd:?})");
+            Message::Result { usage, .. } => {
+                let usage = usage.as_ref().expect("result did not include usage");
+                assert!(
+                    usage.input_tokens > 0,
+                    "input token count should be non-zero"
+                );
+                assert!(
+                    usage.output_tokens > 0,
+                    "output token count should be non-zero"
+                );
+                eprintln!(
+                    "[test] usage: input={} cache_creation={} cache_read={} output={}",
+                    usage.input_tokens,
+                    usage.cache_creation_input_tokens,
+                    usage.cache_read_input_tokens,
+                    usage.output_tokens
+                );
                 got_result = true;
                 break;
             }
-            Message::System { message, .. } => {
-                eprintln!("[test] system: {message:?}");
+            Message::System { .. } => {
+                eprintln!("[test] system message received");
             }
             _ => {}
         }


### PR DESCRIPTION
## What changed

- preserve Claude Code's optional top-level result `usage`
- keep aggregate result input/cache/output counters for invocation activity telemetry
- derive context-driving `total_tokens` from the final assistant message's per-call usage, avoiding tool-loop overcounting and spurious auto-compaction
- attach known usage to the existing clamped `ResponseEvent::Completed` path without double-counting provider requests
- keep missing per-call context usage conservative at zero rather than substituting aggregate usage
- add protocol compatibility, missing/error usage, conversion overflow, cumulative-vs-context regression, downstream JSON telemetry, and live clamp smoke coverage

## Why

Clamp previously dropped Claude Code usage before Chaos's existing session and invocation telemetry accounting could consume it. This left subscription-authenticated clamped turns without complete invocation-local activity telemetry.

Claude Code's result-level usage aggregates all provider calls in a tool loop, so it is useful for invocation counters but unsafe for context-window control flow. The final raw assistant message carries per-call Anthropic usage; this PR uses that source only for `total_tokens`, which feeds the context bar and auto-distillation logic.

This reports process activity. It does not claim authoritative Claude subscription quota remaining or subscription spend.

Closes #18.

## How to verify

Passed locally on Apple Silicon macOS with Rust 1.97.0:

- `cargo fmt --all -- --check`
- `cargo test -p chaos-clamp` — 20 passed
- `cargo test -p chaos-kern clamp_usage --lib` — 3 passed
- `cargo test -p chaos-fork event_processor_with_json_output` — 28 passed
- `cargo clippy -p chaos-clamp -p chaos-kern -p chaos-fork --lib -- -D warnings`
- earlier live verification: `CHAOS_CLAMP_SMOKE=1 cargo test -p chaos-clamp --test smoke -- --ignored --nocapture` against Claude Code 2.0.71 reported non-zero result usage

The repository-prescribed full `just test` run on the original change completed 2,697 tests: 2,694 passed and 3 unrelated existing tests failed:

- `review_diff_prefetch_disables_external_diff_helpers`
- `review_diff_prefetch_disables_textconv_helpers`
- `undo_restores_untracked_file_edit`

The first two receive forced ANSI-colored Git diff output in this local environment. None of the three failing tests or their implementation paths are changed by this PR.

The end-to-end `chaos exec --json` acceptance check remains gated on the separately planned headless clamp enablement.

- [ ] Tests pass (relevant tests pass; full-suite baseline failures documented above)
- [x] Builds on target hardware