### PR TITLE
feat: enable clamped chaos exec sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,25 @@ Windows is not supported.
 ## Clamping / Docking
 
 Anthropic requires MAX subscribers to use the official Claude Code harness.
-The Clamping module works within these terms: it launches Claude Code with `--bare`,
-strips its built-in tools, and connects through MCP. FreeChaOS provides the tools.
-FreeChaOS hooks into the lifecycle. Claude Code becomes the transport.
+The Clamping module works within these terms: it launches Claude Code with settings
+discovery disabled, strips its built-in tools, and connects through MCP. FreeChaOS
+provides the tools. FreeChaOS hooks into the lifecycle. Claude Code becomes the
+transport.
 
 API key users connect directly through the kernel — no clamping needed.
+
+Headless `chaos exec` sessions can request the clamped transport through the
+layered configuration:
+
+```bash
+chaos exec --json -c clamp=true -m claude-sonnet-4-5 "say ok"
+chaos exec --json -c clamp=true resume <process_id> "continue"
+```
+
+The effective config for each invocation governs its transport, so resumed
+sessions must pass `-c clamp=true` again. If Claude Code is missing,
+unauthenticated, or fails during a turn, the exec command fails instead of
+falling back to direct API billing.
 
 This architecture is correct usage of both providers' terms of service.
 

--- a/sys/kern/kern/src/chaos/session/init.rs
+++ b/sys/kern/kern/src/chaos/session/init.rs
@@ -511,6 +511,7 @@ impl Session {
                 config.model_verbosity,
                 true,
                 Self::build_model_client_beta_features_header(config.as_ref()),
+                config.clamp && matches!(session_configuration.session_source, SessionSource::Exec),
             ),
         };
         let (out_of_band_elicitation_paused, _out_of_band_elicitation_paused_rx) =

--- a/sys/kern/kern/src/chaos_tests.rs
+++ b/sys/kern/kern/src/chaos_tests.rs
@@ -467,6 +467,7 @@ fn make_test_session_services(
             config.model_verbosity,
             true,
             Session::build_model_client_beta_features_header(config),
+            false,
         ),
         halluacinate: None,
     }

--- a/sys/kern/kern/src/client/state.rs
+++ b/sys/kern/kern/src/client/state.rs
@@ -50,6 +50,7 @@ impl ModelClient {
         model_verbosity: Option<chaos_ipc::config_types::Verbosity>,
         enable_request_compression: bool,
         beta_features_header: Option<String>,
+        initial_clamped: bool,
     ) -> Self {
         let representer = if provider.is_openai() {
             chaos_parrot::SessionRepresenter::openai()
@@ -69,7 +70,7 @@ impl ModelClient {
                 enable_request_compression,
                 beta_features_header,
                 resolved_wire: std::sync::OnceLock::new(),
-                clamped: std::sync::atomic::AtomicBool::new(false),
+                clamped: std::sync::atomic::AtomicBool::new(initial_clamped),
                 clamp_transport: tokio::sync::Mutex::new(None),
                 clamp_wiretap: tokio::sync::Mutex::new(None),
                 clamp_mcp_bridge: tokio::sync::Mutex::new(None),

--- a/sys/kern/kern/src/client/streaming.rs
+++ b/sys/kern/kern/src/client/streaming.rs
@@ -776,7 +776,8 @@ impl ModelClientSession {
                         if let Err(e) = t.initialize().await {
                             let _ = tx_event
                                 .send(Err(chaos_parrot::error::ApiError::Stream(format!(
-                                    "clamp init failed: {e}"
+                                    "{}: {e}",
+                                    clamp_failure_marker(&e, "clamp_startup_failed")
                                 ))))
                                 .await;
                             return;
@@ -792,7 +793,8 @@ impl ModelClientSession {
                     Err(e) => {
                         let _ = tx_event
                             .send(Err(chaos_parrot::error::ApiError::Stream(format!(
-                                "clamp spawn failed: {e}"
+                                "{}: {e}",
+                                clamp_failure_marker(&e, "clamp_startup_failed")
                             ))))
                             .await;
                         return;
@@ -818,7 +820,8 @@ impl ModelClientSession {
                 *guard = None;
                 let _ = tx_event
                     .send(Err(chaos_parrot::error::ApiError::Stream(format!(
-                        "clamp set_model failed: {e}"
+                        "{}: {e}",
+                        clamp_failure_marker(&e, "clamp_runtime_failed")
                     ))))
                     .await;
                 return;
@@ -846,7 +849,8 @@ impl ModelClientSession {
                 *guard = None;
                 let _ = tx_event
                     .send(Err(chaos_parrot::error::ApiError::Stream(format!(
-                        "clamp send failed: {e}"
+                        "{}: {e}",
+                        clamp_failure_marker(&e, "clamp_runtime_failed")
                     ))))
                     .await;
                 return;
@@ -918,7 +922,8 @@ impl ModelClientSession {
                         *guard = None;
                         let _ = tx_event
                             .send(Err(chaos_parrot::error::ApiError::Stream(format!(
-                                "clamp error: {e}"
+                                "{}: {e}",
+                                clamp_failure_marker(&e, "clamp_runtime_failed")
                             ))))
                             .await;
                         break;
@@ -1299,6 +1304,14 @@ impl ModelClientSession {
             Ok(stream) => Ok(adapt_adapter_stream(stream, session_telemetry.clone())),
             Err(err) => Err(map_api_error(abi_error_to_api_error(err))),
         }
+    }
+}
+
+fn clamp_failure_marker(error: &chaos_clamp::ClampError, fallback: &'static str) -> &'static str {
+    match error {
+        chaos_clamp::ClampError::CliNotFound(_) => "clamp_cli_not_found",
+        chaos_clamp::ClampError::AuthenticationUnavailable => "clamp_auth_unavailable",
+        _ => fallback,
     }
 }
 

--- a/sys/kern/kern/src/client_tests.rs
+++ b/sys/kern/kern/src/client_tests.rs
@@ -33,7 +33,30 @@ fn test_model_client(session_source: SessionSource) -> ModelClient {
         None,
         false,
         None,
+        false,
     )
+}
+
+#[test]
+fn model_client_can_start_clamped_before_the_first_turn() {
+    let provider = crate::model_provider_info::create_oss_provider_with_base_url(
+        "https://example.com/v1",
+        crate::model_provider_info::WireApi::Responses,
+    );
+    let client = ModelClient::new(
+        None,
+        ProcessId::new(),
+        "gpt-oss".to_string(),
+        provider,
+        SessionSource::Exec,
+        ApprovalPolicy::Headless,
+        None,
+        false,
+        None,
+        true,
+    );
+
+    assert!(client.is_clamped());
 }
 
 fn test_anthropic_provider() -> crate::model_provider_info::ModelProviderInfo {
@@ -102,6 +125,7 @@ fn resolve_anthropic_auth_uses_bearer_token_from_provider_config() {
         None,
         false,
         None,
+        false,
     );
     let session = client.new_session();
 
@@ -127,6 +151,7 @@ fn resolve_anthropic_auth_errors_when_provider_has_no_static_auth() {
         None,
         false,
         None,
+        false,
     );
     let session = client.new_session();
 

--- a/sys/kern/kern/src/config.rs
+++ b/sys/kern/kern/src/config.rs
@@ -205,6 +205,12 @@ pub struct Config {
     /// users are only interested in the final agent responses.
     pub hide_agent_reasoning: bool,
 
+    /// Start `chaos exec` sessions using the Claude Code subprocess transport.
+    ///
+    /// Interactive sessions ignore this setting and retain their existing
+    /// `/clamp` and `--clamp` controls.
+    pub clamp: bool,
+
     /// Optional user-provided instructions (currently always `None`; a
     /// schema-based replacement for the removed AGENTS.md loader will
     /// repopulate this later).
@@ -617,6 +623,10 @@ pub struct ConfigToml {
     /// When set to `true`, `AgentReasoning` events will be hidden from the
     /// UI/output. Defaults to `false`.
     pub hide_agent_reasoning: Option<bool>,
+
+    /// Start `chaos exec` sessions using the Claude Code subprocess transport.
+    /// Defaults to `false`.
+    pub clamp: Option<bool>,
 
     pub model_reasoning_effort: Option<ReasoningEffort>,
     /// Allow the parent model to change its own reasoning effort for subsequent turns.

--- a/sys/kern/kern/src/config/config_tests.rs
+++ b/sys/kern/kern/src/config/config_tests.rs
@@ -167,6 +167,41 @@ fn runtime_config_defaults_model_availability_nux() {
 }
 
 #[test]
+fn runtime_config_defaults_clamp_to_false_and_parses_true() {
+    let default_cfg = Config::load_from_base_config_with_overrides(
+        ConfigToml::default(),
+        ConfigOverrides::default(),
+        tempdir().expect("tempdir").path().to_path_buf(),
+    )
+    .expect("load default config");
+    assert!(!default_cfg.clamp);
+
+    let parsed =
+        toml::from_str::<ConfigToml>("clamp = true").expect("clamp should deserialize from TOML");
+    let enabled_cfg = Config::load_from_base_config_with_overrides(
+        parsed,
+        ConfigOverrides::default(),
+        tempdir().expect("tempdir").path().to_path_buf(),
+    )
+    .expect("load clamped config");
+    assert!(enabled_cfg.clamp);
+}
+
+#[tokio::test]
+async fn config_builder_applies_clamp_cli_override() {
+    let chaos_home = tempdir().expect("tempdir");
+    let cfg = ConfigBuilder::default()
+        .chaos_home(chaos_home.path().to_path_buf())
+        .cli_overrides(vec![("clamp".to_string(), TomlValue::Boolean(true))])
+        .fallback_cwd(Some(chaos_home.path().to_path_buf()))
+        .build()
+        .await
+        .expect("load config with clamp CLI override");
+
+    assert!(cfg.clamp);
+}
+
+#[test]
 fn tui_theme_deserializes_from_toml() {
     let cfg = r#"
 [tui]
@@ -872,6 +907,7 @@ fn expected_precedence_fixture_config_baseline(fixture: &PrecedenceTestFixture) 
         permissions: expected_precedence_fixture_permissions(ApprovalPolicy::Supervised),
         approvals_reviewer: ApprovalsReviewer::User,
         enforce_residency: Constrained::allow_any(None),
+        clamp: false,
         user_instructions: None,
         cwd: fixture.cwd(),
         cli_auth_credentials_store_mode: Default::default(),

--- a/sys/kern/kern/src/config/requirements.rs
+++ b/sys/kern/kern/src/config/requirements.rs
@@ -651,6 +651,7 @@ impl Config {
             alcatraz_macos_exe,
 
             hide_agent_reasoning: cfg.hide_agent_reasoning.unwrap_or(false),
+            clamp: cfg.clamp.unwrap_or(false),
             model_reasoning_effort: config_profile
                 .model_reasoning_effort
                 .or(cfg.model_reasoning_effort),

--- a/sys/kern/kern/tests/responses_headers.rs
+++ b/sys/kern/kern/tests/responses_headers.rs
@@ -96,6 +96,7 @@ async fn responses_stream_includes_subagent_header_on_review() {
         config.model_verbosity,
         false,
         None,
+        false,
     );
     let mut client_session = client.new_session();
 
@@ -209,6 +210,7 @@ async fn responses_stream_includes_subagent_header_on_other() {
         config.model_verbosity,
         false,
         None,
+        false,
     );
     let mut client_session = client.new_session();
 
@@ -321,6 +323,7 @@ async fn responses_respects_model_info_overrides_from_config() {
         config.model_verbosity,
         false,
         None,
+        false,
     );
     let mut client_session = client.new_session();
 

--- a/sys/modules/clamp/src/protocol.rs
+++ b/sys/modules/clamp/src/protocol.rs
@@ -135,6 +135,10 @@ pub enum Message {
     Result {
         result: Value,
         #[serde(default)]
+        subtype: Option<String>,
+        #[serde(default)]
+        is_error: bool,
+        #[serde(default)]
         total_cost_usd: Option<f64>,
         #[serde(default)]
         session_id: Option<String>,
@@ -293,10 +297,18 @@ mod tests {
         }))
         .expect("error result should deserialize");
 
-        let Message::Result { usage, .. } = message else {
+        let Message::Result {
+            usage,
+            subtype,
+            is_error,
+            ..
+        } = message
+        else {
             panic!("expected result message");
         };
 
         assert_eq!(usage, None);
+        assert_eq!(subtype.as_deref(), Some("error_during_execution"));
+        assert!(is_error);
     }
 }

--- a/sys/modules/clamp/src/transport.rs
+++ b/sys/modules/clamp/src/transport.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 
@@ -33,6 +34,9 @@ use crate::protocol::Message;
 use crate::protocol::UserMessage;
 use crate::protocol::control_request_envelope;
 use crate::protocol::initialize_request;
+
+const STDERR_TAIL_MAX_LINES: usize = 32;
+const STDERR_TAIL_MAX_CHARS_PER_LINE: usize = 512;
 
 /// Async callback for Claude Code `can_use_tool` requests.
 pub type ToolPermissionHandler = Arc<
@@ -177,6 +181,10 @@ pub struct ClampTransport {
     hook_callback_handler: Option<HookCallbackHandler>,
     /// Optional handler for MCP messages.
     mcp_message_handler: Option<McpMessageHandler>,
+    /// Bounded stderr tail retained only for classifying subprocess failures.
+    /// It is never included in user-facing errors because it may contain
+    /// credentials or other sensitive diagnostic context.
+    stderr_tail: Arc<StdMutex<VecDeque<String>>>,
 }
 
 /// Runtime info about the clamped Claude Code subprocess.
@@ -304,6 +312,12 @@ pub enum ClampError {
     #[error("control request failed: {0}")]
     ControlError(String),
 
+    #[error("Claude Code subscription authentication is unavailable")]
+    AuthenticationUnavailable,
+
+    #[error("Claude Code reported a failed result")]
+    TurnFailed,
+
     #[error("transport closed")]
     Closed,
 
@@ -332,13 +346,28 @@ impl ClampTransport {
             .take()
             .ok_or_else(|| ClampError::Protocol("no stdout on child".to_string()))?;
 
-        // Drain stderr in background
+        let stderr_tail = Arc::new(StdMutex::new(VecDeque::new()));
+
+        // Drain stderr in the background. Keep only a small bounded tail for
+        // failure classification; never expose the captured text directly.
         if let Some(stderr) = child.stderr.take() {
+            let stderr_tail = Arc::clone(&stderr_tail);
             tokio::spawn(async move {
                 let reader = BufReader::new(stderr);
                 let mut lines = reader.lines();
                 while let Ok(Some(line)) = lines.next_line().await {
                     debug!(target: "chaos_clamp::stderr", "{}", line);
+                    let line = line
+                        .chars()
+                        .take(STDERR_TAIL_MAX_CHARS_PER_LINE)
+                        .collect::<String>();
+                    let mut tail = stderr_tail
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    if tail.len() == STDERR_TAIL_MAX_LINES {
+                        tail.pop_front();
+                    }
+                    tail.push_back(line);
                 }
             });
         }
@@ -362,6 +391,7 @@ impl ClampTransport {
             tool_permission_handler: config.tool_permission_handler,
             hook_callback_handler: config.hook_callback_handler,
             mcp_message_handler: config.mcp_message_handler,
+            stderr_tail,
         })
     }
 
@@ -381,8 +411,10 @@ impl ClampTransport {
         loop {
             let msg = tokio::time::timeout_at(deadline, self.message_rx.recv())
                 .await
-                .map_err(|_| ClampError::Timeout(id.clone()))?
-                .ok_or(ClampError::Closed)?;
+                .map_err(|_| ClampError::Timeout(id.clone()))?;
+            let Some(msg) = msg else {
+                return Err(self.closed_error().await);
+            };
 
             let Some(resp_id) = control_response_request_id(&msg) else {
                 if let Some(queued) = self.handle_message(msg).await? {
@@ -411,7 +443,7 @@ impl ClampTransport {
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown error")
                     .to_string();
-                return Err(ClampError::ControlError(err));
+                return Err(self.classify_control_error(err));
             }
             let result = response
                 .get("response")
@@ -469,15 +501,20 @@ impl ClampTransport {
         loop {
             tokio::select! {
                 result = &mut rx => {
-                    let result = result.map_err(|_| ClampError::Closed)?;
-                    return result.map_err(ClampError::ControlError);
+                    let result = match result {
+                        Ok(result) => result,
+                        Err(_) => return Err(self.closed_error().await),
+                    };
+                    return result.map_err(|err| self.classify_control_error(err));
                 }
                 _ = &mut timeout => {
                     self.pending.remove(&id);
                     return Err(ClampError::Timeout(id));
                 }
                 maybe_msg = self.message_rx.recv() => {
-                    let msg = maybe_msg.ok_or(ClampError::Closed)?;
+                    let Some(msg) = maybe_msg else {
+                        return Err(self.closed_error().await);
+                    };
                     if let Some(queued) = self.handle_message(msg).await? {
                         self.queued_messages.push_back(queued);
                     }
@@ -501,10 +538,20 @@ impl ClampTransport {
 
             let msg = match self.message_rx.recv().await {
                 Some(msg) => msg,
-                None => return Ok(None),
+                None => return Err(self.closed_error().await),
             };
 
             if let Some(message) = self.handle_message(msg).await? {
+                if let Message::Result {
+                    result,
+                    subtype,
+                    is_error,
+                    ..
+                } = &message
+                    && result_indicates_error(subtype.as_deref(), *is_error)
+                {
+                    return Err(self.classify_result_error(result));
+                }
                 return Ok(Some(message));
             }
         }
@@ -542,6 +589,38 @@ impl ClampTransport {
     fn next_request_id(&self) -> String {
         let n = self.request_counter.fetch_add(1, Ordering::Relaxed);
         format!("chaos_req_{n}")
+    }
+
+    async fn closed_error(&self) -> ClampError {
+        // Give the stderr drain task one scheduling turn to record diagnostics
+        // emitted immediately before the subprocess closed stdout.
+        tokio::task::yield_now().await;
+        if stderr_indicates_auth_failure(&self.stderr_tail) {
+            ClampError::AuthenticationUnavailable
+        } else {
+            ClampError::Closed
+        }
+    }
+
+    fn classify_control_error(&self, error: String) -> ClampError {
+        if text_indicates_auth_failure(&error) || stderr_indicates_auth_failure(&self.stderr_tail) {
+            ClampError::AuthenticationUnavailable
+        } else {
+            ClampError::ControlError(error)
+        }
+    }
+
+    fn classify_result_error(&self, result: &Value) -> ClampError {
+        let result = result
+            .as_str()
+            .map(str::to_owned)
+            .unwrap_or_else(|| result.to_string());
+        if text_indicates_auth_failure(&result) || stderr_indicates_auth_failure(&self.stderr_tail)
+        {
+            ClampError::AuthenticationUnavailable
+        } else {
+            ClampError::TurnFailed
+        }
     }
 
     async fn write_json(&mut self, value: &Value) -> Result<(), ClampError> {
@@ -583,12 +662,16 @@ impl ClampTransport {
             Message::Result {
                 session_id: Some(session_id),
                 result,
+                subtype,
+                is_error,
                 total_cost_usd,
                 usage,
             } => {
                 self.session_id = session_id.clone();
                 Ok(Some(Message::Result {
                     result,
+                    subtype,
+                    is_error,
                     total_cost_usd,
                     session_id: Some(session_id),
                     usage,
@@ -731,6 +814,33 @@ impl ClampTransport {
     }
 }
 
+fn stderr_indicates_auth_failure(stderr_tail: &StdMutex<VecDeque<String>>) -> bool {
+    let tail = stderr_tail
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    tail.iter().any(|line| text_indicates_auth_failure(line))
+}
+
+fn text_indicates_auth_failure(text: &str) -> bool {
+    let text = text.to_ascii_lowercase();
+    [
+        "not logged in",
+        "not authenticated",
+        "authentication required",
+        "authentication failed",
+        "oauth token",
+        "invalid api key",
+        "please run /login",
+        "please run claude auth login",
+    ]
+    .iter()
+    .any(|marker| text.contains(marker))
+}
+
+fn result_indicates_error(subtype: Option<&str>, is_error: bool) -> bool {
+    is_error || subtype.is_some_and(|subtype| subtype != "success")
+}
+
 fn control_response_request_id(msg: &Message) -> Option<&str> {
     let Message::ControlResponse { response } = msg else {
         return None;
@@ -831,6 +941,43 @@ async fn read_stdout(stdout: ChildStdout, tx: mpsc::Sender<Message>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn explicit_missing_cli_path_is_distinguishable() {
+        let config = ClampConfig {
+            cli_path: Some(PathBuf::from("/definitely/not/a/real/claude-code-binary")),
+            ..Default::default()
+        };
+
+        assert!(matches!(
+            find_claude_cli(&config),
+            Err(ClampError::CliNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn authentication_failures_are_classified_without_exposing_stderr() {
+        assert!(text_indicates_auth_failure(
+            "Not logged in. Please run claude auth login."
+        ));
+        assert!(text_indicates_auth_failure(
+            "Authentication failed: invalid OAuth token"
+        ));
+        assert!(!text_indicates_auth_failure(
+            "unexpected control protocol response"
+        ));
+    }
+
+    #[test]
+    fn failed_result_detection_preserves_legacy_success_messages() {
+        assert!(result_indicates_error(Some("error_during_execution"), true));
+        assert!(result_indicates_error(
+            Some("error_during_execution"),
+            false
+        ));
+        assert!(!result_indicates_error(Some("success"), false));
+        assert!(!result_indicates_error(None, false));
+    }
 
     #[test]
     fn default_tool_permission_allow_preserves_input() {


### PR DESCRIPTION
## What changed

- add a root-level `clamp` config key, including `-c clamp=true` overrides
- initialize `chaos exec` model clients as clamped before the first turn, including resumed exec sessions
- keep interactive clamp controls unchanged
- fail clamped turns without falling back to direct API transport
- emit stable markers for missing CLI, unavailable subscription auth, startup failures, and runtime failures
- treat Claude Code error-result JSON and unexpected subprocess EOF as failures
- document headless clamp usage and resume semantics in the README

Closes #20.

## Why

Hosted agents use `chaos exec`, but clamp was previously reachable only through interactive TUI/console controls. Headless processes therefore could not use the Claude Code subscription transport. This enables subscription-backed exec sessions while making failure explicit so a requested clamp cannot silently move billing to the direct API transport.

## How to verify

```bash
rustup run 1.97.0 cargo fmt --all -- --check
rustup run 1.97.0 cargo test -p chaos-clamp --lib
rustup run 1.97.0 cargo test -p chaos-kern runtime_config_defaults_clamp_to_false_and_parses_true --lib
rustup run 1.97.0 cargo test -p chaos-kern config_builder_applies_clamp_cli_override --lib
rustup run 1.97.0 cargo test -p chaos-kern model_client_can_start_clamped_before_the_first_turn --lib
rustup run 1.97.0 cargo test -p chaos-kern --no-run --quiet
```

- [x] Focused tests pass locally on macOS/aarch64
- [ ] Full CI passes on all target hardware
