### PR TITLE
feat: bridge Antigravity through Chaos clamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,6 +1330,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "which",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -85,9 +85,11 @@ The clamp module also has an experimental Google Antigravity backend. It invokes
 the official `agy` CLI in sandboxed print mode, keeps authentication in an
 isolated `agy` home, and removes `GEMINI_API_KEY` and `GOOGLE_API_KEY` from the
 subprocess environment so a failed subscription connection cannot silently
-fall back to metered API billing. This first implementation is model-only:
-Antigravity's built-in tools are not yet bridged through Chaos, and Chaos does
-not auto-approve them.
+fall back to metered API billing. Chaos writes a managed MCP configuration for
+each dedicated home, denies Antigravity's native command, filesystem, and URL
+tools, and exposes the session-scoped Chaos tool bridge as `agy`'s sole action
+surface. The bridge socket and capability token are inherited through the
+invocation environment and are never persisted in Antigravity configuration.
 
 API key users connect directly through the kernel — no clamping needed.
 
@@ -122,9 +124,11 @@ sessions must pass both `-c clamp=true` and any non-default
 `-c clamp_backend=...` selection again. Antigravity resumes must also pass the
 same `-m` model selection used for the original process. `CHAOS_AGY_PATH` can
 pin an explicit `agy` binary, while `CHAOS_AGY_HOME` selects its private
-authenticated state. If the selected CLI is missing, unauthenticated, or fails
-during a turn, the exec command fails instead of falling back to direct API
-billing.
+authenticated state. The home must be dedicated to Chaos because each turn
+replaces its effective MCP server list and permission policy with the
+fail-closed Chaos configuration. If the selected CLI is missing,
+unauthenticated, cannot establish the managed bridge, or fails during a turn,
+the exec command fails instead of falling back to direct API billing.
 
 Operators are responsible for confirming that their subscription and chosen
 first-party CLI usage comply with the provider terms that apply to them.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ discovery disabled, strips its built-in tools, and connects through MCP. FreeCha
 provides the tools. FreeChaOS hooks into the lifecycle. Claude Code becomes the
 transport.
 
+The clamp module also has an experimental Google Antigravity backend. It invokes
+the official `agy` CLI in sandboxed print mode, keeps authentication in an
+isolated `agy` home, and removes `GEMINI_API_KEY` and `GOOGLE_API_KEY` from the
+subprocess environment so a failed subscription connection cannot silently
+fall back to metered API billing. This first implementation is model-only:
+Antigravity's built-in tools are not yet bridged through Chaos, and Chaos does
+not auto-approve them.
+
 API key users connect directly through the kernel — no clamping needed.
 
 Headless `chaos exec` sessions can request the clamped transport through the
@@ -89,14 +97,47 @@ layered configuration:
 ```bash
 chaos exec --json -c clamp=true -m claude-sonnet-4-5 "say ok"
 chaos exec --json -c clamp=true resume <process_id> "continue"
+
+CHAOS_AGY_HOME=/private/antigravity-state \
+  chaos exec --json \
+  -c clamp=true \
+  -c clamp_backend=antigravity \
+  -m gemini-3.1-pro-preview \
+  "say ok"
+```
+
+Authenticate and inspect the isolated Antigravity state through Chaos:
+
+```bash
+export CHAOS_AGY_HOME=/private/antigravity-state
+export CHAOS_AGY_PATH=/opt/antigravity/bin/agy # optional when agy is in PATH
+
+chaos clamp antigravity connect
+chaos clamp antigravity status --json
+chaos clamp antigravity disconnect
 ```
 
 The effective config for each invocation governs its transport, so resumed
-sessions must pass `-c clamp=true` again. If Claude Code is missing,
-unauthenticated, or fails during a turn, the exec command fails instead of
-falling back to direct API billing.
+sessions must pass both `-c clamp=true` and any non-default
+`-c clamp_backend=...` selection again. Antigravity resumes must also pass the
+same `-m` model selection used for the original process. `CHAOS_AGY_PATH` can
+pin an explicit `agy` binary, while `CHAOS_AGY_HOME` selects its private
+authenticated state. If the selected CLI is missing, unauthenticated, or fails
+during a turn, the exec command fails instead of falling back to direct API
+billing.
 
-This architecture is correct usage of both providers' terms of service.
+Operators are responsible for confirming that their subscription and chosen
+first-party CLI usage comply with the provider terms that apply to them.
+
+For a remote service such as souls.house, keep `CHAOS_AGY_HOME` on a persistent
+private volume, run `connect` once in an operator-controlled environment, and
+use `status --json` as the readiness boundary. Each worker must receive the
+same `CHAOS_AGY_HOME`, `CHAOS_AGY_PATH`, and clamp configuration. Preserve the
+Chaos process ID between requests and invoke `chaos exec ... resume
+<process_id>` with the original `-m` selection so Chaos can restore the matching
+provider conversation. Do not copy browser authorization codes into
+configuration or logs; only the credential state produced by the official CLI
+belongs on the private volume.
 
 ---
 

--- a/bin/chaos/Cargo.toml
+++ b/bin/chaos/Cargo.toml
@@ -52,6 +52,7 @@ tokio = { workspace = true, features = [
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+which = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 alcatraz-linux = { workspace = true }

--- a/bin/chaos/src/clamp_cmd.rs
+++ b/bin/chaos/src/clamp_cmd.rs
@@ -76,7 +76,7 @@ async fn run_antigravity(cli: AntigravityCli) -> anyhow::Result<()> {
                     "  Authentication: {}",
                     status["authentication_state"].as_str().unwrap_or("unknown")
                 );
-                println!("  Tool authority: model-only-sandboxed");
+                println!("  Tool authority: chaos-session-bridge");
             }
             Ok(())
         }
@@ -116,7 +116,7 @@ fn antigravity_status() -> serde_json::Value {
         } else {
             "none"
         },
-        "tool_authority": "model-only-sandboxed",
+        "tool_authority": "chaos-session-bridge",
         "capabilities": {
             "exec": true,
             "chaos_resume": true,
@@ -124,7 +124,7 @@ fn antigravity_status() -> serde_json::Value {
             "connect": true,
             "disconnect": true,
             "incremental_output": false,
-            "chaos_tool_bridge": false,
+            "chaos_tool_bridge": true,
         }
     })
 }
@@ -132,8 +132,8 @@ fn antigravity_status() -> serde_json::Value {
 async fn antigravity_connect() -> anyhow::Result<()> {
     let cli_path = antigravity_cli_path()
         .context("Antigravity CLI not found; set CHAOS_AGY_PATH or install agy in PATH")?;
-    let home =
-        antigravity_home().context("Antigravity home unavailable; set CHAOS_AGY_HOME or HOME")?;
+    let home = antigravity_home()
+        .context("Antigravity home unavailable; set CHAOS_AGY_HOME to a dedicated directory")?;
     std::fs::create_dir_all(&home)
         .with_context(|| format!("create Antigravity home {}", home.display()))?;
     #[cfg(unix)]
@@ -159,8 +159,8 @@ async fn antigravity_connect() -> anyhow::Result<()> {
 }
 
 fn antigravity_disconnect() -> anyhow::Result<()> {
-    let home =
-        antigravity_home().context("Antigravity home unavailable; set CHAOS_AGY_HOME or HOME")?;
+    let home = antigravity_home()
+        .context("Antigravity home unavailable; set CHAOS_AGY_HOME to a dedicated directory")?;
     let token_path = antigravity_token_path(&home);
     match std::fs::remove_file(&token_path) {
         Ok(()) => {}
@@ -197,9 +197,7 @@ fn antigravity_cli_path() -> Option<PathBuf> {
 }
 
 fn antigravity_home() -> Option<PathBuf> {
-    std::env::var_os("CHAOS_AGY_HOME")
-        .or_else(|| std::env::var_os("HOME"))
-        .map(PathBuf::from)
+    std::env::var_os("CHAOS_AGY_HOME").map(PathBuf::from)
 }
 
 fn antigravity_token_path(home: &Path) -> PathBuf {

--- a/bin/chaos/src/clamp_cmd.rs
+++ b/bin/chaos/src/clamp_cmd.rs
@@ -1,0 +1,223 @@
+//! Machine-readable lifecycle boundary for first-party clamp transports.
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use clap::Args;
+use clap::Subcommand;
+use serde_json::json;
+
+#[derive(Debug, Args)]
+pub(crate) struct ClampCli {
+    #[command(subcommand)]
+    command: ClampCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum ClampCommand {
+    /// Inspect the Google Antigravity clamp transport.
+    Antigravity(AntigravityCli),
+}
+
+#[derive(Debug, Args)]
+struct AntigravityCli {
+    #[command(subcommand)]
+    command: AntigravityCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum AntigravityCommand {
+    /// Report transport availability, version, authentication state, and capabilities.
+    Status {
+        /// Emit one JSON object.
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
+    /// Run the official Antigravity browser sign-in ceremony.
+    Connect,
+    /// Remove Antigravity credentials and Chaos provider-conversation mappings.
+    Disconnect {
+        /// Emit one JSON object.
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
+}
+
+impl ClampCli {
+    pub(crate) async fn run(self) -> anyhow::Result<()> {
+        match self.command {
+            ClampCommand::Antigravity(command) => run_antigravity(command).await,
+        }
+    }
+}
+
+async fn run_antigravity(cli: AntigravityCli) -> anyhow::Result<()> {
+    match cli.command {
+        AntigravityCommand::Status { json } => {
+            let status = antigravity_status();
+            if json {
+                println!("{}", serde_json::to_string(&status)?);
+            } else {
+                println!("Antigravity clamp");
+                println!(
+                    "  CLI: {}",
+                    if status["available"] == true {
+                        "available"
+                    } else {
+                        "unavailable"
+                    }
+                );
+                println!(
+                    "  Version: {}",
+                    status["version"].as_str().unwrap_or("unknown")
+                );
+                println!(
+                    "  Authentication: {}",
+                    status["authentication_state"].as_str().unwrap_or("unknown")
+                );
+                println!("  Tool authority: model-only-sandboxed");
+            }
+            Ok(())
+        }
+        AntigravityCommand::Connect => antigravity_connect().await,
+        AntigravityCommand::Disconnect { json } => {
+            antigravity_disconnect()?;
+            if json {
+                println!(
+                    "{}",
+                    json!({
+                        "backend": "antigravity",
+                        "authentication_state": "none",
+                    })
+                );
+            } else {
+                println!("Disconnected the Antigravity clamp account.");
+            }
+            Ok(())
+        }
+    }
+}
+
+fn antigravity_status() -> serde_json::Value {
+    let cli_path = antigravity_cli_path();
+    let version = cli_path.as_deref().and_then(antigravity_version);
+    let credential_present = antigravity_home()
+        .map(|home| antigravity_token_path(&home))
+        .and_then(|path| std::fs::metadata(path).ok())
+        .is_some_and(|metadata| metadata.is_file() && metadata.len() > 0);
+
+    json!({
+        "backend": "antigravity",
+        "available": cli_path.is_some(),
+        "version": version,
+        "authentication_state": if credential_present {
+            "credential-present"
+        } else {
+            "none"
+        },
+        "tool_authority": "model-only-sandboxed",
+        "capabilities": {
+            "exec": true,
+            "chaos_resume": true,
+            "provider_conversation_resume": true,
+            "connect": true,
+            "disconnect": true,
+            "incremental_output": false,
+            "chaos_tool_bridge": false,
+        }
+    })
+}
+
+async fn antigravity_connect() -> anyhow::Result<()> {
+    let cli_path = antigravity_cli_path()
+        .context("Antigravity CLI not found; set CHAOS_AGY_PATH or install agy in PATH")?;
+    let home =
+        antigravity_home().context("Antigravity home unavailable; set CHAOS_AGY_HOME or HOME")?;
+    std::fs::create_dir_all(&home)
+        .with_context(|| format!("create Antigravity home {}", home.display()))?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&home, std::os::unix::fs::PermissionsExt::from_mode(0o700))?;
+
+    let status = tokio::process::Command::new(cli_path)
+        .arg("models")
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env_remove("GEMINI_API_KEY")
+        .env_remove("GOOGLE_API_KEY")
+        .status()
+        .await
+        .context("run Antigravity sign-in ceremony")?;
+    if !status.success() {
+        anyhow::bail!("Antigravity sign-in was not completed");
+    }
+    if !antigravity_token_path(&home).is_file() {
+        anyhow::bail!("Antigravity exited successfully but no credential state was created");
+    }
+    println!("Antigravity account connected.");
+    Ok(())
+}
+
+fn antigravity_disconnect() -> anyhow::Result<()> {
+    let home =
+        antigravity_home().context("Antigravity home unavailable; set CHAOS_AGY_HOME or HOME")?;
+    let token_path = antigravity_token_path(&home);
+    match std::fs::remove_file(&token_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("remove Antigravity token {}", token_path.display()));
+        }
+    }
+    let conversation_dir = home.join(".chaos-conversations");
+    match std::fs::remove_dir_all(&conversation_dir) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "remove Antigravity conversation mappings {}",
+                    conversation_dir.display()
+                )
+            });
+        }
+    }
+    Ok(())
+}
+
+fn antigravity_cli_path() -> Option<PathBuf> {
+    match std::env::var_os("CHAOS_AGY_PATH") {
+        Some(path) => {
+            let path = PathBuf::from(path);
+            path.is_file().then_some(path)
+        }
+        None => which::which("agy").ok(),
+    }
+}
+
+fn antigravity_home() -> Option<PathBuf> {
+    std::env::var_os("CHAOS_AGY_HOME")
+        .or_else(|| std::env::var_os("HOME"))
+        .map(PathBuf::from)
+}
+
+fn antigravity_token_path(home: &Path) -> PathBuf {
+    home.join(".gemini")
+        .join("antigravity-cli")
+        .join("antigravity-oauth-token")
+}
+
+fn antigravity_version(cli_path: &Path) -> Option<String> {
+    let output = std::process::Command::new(cli_path)
+        .arg("--version")
+        .env_remove("GEMINI_API_KEY")
+        .env_remove("GOOGLE_API_KEY")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!version.is_empty()).then_some(version)
+}

--- a/bin/chaos/src/main.rs
+++ b/bin/chaos/src/main.rs
@@ -29,10 +29,12 @@ use owo_colors::OwoColorize;
 use std::io::IsTerminal;
 use supports_color::Stream;
 
+mod clamp_cmd;
 mod debug_logging;
 mod mcp_cmd;
 mod models_cmd;
 
+use crate::clamp_cmd::ClampCli;
 use crate::mcp_cmd::McpCli;
 use crate::models_cmd::ModelsCli;
 
@@ -84,6 +86,9 @@ enum Subcommand {
     /// Manage provider accounts and connections.
     #[clap(visible_alias = "login")]
     Accounts(AccountsCommand),
+
+    /// Inspect and manage first-party clamp transports.
+    Clamp(ClampCli),
 
     /// Disconnect stored provider accounts.
     Logout(LogoutCommand),
@@ -414,6 +419,9 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                     }
                 }
             }
+        }
+        Some(Subcommand::Clamp(clamp_cli)) => {
+            clamp_cli.run().await?;
         }
         Some(Subcommand::Logout(mut logout_cli)) => {
             prepend_root_flags!(logout_cli, root_config_overrides);

--- a/bin/chaos/tests/clamp_antigravity.rs
+++ b/bin/chaos/tests/clamp_antigravity.rs
@@ -1,0 +1,239 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::Result;
+use pretty_assertions::assert_eq;
+use serde_json::Value as JsonValue;
+use tempfile::TempDir;
+
+mod common;
+
+#[cfg(unix)]
+fn write_fake_agy(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::write(
+        path,
+        r#"#!/bin/sh
+set -eu
+
+case "${1:-}" in
+  --version)
+    printf 'agy-test 1.2.3\n'
+    ;;
+  models)
+    test -z "${GEMINI_API_KEY+x}"
+    test -z "${GOOGLE_API_KEY+x}"
+    test "${XDG_CONFIG_HOME:-}" = "$HOME/.config"
+    mkdir -p "$HOME/.gemini/antigravity-cli"
+    printf 'test credential\n' > "$HOME/.gemini/antigravity-cli/antigravity-oauth-token"
+    ;;
+  *)
+    case "$*" in
+      *"--conversation conversation-e2e"*) response=CHAOS_AGY_RESUMED ;;
+      *) response=CHAOS_AGY_FRESH ;;
+    esac
+    printf '{"event":"init","conversation_id":"conversation-e2e","init":{"model":"gemini-3.1-pro-low","permission_mode":"request-review"}}\n'
+    printf '{"event":"result","result":{"conversation_id":"conversation-e2e","status":"SUCCESS","response":"%s","usage":{"input_tokens":10,"output_tokens":2,"thinking_tokens":3,"cache_read_tokens":4,"total_tokens":19}}}\n' "$response"
+    ;;
+esac
+"#,
+    )?;
+    let mut permissions = fs::metadata(path)?.permissions();
+    permissions.set_mode(0o700);
+    fs::set_permissions(path, permissions)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn status_reports_cli_version_and_isolated_credential_state() -> Result<()> {
+    let fixture = TempDir::new()?;
+    let chaos_home = fixture.path().join("chaos");
+    let agy_home = fixture.path().join("antigravity");
+    let agy_path = fixture.path().join("agy");
+    write_fake_agy(&agy_path)?;
+
+    let token_path = agy_home
+        .join(".gemini")
+        .join("antigravity-cli")
+        .join("antigravity-oauth-token");
+    fs::create_dir_all(token_path.parent().expect("token parent"))?;
+    fs::write(&token_path, "test credential\n")?;
+
+    let output = common::chaos_command(&chaos_home)?
+        .args(["clamp", "antigravity", "status", "--json"])
+        .env("CHAOS_AGY_PATH", &agy_path)
+        .env("CHAOS_AGY_HOME", &agy_home)
+        .output()?;
+    assert!(output.status.success());
+
+    let status: JsonValue = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(status["backend"], "antigravity");
+    assert_eq!(status["available"], true);
+    assert_eq!(status["version"], "agy-test 1.2.3");
+    assert_eq!(status["authentication_state"], "credential-present");
+    assert_eq!(status["tool_authority"], "model-only-sandboxed");
+    assert_eq!(status["capabilities"]["provider_conversation_resume"], true);
+    assert_eq!(status["capabilities"]["incremental_output"], false);
+    assert_eq!(status["capabilities"]["chaos_tool_bridge"], false);
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn connect_uses_isolated_home_and_removes_metered_api_keys() -> Result<()> {
+    let fixture = TempDir::new()?;
+    let chaos_home = fixture.path().join("chaos");
+    let agy_home = fixture.path().join("antigravity");
+    let agy_path = fixture.path().join("agy");
+    write_fake_agy(&agy_path)?;
+
+    common::chaos_command(&chaos_home)?
+        .args(["clamp", "antigravity", "connect"])
+        .env("CHAOS_AGY_PATH", &agy_path)
+        .env("CHAOS_AGY_HOME", &agy_home)
+        .env("GEMINI_API_KEY", "must-not-reach-agy")
+        .env("GOOGLE_API_KEY", "must-not-reach-agy")
+        .assert()
+        .success();
+
+    assert!(
+        agy_home
+            .join(".gemini")
+            .join("antigravity-cli")
+            .join("antigravity-oauth-token")
+            .is_file()
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn disconnect_removes_managed_state_but_preserves_unrelated_files() -> Result<()> {
+    let fixture = TempDir::new()?;
+    let chaos_home = fixture.path().join("chaos");
+    let agy_home = fixture.path().join("antigravity");
+    let token_path = agy_home
+        .join(".gemini")
+        .join("antigravity-cli")
+        .join("antigravity-oauth-token");
+    let conversation_dir = agy_home.join(".chaos-conversations");
+    let unrelated_path = agy_home.join("keep-me");
+    fs::create_dir_all(token_path.parent().expect("token parent"))?;
+    fs::create_dir_all(&conversation_dir)?;
+    fs::write(&token_path, "test credential\n")?;
+    fs::write(conversation_dir.join("process.json"), "{}")?;
+    fs::write(&unrelated_path, "unrelated\n")?;
+
+    let output = common::chaos_command(&chaos_home)?
+        .args(["clamp", "antigravity", "disconnect", "--json"])
+        .env("CHAOS_AGY_HOME", &agy_home)
+        .output()?;
+    assert!(output.status.success());
+    let status: JsonValue = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(status["authentication_state"], "none");
+
+    assert!(!token_path.exists());
+    assert!(!conversation_dir.exists());
+    assert!(unrelated_path.is_file());
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn exec_resumes_the_provider_conversation_across_processes() -> Result<()> {
+    let fixture = TempDir::new()?;
+    let chaos_home = fixture.path().join("chaos");
+    let agy_home = fixture.path().join("antigravity");
+    let agy_path = fixture.path().join("agy");
+    write_fake_agy(&agy_path)?;
+    fs::create_dir_all(&chaos_home)?;
+    fs::create_dir_all(&agy_home)?;
+
+    let mut fresh = common::chaos_command(&chaos_home)?;
+    let fresh = fresh
+        .args([
+            "exec",
+            "--json",
+            "--skip-git-repo-check",
+            "-c",
+            "clamp=true",
+            "-c",
+            "clamp_backend=antigravity",
+            "-m",
+            "gemini-3.1-pro-preview",
+            "start",
+        ])
+        .env("CHAOS_AGY_PATH", &agy_path)
+        .env("CHAOS_AGY_HOME", &agy_home)
+        .output()?;
+    assert!(
+        fresh.status.success(),
+        "fresh exec failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&fresh.stdout),
+        String::from_utf8_lossy(&fresh.stderr)
+    );
+    let fresh_events = parse_jsonl(&fresh.stdout)?;
+    let process_id = fresh_events
+        .iter()
+        .find(|event| event["type"] == "process.started")
+        .and_then(|event| event["process_id"].as_str())
+        .expect("fresh process id");
+    assert_agent_message(&fresh_events, "CHAOS_AGY_FRESH");
+
+    let state_path = agy_home
+        .join(".chaos-conversations")
+        .join(format!("{process_id}.json"));
+    assert!(state_path.is_file());
+
+    let mut resumed = common::chaos_command(&chaos_home)?;
+    let resumed = resumed
+        .args([
+            "exec",
+            "--json",
+            "--skip-git-repo-check",
+            "-c",
+            "clamp=true",
+            "-c",
+            "clamp_backend=antigravity",
+            "-m",
+            "gemini-3.1-pro-preview",
+            "resume",
+            process_id,
+            "continue",
+        ])
+        .env("CHAOS_AGY_PATH", &agy_path)
+        .env("CHAOS_AGY_HOME", &agy_home)
+        .output()?;
+    assert!(
+        resumed.status.success(),
+        "resumed exec failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&resumed.stdout),
+        String::from_utf8_lossy(&resumed.stderr)
+    );
+    let resumed_events = parse_jsonl(&resumed.stdout)?;
+    assert_agent_message(&resumed_events, "CHAOS_AGY_RESUMED");
+    assert!(
+        resumed_events
+            .iter()
+            .all(|event| event["type"] != "turn.failed")
+    );
+    Ok(())
+}
+
+fn parse_jsonl(output: &[u8]) -> Result<Vec<JsonValue>> {
+    String::from_utf8(output.to_vec())?
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| Ok(serde_json::from_str(line)?))
+        .collect()
+}
+
+fn assert_agent_message(events: &[JsonValue], expected: &str) {
+    assert!(events.iter().any(|event| {
+        event["type"] == "item.completed"
+            && event["item"]["type"] == "agent_message"
+            && event["item"]["text"] == expected
+    }));
+}

--- a/bin/chaos/tests/clamp_antigravity.rs
+++ b/bin/chaos/tests/clamp_antigravity.rs
@@ -29,6 +29,14 @@ case "${1:-}" in
     printf 'test credential\n' > "$HOME/.gemini/antigravity-cli/antigravity-oauth-token"
     ;;
   *)
+    test -n "${CHAOS_CLAMP_MCP_SOCKET:-}"
+    test -n "${CHAOS_CLAMP_MCP_TOKEN:-}"
+    test -f "$HOME/.gemini/config/mcp_config.json"
+    test -f "$HOME/.gemini/antigravity-cli/settings.json"
+    grep -q '"clamp-session-bridge"' "$HOME/.gemini/config/mcp_config.json"
+    ! grep -q 'CHAOS_CLAMP_MCP_' "$HOME/.gemini/config/mcp_config.json"
+    grep -q 'mcp(chaos/\*)' "$HOME/.gemini/antigravity-cli/settings.json"
+    grep -q 'command(\*)' "$HOME/.gemini/antigravity-cli/settings.json"
     case "$*" in
       *"--conversation conversation-e2e"*) response=CHAOS_AGY_RESUMED ;;
       *) response=CHAOS_AGY_FRESH ;;
@@ -73,10 +81,10 @@ fn status_reports_cli_version_and_isolated_credential_state() -> Result<()> {
     assert_eq!(status["available"], true);
     assert_eq!(status["version"], "agy-test 1.2.3");
     assert_eq!(status["authentication_state"], "credential-present");
-    assert_eq!(status["tool_authority"], "model-only-sandboxed");
+    assert_eq!(status["tool_authority"], "chaos-session-bridge");
     assert_eq!(status["capabilities"]["provider_conversation_resume"], true);
     assert_eq!(status["capabilities"]["incremental_output"], false);
-    assert_eq!(status["capabilities"]["chaos_tool_bridge"], false);
+    assert_eq!(status["capabilities"]["chaos_tool_bridge"], true);
     Ok(())
 }
 
@@ -104,6 +112,35 @@ fn connect_uses_isolated_home_and_removes_metered_api_keys() -> Result<()> {
             .join("antigravity-cli")
             .join("antigravity-oauth-token")
             .is_file()
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn connect_requires_an_explicit_dedicated_home() -> Result<()> {
+    let fixture = TempDir::new()?;
+    let chaos_home = fixture.path().join("chaos");
+    let agy_path = fixture.path().join("agy");
+    write_fake_agy(&agy_path)?;
+
+    let output = common::chaos_command(&chaos_home)?
+        .args(["clamp", "antigravity", "connect"])
+        .env("CHAOS_AGY_PATH", &agy_path)
+        .env_remove("CHAOS_AGY_HOME")
+        .output()?;
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("set CHAOS_AGY_HOME to a dedicated directory")
+    );
+    assert!(
+        !chaos_home
+            .join(".gemini")
+            .join("antigravity-cli")
+            .join("antigravity-oauth-token")
+            .exists()
     );
     Ok(())
 }

--- a/docs/antigravity-full-chaos-clamp-plan.md
+++ b/docs/antigravity-full-chaos-clamp-plan.md
@@ -7,6 +7,9 @@
 **Status:** real Chaos bridge proven for fresh and cross-process resumed turns;
 implementation and regression review in progress
 
+The user-facing provider-risk and architecture documentation is
+[`antigravity-oauth-risk-and-design.md`](antigravity-oauth-risk-and-design.md).
+
 ## Purpose
 
 The Antigravity clamp is useful only if a Gemini resident retains the practical

--- a/docs/antigravity-full-chaos-clamp-plan.md
+++ b/docs/antigravity-full-chaos-clamp-plan.md
@@ -1,0 +1,415 @@
+# Antigravity full-Chaos clamp plan
+
+**Date:** 2026-08-11  
+**Branch:** `feat/antigravity-clamp`  
+**Issue:** #26  
+**Withdrawn proof-of-concept:** #25  
+**Status:** MCP feasibility proven outside the repository; real Chaos bridge
+integration not yet proven
+
+## Purpose
+
+The Antigravity clamp is useful only if a Gemini resident retains the practical
+agency it has on the direct Chaos provider path. Successful OAuth-authenticated
+model output and provider-conversation resume are necessary but not sufficient.
+
+The acceptance criterion is:
+
+> A subscription-authenticated `agy` process can perform an iterative model
+> turn using the real tools, permissions, events, and session lifecycle owned
+> by Chaos, without direct use of Antigravity OAuth credentials by Chaos and
+> without granting Antigravity's native tools independent authority.
+
+Do not reopen a pull request while the backend remains model-only.
+
+## Existing branch foundation
+
+Commit `70048a3ec` currently provides:
+
+- the `AntigravityTransport` subprocess wrapper;
+- Google consumer OAuth lifecycle commands delegated to the official `agy`
+  binary;
+- isolated `CHAOS_AGY_HOME` state;
+- removal of `GEMINI_API_KEY` and `GOOGLE_API_KEY`;
+- model and effort mapping;
+- JSONL parsing and normalized final response/usage;
+- provider-conversation resume across separate Chaos processes;
+- fake-executable integration tests and an ignored live smoke test.
+
+These pieces should be retained where they still fit. They are not by
+themselves evidence of a usable Souls.house resident transport.
+
+## Proven MCP spike
+
+The runnable development evidence lives outside Git worktrees at:
+
+```text
+~/.local/share/mira-antigravity-spike
+```
+
+Do not move OAuth state, browser return codes, or tokens into the repository.
+
+Tested artifact:
+
+- `agy 1.1.11`
+- macOS arm64
+- Google consumer OAuth account
+- `gemini-3.1-pro-low`
+
+On 2026-08-11, print-mode `agy` successfully:
+
+1. loaded an MCP server;
+2. exposed its tool to the model;
+3. requested that tool during an agent turn;
+4. passed the MCP arguments to the server;
+5. received the result;
+6. continued the model turn with the result;
+7. emitted tool start/completion JSONL steps and a final response.
+
+The successful invocation used:
+
+- `--sandbox`;
+- no `--dangerously-skip-permissions`;
+- an exact allow rule for `mcp(chaos-spike/*)`;
+- explicit deny rules for native commands, filesystem access, unsandboxed
+  execution, and URL access.
+
+The evidence files are:
+
+```text
+mcp-bridge-smoke-6.jsonl
+mcp-echo-calls.jsonl
+home/.gemini/antigravity-cli/settings.json
+```
+
+The returned marker was:
+
+```text
+CHAOS_TOOL_CONFIRMED:AGY_CHAOS_MCP_OK
+```
+
+This proves MCP feasibility through the official OAuth-authenticated `agy`
+process. It does not yet prove that the existing Chaos bridge works under
+`agy`, that every Chaos tool schema is compatible, or that normalized Chaos
+events remain correct.
+
+## Intended architecture
+
+```text
+Chaos ModelClientSession
+  |
+  +-- ensure_clamp_mcp_bridge()
+  |     |
+  |     +-- session-scoped Unix socket
+  |     +-- random capability token
+  |
+  +-- write managed, non-secret agy configuration
+  |
+  +-- launch official agy
+        |
+        +-- Google consumer OAuth remains owned by agy
+        +-- CHAOS_CLAMP_MCP_SOCKET in process environment
+        +-- CHAOS_CLAMP_MCP_TOKEN in process environment
+        +-- native tool permissions denied
+        +-- only mcp(chaos/*) allowed
+        |
+        +-- spawn `chaos clamp-session-bridge`
+              |
+              +-- list real session tools
+              +-- execute them through Chaos
+              +-- return tool results to Gemini
+```
+
+The existing `clamp-session-bridge` and session socket are the preferred seam.
+Do not create a second Antigravity-specific tool execution protocol unless the
+existing bridge is proven incompatible.
+
+## Implementation sequence
+
+### 1. Make Antigravity configuration managed and non-secret
+
+Add a small configuration preparation layer to `chaos-clamp` or the kernel
+integration that writes only files owned by Chaos inside the dedicated
+`CHAOS_AGY_HOME`:
+
+- MCP configuration naming a `chaos` server whose command is the current Chaos
+  executable and whose arguments are `clamp-session-bridge`;
+- `agy` permission settings that allow only `mcp(chaos/*)` and deny native
+  command, filesystem, unsandboxed, and URL operations.
+
+Requirements:
+
+- do not write the bridge socket path or capability token to persistent config;
+- pass both through the parent `agy` environment so the MCP child inherits
+  them;
+- write files atomically with private permissions;
+- do not overwrite unrelated state in a non-dedicated home;
+- either require a dedicated managed home or merge only the fields Chaos owns;
+- validate effective configuration before launching `agy`;
+- fail closed if safe configuration cannot be established.
+
+First prove that `agy`-spawned stdio MCP children inherit the bridge
+environment. If they do not, use an ephemeral per-invocation config file or
+wrapper directory that is deleted after the turn. Do not persist the token.
+
+### 2. Reuse the session bridge in `stream_antigravity`
+
+Before launching an Antigravity turn:
+
+1. call `ensure_clamp_mcp_bridge()`;
+2. obtain the socket path and capability token;
+3. pass them into `AntigravityConfig`;
+4. export them only to the `agy` process;
+5. keep metered Gemini API-key variables removed.
+
+The bridge must expose the same effective session tools as the Claude Code
+clamp. Tool execution must continue to use Chaos approval policy, sandboxing,
+hooks, and event publication.
+
+### 3. Establish reliable model instructions
+
+The earlier transport-only custom agent declared `tools: []`. That disables the
+MCP route and must not be reused.
+
+The default `agy` agent successfully called MCP under the scoped permission
+policy. A custom agent with no `tools` field did not reliably use the MCP
+surface and attempted native file inspection before becoming stuck.
+
+Proceed in this order:
+
+1. use the default agent plus explicit full-prompt instructions and strict
+   permissions for the first real bridge proof;
+2. inspect the effective tool description and system behavior;
+3. only introduce a custom agent after a live test proves that its declared
+   tool configuration includes working dynamic MCP tools;
+4. treat permissions, not prompt text, as the security boundary.
+
+The model should be told:
+
+- Chaos MCP tools are its sole action surface;
+- native Antigravity tools are unavailable;
+- tool results are authoritative;
+- it may make multiple MCP calls before answering;
+- it should return the user-facing answer without Antigravity checkpoint or
+  timestamp boilerplate.
+
+### 4. Normalize tool activity
+
+Extend Antigravity JSONL parsing for observed tool steps:
+
+- `step_type: "tool"`;
+- `state: "ACTIVE"`, `"DONE"`, or `"ERROR"`;
+- `tool_name`;
+- structured parameters;
+- output or error.
+
+Do not guess undocumented fields. Unknown step types must remain forward
+compatible rather than failing the whole turn.
+
+Determine which tool events the Chaos session bridge already emits. Avoid
+duplicating tool start/completion events if bridge execution already publishes
+canonical Chaos events. The Antigravity parser may need tool steps mainly for:
+
+- detecting denied native-tool attempts;
+- classifying MCP failures;
+- proving that the result returned to the model;
+- transport diagnostics.
+
+### 5. Preserve resume semantics
+
+Every resumed operating-system process must recreate:
+
+- the MCP configuration;
+- scoped permission settings;
+- bridge socket and capability environment;
+- original model selection;
+- provider conversation ID.
+
+The provider conversation must not retain a stale bridge endpoint or capability
+token. Tool discovery and connection must be invocation-scoped even when model
+context is provider-resumed.
+
+### 6. Update capability reporting
+
+Do not report `chaos_tool_bridge: true` merely because configuration files were
+written.
+
+Report full bridge authority only after:
+
+- the bridge is configured;
+- the session MCP endpoint is available;
+- safe permission policy is active;
+- the runtime path has passed an actual tool round trip.
+
+Static `status` output may distinguish:
+
+- CLI/auth available;
+- MCP configuration support available;
+- runtime session bridge active only during a turn.
+
+## Required tests
+
+### Unit tests
+
+- managed MCP config contains the current Chaos executable and
+  `clamp-session-bridge`;
+- persistent config contains no bridge token or socket;
+- permission settings allow `mcp(chaos/*)`;
+- native command, filesystem, unsandboxed, and URL permissions are denied;
+- writes are atomic and private;
+- existing unrelated OAuth state is preserved;
+- API-key environment variables are removed;
+- bridge environment reaches the `agy` child;
+- tool JSONL steps parse without breaking unknown step types;
+- native-tool denial is classified separately from MCP failure.
+
+### Fake-`agy` integration tests
+
+- assert bridge socket/token exist in the `agy` environment;
+- inspect generated settings and MCP configuration;
+- emit MCP tool start/done/error-shaped JSONL;
+- complete a fresh and resumed turn;
+- verify secrets do not appear in normalized output.
+
+### Live MCP transport test
+
+Use a deterministic local MCP tool and the authenticated isolated home:
+
+- one tool call;
+- multiple sequential tool calls;
+- tool error followed by model recovery;
+- native filesystem or shell attempt denied;
+- final answer derived from the tool result.
+
+### Live full-Chaos test
+
+Run the actual Chaos binary and existing session MCP bridge:
+
+1. start `chaos exec --json` with Antigravity clamping;
+2. require Gemini to invoke a harmless deterministic Chaos tool;
+3. verify canonical Chaos tool events;
+4. verify the final answer contains information available only from the tool;
+5. resume the same Chaos process from a new OS process;
+6. require another tool call;
+7. verify provider context and tool access both survived.
+
+This is the minimum proof required before reopening a PR.
+
+### Regression tests
+
+- Claude Code clamp behavior remains unchanged;
+- direct Gemini API behavior remains unchanged;
+- Anthropic and Gemini API keys never leak into their subscription subprocesses;
+- clamp selection remains explicit and never silently falls back to metered API
+  transport;
+- non-clamped interactive and exec sessions remain unchanged.
+
+## Dead ends and approaches not worth repeating
+
+### Model-only transport
+
+Do not ship a backend that only renders the prompt, returns final text, and
+resumes provider conversation state. That creates a chatbot, not a functional
+Chaos resident.
+
+### Direct use of Antigravity OAuth credentials
+
+Do not read, copy, parse, export, refresh, or submit Antigravity OAuth tokens
+from Chaos or Souls.house. Google authentication and network requests must
+remain inside the official `agy` process.
+
+### `--dangerously-skip-permissions`
+
+Do not use it. It grants native Antigravity tools independent authority and
+defeats Chaos's permission boundary.
+
+### Trusting prompt instructions as isolation
+
+“Do not use native tools” is not enforcement. The live custom-agent test tried
+`view_file` despite explicit instructions. The deny rules correctly blocked it.
+Keep the deny policy even if model instructions appear reliable.
+
+### `tools: []` transport agent
+
+This was the original spike configuration. It prevents usable MCP calls while
+the `init.tools` catalog can still misleadingly list tool names. Do not infer
+tool usability from the init catalog.
+
+### Declaring `call_mcp_tool` directly in custom-agent frontmatter
+
+The attempted `tools: [call_mcp_tool]` configuration failed with “no tool
+converter registered.” Do not revisit it without evidence for the correct
+dynamic MCP tool declaration syntax in the tested `agy` version.
+
+### Custom agent before the bridge works
+
+A custom agent with no `tools` field attempted native file inspection and did
+not complete the MCP call. Use the default agent for the first integration
+proof. Optimize agent behavior only after functionality is established.
+
+### Replacing Chaos with `agy`
+
+`agy` does not replace Chaos's trigger lifecycle, session identity, resident
+tools, permission semantics, event normalization, or Souls.house orchestration.
+Use it as the official Google-authenticated harness beneath Chaos, not as the
+resident runtime.
+
+### Antigravity SDK as subscription authentication
+
+The public SDK is useful for programmatic agents but currently documents API
+key and Vertex credentials, not the tested consumer subscription OAuth path.
+It does not satisfy this work's billing/authentication goal unless Google adds
+and documents that capability.
+
+### Persistent per-session MCP secrets
+
+Do not store bridge socket paths or capability tokens in
+`mcp_config.json`, Rails, logs, conversation state, or backups. They are
+invocation-scoped capabilities.
+
+### Treating successful tool request as sufficient
+
+The following are all separately required:
+
+- tool discovery;
+- permission authorization;
+- execution by the real Chaos bridge;
+- result returned to Gemini;
+- Gemini using the result;
+- canonical Chaos events;
+- cross-process resume;
+- native-tool denial.
+
+Tests must prove the chain rather than assert only its final text.
+
+## Commit strategy
+
+Keep commits atomic and signed off:
+
+1. plan and issue reference;
+2. managed safe `agy` configuration plus tests;
+3. session bridge wiring plus fake integration tests;
+4. tool-step normalization and diagnostics;
+5. live-test harness and documentation;
+6. final review corrections.
+
+Each code commit should compile and pass its focused tests. Before any new PR:
+
+```text
+just fmt
+just test
+```
+
+Review the complete diff as an agent, then let Daniel decide whether it is
+ready. Fill the PR template with What / Why / How and reference issue #26.
+
+## Continuation checkpoint
+
+If context is compacted, resume here:
+
+1. read this file;
+2. inspect issue #26 and closed PR #25;
+3. inspect the external evidence file `mcp-bridge-smoke-6.jsonl`;
+4. do not return to model-only work;
+5. begin with managed non-secret MCP configuration and environment inheritance;
+6. do not reopen a PR until the live full-Chaos tool-and-resume test passes.

--- a/docs/antigravity-full-chaos-clamp-plan.md
+++ b/docs/antigravity-full-chaos-clamp-plan.md
@@ -1,11 +1,11 @@
 # Antigravity full-Chaos clamp plan
 
-**Date:** 2026-08-11  
-**Branch:** `feat/antigravity-clamp`  
-**Issue:** #26  
-**Withdrawn proof-of-concept:** #25  
-**Status:** MCP feasibility proven outside the repository; real Chaos bridge
-integration not yet proven
+**Date:** 2026-08-11
+**Branch:** `feat/antigravity-clamp`
+**Issue:** #26
+**Withdrawn proof-of-concept:** #25
+**Status:** real Chaos bridge proven for fresh and cross-process resumed turns;
+implementation and regression review in progress
 
 ## Purpose
 
@@ -49,9 +49,10 @@ The runnable development evidence lives outside Git worktrees at:
 
 Do not move OAuth state, browser return codes, or tokens into the repository.
 
-Tested artifact:
+Tested artifacts:
 
-- `agy 1.1.11`
+- `agy 1.1.11` for the original standalone MCP spike
+- `agy 1.1.12` for environment inheritance and full-Chaos tests
 - macOS arm64
 - Google consumer OAuth account
 - `gemini-3.1-pro-low`
@@ -295,6 +296,122 @@ Run the actual Chaos binary and existing session MCP bridge:
 
 This is the minimum proof required before reopening a PR.
 
+## Implementation checkpoint — 2026-08-11
+
+The first full implementation pass now:
+
+- reuses the existing session-scoped `ClampSessionBridge`;
+- writes managed `mcp_config.json` and Antigravity permission settings inside
+  the dedicated `CHAOS_AGY_HOME`;
+- exposes only the `chaos` MCP server;
+- denies native command, filesystem, unsandboxed, and URL operations;
+- passes the bridge socket and capability token only through the `agy`
+  environment;
+- uses the default Antigravity agent rather than the dead-end transport-only
+  custom agent; the public transport configuration no longer permits callers
+  to select a custom agent and accidentally remove dynamic MCP tools;
+- removes metered Gemini API-key variables;
+- preserves provider conversation resume and normalized usage.
+
+Live proofs are stored outside Git worktrees. The environment inheritance proof
+is:
+
+```text
+~/.local/share/mira-antigravity-spike/mcp-env-inheritance.jsonl
+```
+
+The full-Chaos proofs are under:
+
+```text
+~/.local/share/mira-antigravity-spike/full-chaos-smoke
+```
+
+The following passed against OAuth-authenticated `agy 1.1.12`:
+
+1. `mcp-env-inheritance.jsonl` proves an `agy`-spawned MCP child inherited a
+   random parent-only environment marker and returned it to Gemini.
+2. `fresh.jsonl` proves a fresh `chaos exec` turn called the real Chaos
+   `read_file` tool and returned a file-only marker.
+3. `resume.jsonl` proves a new operating-system process resumed the same Chaos
+   and provider conversation, recreated tool access, and called `read_file`
+   again.
+4. `exec-tool.jsonl` proves a resumed turn called the real Chaos
+   `exec_command` tool and emitted canonical `item.started` and
+   `item.completed` command events before the final answer.
+5. All three full-Chaos turns emitted complete invocation and
+   process-cumulative usage without a `turn.failed` event.
+
+The `read_file` smoke turn did not emit a generic process item because Chaos
+does not currently publish one for that built-in tool on any provider path.
+The `exec_command` turn was used to verify canonical tool lifecycle events.
+
+Remaining before a new PR:
+
+- review the full branch diff against `master`;
+- split the implementation into atomic signed-off commits;
+- keep the PR withdrawn until those checks pass.
+
+Focused automated validation completed on 2026-08-11:
+
+```text
+cargo test -q -p chaos-clamp
+cargo test -q -p chaos-cli --test clamp_antigravity
+cargo check -q -p chaos-kern
+```
+
+Results:
+
+- `chaos-clamp`: 30 passed, 0 failed; live provider tests remained ignored;
+- `clamp_antigravity`: 5 passed, 0 failed;
+- `chaos-kern`: check passed.
+
+Final safety review removed the lifecycle command's fallback from
+`CHAOS_AGY_HOME` to ordinary `HOME`. Connect and disconnect now require an
+explicit dedicated home, matching turn execution and preventing managed
+Antigravity configuration or credential removal from touching a user's normal
+home accidentally. A regression test proves connect fails closed without the
+environment variable.
+
+Repository-wide contribution checks:
+
+```text
+just fmt
+cargo fmt --all -- --check
+just test
+```
+
+Formatting passed. The complete test run executed 2,734 tests: 2,730 passed,
+19 were skipped, and 4 failed for confirmed baseline/environment reasons:
+
+1. `review_diff_prefetch_disables_external_diff_helpers` and
+   `review_diff_prefetch_disables_textconv_helpers` receive ANSI-colored Git
+   output because Daniel's global Git configuration sets `color.ui=always`;
+   their assertions expect literal uncolored `-before\n` and `+after\n`.
+2. `undo_restores_untracked_file_edit` likewise expects literal uncolored
+   `git status --short` output and misses the ANSI-wrapped `?? notes.txt`.
+3. `unified_exec_emits_one_begin_and_one_end_event` reproduces identically when
+   run alone on the clean `master` checkout at `62ec36cbc`.
+
+The branch does not modify any of those tests or their implementation areas.
+Do not contaminate this focused change by fixing baseline test isolation here.
+
+The first focused run caught and corrected a stale model-only authority assertion
+in the ignored Antigravity smoke test. The live smoke now requires an explicit
+session bridge capability rather than pretending a model-only invocation is a
+valid full clamp.
+
+Observed tool-step review:
+
+- successful Chaos MCP calls are `step_type: "tool"`,
+  `tool_name: "call_mcp_tool"`, with `ACTIVE` then `DONE`;
+- a blocked native `view_file` attempt is `state: "ERROR"` and reports that it
+  matched the configured `read_file(...)` deny rule;
+- the existing Chaos MCP bridge already emits canonical tool/process events, so
+  `agy` tool steps must remain transport diagnostics and must not be translated
+  into duplicate Chaos lifecycle events;
+- unknown `step_type` values remain parseable because `step_type` is stored as
+  a string rather than a closed enum.
+
 ### Regression tests
 
 - Claude Code clamp behavior remains unchanged;
@@ -409,7 +526,13 @@ If context is compacted, resume here:
 
 1. read this file;
 2. inspect issue #26 and closed PR #25;
-3. inspect the external evidence file `mcp-bridge-smoke-6.jsonl`;
+3. inspect the uncommitted worktree diff and external full-Chaos evidence under
+   `~/.local/share/mira-antigravity-spike/full-chaos-smoke`;
 4. do not return to model-only work;
-5. begin with managed non-secret MCP configuration and environment inheritance;
-6. do not reopen a PR until the live full-Chaos tool-and-resume test passes.
+5. the next validation command is `just fmt`, followed by `just test`;
+6. formatting and the complete suite have already run; read the documented
+   baseline failures above rather than rediscovering them;
+7. review the complete `master...HEAD` plus worktree diff, scan for secrets,
+   then create atomic
+   signed-off commits;
+8. do not reopen a PR until Daniel has reviewed the finished diff.

--- a/docs/antigravity-oauth-risk-and-design.md
+++ b/docs/antigravity-oauth-risk-and-design.md
@@ -1,0 +1,186 @@
+# Antigravity OAuth: provider restrictions and clamp design
+
+**Last reviewed:** 2026-08-11
+
+## Status and warning
+
+The Antigravity clamp is experimental and opt-in.
+
+Google's current Antigravity terms prohibit using third-party software, tools,
+or services to access Antigravity, explicitly naming use of Antigravity OAuth
+from a third-party product as an example. The terms say this may be grounds for
+account suspension or termination:
+
+- <https://antigravity.google/terms>
+
+Google has enforced this policy. On 2026-02-27, a Gemini CLI maintainer
+confirmed that Google had banned accounts for using third-party tools or proxies
+to access Antigravity resources and quotas. Because enforcement happened at a
+shared backend layer, affected users also lost access to Gemini CLI and Gemini
+Code Assist. The announcement described reinstatement after recertification for
+a first flag and a permanent ban after a second violation:
+
+- <https://github.com/google-gemini/gemini-cli/discussions/20632>
+- <https://x.com/antigravity/status/2027435365275967591>
+
+Using the official `agy` executable as a subprocess does **not** make a
+Chaos-driven workflow officially supported or compliant with those terms.
+Operators must decide whether to accept this provider-policy risk. A metered
+Gemini API or another provider-supported integration remains the appropriate
+choice when terms compliance or account continuity is required.
+
+The strongest official evidence establishes restrictions affecting
+Antigravity, Gemini CLI, Gemini Code Assist, and related AI developer services.
+It does not establish that every enforcement action disables Gmail, Drive, or
+an entire Google identity. The Antigravity terms nevertheless use the broader
+word “account,” so Chaos must not promise that enforcement will remain limited
+to developer services.
+
+## Why Chaos does not consume Antigravity OAuth credentials directly
+
+Chaos deliberately does not:
+
+- read or parse Antigravity OAuth token files;
+- accept browser return codes or refresh tokens;
+- copy credentials into Chaos configuration or a service database;
+- submit those credentials to Google's private backend;
+- reproduce or impersonate Antigravity's private network protocol.
+
+Directly reusing OAuth credentials would create both a security liability and
+the exact “piggybacking” pattern called out in Google's enforcement statement.
+It would also couple Chaos to an undocumented private API that Google may change
+without notice.
+
+Instead, authentication, token refresh, and Google network requests remain
+inside the official `agy` process and its dedicated private home.
+
+This separation reduces credential exposure and avoids implementing a private
+Google client. It is a technical safety boundary, not a claim of provider
+approval.
+
+## Why model-only subprocess output is insufficient
+
+A Chaos resident needs more than authenticated model text. It must retain:
+
+- Chaos-owned tools;
+- permission and approval policy;
+- sandboxing;
+- hooks and lifecycle events;
+- usage telemetry;
+- process identity and resume behavior.
+
+An earlier proof of concept could send prompts through OAuth-authenticated
+`agy`, return text, and resume the provider conversation. It could not use Chaos
+tools and was therefore not a usable resident transport.
+
+Replacing Chaos with `agy` is also not sufficient. Antigravity does not own the
+Chaos trigger lifecycle, resident identity, tool policy, event protocol, or
+hosted-session orchestration.
+
+## Implemented architecture
+
+```text
+Chaos model session
+  |
+  +-- creates the existing session-scoped Chaos MCP bridge
+  |     +-- Unix socket
+  |     +-- random capability token
+  |
+  +-- writes non-secret managed agy configuration
+  |     +-- only the `chaos` MCP server
+  |     +-- allow `mcp(chaos/*)`
+  |     +-- deny native command/filesystem/URL operations
+  |
+  +-- launches the official agy executable
+        +-- owns Google OAuth and network traffic
+        +-- inherits the ephemeral bridge socket/token
+        +-- invokes `chaos clamp-session-bridge` over stdio
+              +-- lists real session tools
+              +-- executes through Chaos policy
+              +-- returns results to Gemini
+```
+
+The bridge socket and capability token exist only in the invocation
+environment. They are not written to Antigravity settings, MCP configuration,
+conversation state, logs, or service storage.
+
+Every turn runs `agy` with:
+
+- sandbox mode enabled;
+- no permission auto-approval flag;
+- native command, filesystem, unsandboxed, and URL operations denied;
+- only `mcp(chaos/*)` allowed;
+- `GEMINI_API_KEY` and `GOOGLE_API_KEY` removed.
+
+Removing metered API-key variables is a fail-closed billing control: failed
+subscription authentication must fail the turn rather than silently charge an
+API key.
+
+## Dedicated home requirement
+
+`CHAOS_AGY_HOME` is mandatory and must point to a dedicated private directory.
+Chaos owns the effective MCP server list and permission policy within this
+home, while `agy` owns its OAuth state.
+
+Chaos does not fall back to the user's ordinary `HOME`. This prevents managed
+configuration and disconnect operations from modifying a non-dedicated
+Antigravity installation accidentally.
+
+The home must persist across operating-system processes when provider
+conversation resume is required.
+
+## Permission boundary
+
+Prompt instructions tell Gemini to use the Chaos MCP server as its sole action
+surface, but prompt text is not treated as enforcement.
+
+Live testing showed that a model may still attempt a native Antigravity tool
+despite explicit instructions. The configured deny rules blocked that attempt.
+The permission policy—not model cooperation—is therefore the security
+boundary.
+
+`--dangerously-skip-permissions` must not be added. Doing so would give
+Antigravity's native tools authority independent of Chaos and defeat the clamp.
+
+## Verified behavior
+
+Live testing on macOS arm64 with consumer OAuth and `agy 1.1.12` demonstrated:
+
+1. a fresh `chaos exec` turn calling the real Chaos `read_file` tool and using
+   file-only information in its answer;
+2. a new operating-system process resuming the same Chaos and provider
+   conversation and calling `read_file` again;
+3. a resumed turn calling the real `exec_command` tool;
+4. canonical Chaos command start/completion events;
+5. complete invocation and process-cumulative usage telemetry;
+6. no direct Gemini API key and no model-only fallback.
+
+These tests establish technical functionality. They do not remove the provider
+policy risk described above.
+
+## Approaches intentionally rejected
+
+- **Direct OAuth-token reuse:** exposes credentials and directly matches the
+  prohibited third-party OAuth pattern.
+- **Calling Google's private backend from Chaos:** undocumented, brittle, and
+  indistinguishable from client impersonation.
+- **Model-only transport:** authenticates Gemini but removes the agency required
+  by Chaos residents.
+- **Native `agy` tools with auto-approval:** bypasses Chaos permissions,
+  sandboxing, hooks, and canonical events.
+- **Prompt-only isolation:** the model can ignore instructions; permissions must
+  enforce the boundary.
+- **Persistent bridge secrets:** turns an invocation-scoped capability into a
+  reusable credential.
+- **Using `agy` as the resident runtime:** loses Chaos lifecycle and
+  orchestration semantics.
+
+## Operational decision
+
+Enable this backend only after the operator has reviewed Google's current terms
+and accepted the possibility of losing access to Antigravity and related Gemini
+developer services. Do not use an irreplaceable Google identity if that risk is
+unacceptable.
+
+For provider-supported operation, use metered Gemini API credentials instead of
+the Antigravity clamp.

--- a/sys/exec/fork/src/event_processor_with_jsonl_output.rs
+++ b/sys/exec/fork/src/event_processor_with_jsonl_output.rs
@@ -124,6 +124,10 @@ impl EventProcessorWithJsonOutput {
             protocol::EventMsg::ProcessNameUpdated(_) => Vec::new(),
             protocol::EventMsg::AgentMessage(ev) => self.handle_agent_message(ev),
             protocol::EventMsg::ItemCompleted(protocol::ItemCompletedEvent {
+                item: chaos_ipc::items::TurnItem::AgentMessage(item),
+                ..
+            }) => self.handle_agent_message_item(item),
+            protocol::EventMsg::ItemCompleted(protocol::ItemCompletedEvent {
                 item: chaos_ipc::items::TurnItem::Plan(item),
                 ..
             }) => {
@@ -633,6 +637,24 @@ impl EventProcessorWithJsonOutput {
                 agents_states,
                 status,
             }),
+        };
+        vec![ProcessEvent::ItemCompleted(ItemCompletedEvent { item })]
+    }
+
+    fn handle_agent_message_item(
+        &self,
+        payload: &chaos_ipc::items::AgentMessageItem,
+    ) -> Vec<ProcessEvent> {
+        let text = payload
+            .content
+            .iter()
+            .map(|content| match content {
+                chaos_ipc::items::AgentMessageContent::Text { text } => text.as_str(),
+            })
+            .collect::<String>();
+        let item = ProcessItem {
+            id: payload.id.clone(),
+            details: ProcessItemDetails::AgentMessage(AgentMessageItem { text }),
         };
         vec![ProcessEvent::ItemCompleted(ItemCompletedEvent { item })]
     }

--- a/sys/exec/fork/tests/suite/event_processor_with_json_output.rs
+++ b/sys/exec/fork/tests/suite/event_processor_with_json_output.rs
@@ -33,6 +33,9 @@ use chaos_fork::exec_events::UsageScope;
 use chaos_fork::exec_events::WebSearchItem;
 use chaos_ipc::ProcessId;
 use chaos_ipc::config_types::ModeKind;
+use chaos_ipc::items::AgentMessageContent;
+use chaos_ipc::items::AgentMessageItem as CoreAgentMessageItem;
+use chaos_ipc::items::TurnItem;
 use chaos_ipc::mcp::CallToolResult;
 use chaos_ipc::models::WebSearchAction;
 use chaos_ipc::openai_models::ReasoningEffort as ReasoningEffortConfig;
@@ -853,6 +856,38 @@ fn agent_message_produces_item_completed_agent_message() {
                 }),
             },
         })]
+    );
+}
+
+#[test]
+fn completed_agent_message_item_produces_json_item() {
+    let mut ep = EventProcessorWithJsonOutput::new(None);
+    let ev = event(
+        "e1",
+        EventMsg::ItemCompleted(chaos_ipc::protocol::ItemCompletedEvent {
+            process_id: ProcessId::new(),
+            turn_id: "turn-1".to_string(),
+            item: TurnItem::AgentMessage(CoreAgentMessageItem {
+                id: "message-1".to_string(),
+                content: vec![
+                    AgentMessageContent::Text {
+                        text: "hello ".to_string(),
+                    },
+                    AgentMessageContent::Text {
+                        text: "world".to_string(),
+                    },
+                ],
+                phase: None,
+            }),
+        }),
+    );
+
+    assert_single_item_completed(
+        ep.collect_process_events(&ev),
+        "message-1",
+        ProcessItemDetails::AgentMessage(AgentMessageItem {
+            text: "hello world".to_string(),
+        }),
     );
 }
 

--- a/sys/kern/kern/src/chaos/session/init.rs
+++ b/sys/kern/kern/src/chaos/session/init.rs
@@ -511,6 +511,7 @@ impl Session {
                 true,
                 Self::build_model_client_beta_features_header(config.as_ref()),
                 config.clamp && matches!(session_configuration.session_source, SessionSource::Exec),
+                config.clamp_backend,
             ),
         };
         let (out_of_band_elicitation_paused, _out_of_band_elicitation_paused_rx) =

--- a/sys/kern/kern/src/chaos_tests.rs
+++ b/sys/kern/kern/src/chaos_tests.rs
@@ -468,6 +468,7 @@ fn make_test_session_services(
             true,
             Session::build_model_client_beta_features_header(config),
             false,
+            config.clamp_backend,
         ),
         halluacinate: None,
     }

--- a/sys/kern/kern/src/client.rs
+++ b/sys/kern/kern/src/client.rs
@@ -51,6 +51,7 @@ use rama::http::sse::Event;
 use crate::api_bridge::CoreAuthProvider;
 use crate::auth::AuthMode;
 use crate::auth::ChaosAuth;
+use crate::config::ClampBackend;
 use crate::model_provider_info::ModelProviderInfo;
 use crate::model_provider_info::WireApi;
 use crate::response_debug_context::extract_response_debug_context;
@@ -90,8 +91,15 @@ pub(super) struct ModelClientState {
     pub(super) resolved_wire: OnceLock<WireApi>,
     /// When true, route all turns through the Claude Code subprocess (clamped mode).
     pub(super) clamped: AtomicBool,
+    /// First-party CLI transport selected for clamped turns.
+    pub(super) clamp_backend: ClampBackend,
     /// Persistent Claude Code subprocess for clamped mode.
     pub(super) clamp_transport: tokio::sync::Mutex<Option<chaos_clamp::ClampTransport>>,
+    /// Session-scoped Antigravity conversation transport.
+    pub(super) antigravity_transport: tokio::sync::Mutex<Option<chaos_clamp::AntigravityTransport>>,
+    /// Per-Chaos-process record used to resume the provider conversation after
+    /// a later `chaos exec resume` starts a new operating-system process.
+    pub(super) antigravity_conversation_state_path: Option<std::path::PathBuf>,
     /// Wiretap proxy recording subprocess traffic (opt-in via env), held for the
     /// lifetime of the clamp transport.
     pub(super) clamp_wiretap: tokio::sync::Mutex<Option<chaos_clamp::WiretapProxy>>,

--- a/sys/kern/kern/src/client/state.rs
+++ b/sys/kern/kern/src/client/state.rs
@@ -26,6 +26,7 @@ use crate::api_bridge::map_api_error;
 use crate::auth::ChaosAuth;
 use crate::client::auth_breaker;
 use crate::client_common::Prompt;
+use crate::config::ClampBackend;
 use crate::error::ChaosErr;
 use crate::error::Result;
 use crate::model_provider_info::ModelProviderInfo;
@@ -36,6 +37,17 @@ use super::{
     ApiTelemetry, AuthRequestTelemetryContext, CurrentClientSetup, ModelClient, ModelClientSession,
     ModelClientState, PendingUnauthorizedRetry, RESPONSES_COMPACT_ENDPOINT, RequestRouteTelemetry,
 };
+
+fn antigravity_conversation_state_path(conversation_id: &chaos_ipc::ProcessId) -> Option<PathBuf> {
+    let directory = std::env::var_os("CHAOS_AGY_CONVERSATION_DIR")
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("CHAOS_AGY_HOME")
+                .map(PathBuf::from)
+                .map(|home| home.join(".chaos-conversations"))
+        })?;
+    Some(directory.join(format!("{conversation_id}.json")))
+}
 
 impl ModelClient {
     /// Creates a new session-scoped `ModelClient`.
@@ -51,6 +63,7 @@ impl ModelClient {
         enable_request_compression: bool,
         beta_features_header: Option<String>,
         initial_clamped: bool,
+        clamp_backend: ClampBackend,
     ) -> Self {
         let representer = if provider.is_openai() {
             chaos_parrot::SessionRepresenter::openai()
@@ -58,6 +71,8 @@ impl ModelClient {
             chaos_parrot::SessionRepresenter::wannabe()
         };
         let auth_breaker = auth_breaker::AuthBreaker::new(&provider_id);
+        let antigravity_conversation_state_path =
+            antigravity_conversation_state_path(&conversation_id);
         Self {
             state: Arc::new(ModelClientState {
                 auth_manager,
@@ -71,7 +86,10 @@ impl ModelClient {
                 beta_features_header,
                 resolved_wire: std::sync::OnceLock::new(),
                 clamped: std::sync::atomic::AtomicBool::new(initial_clamped),
+                clamp_backend,
                 clamp_transport: tokio::sync::Mutex::new(None),
+                antigravity_transport: tokio::sync::Mutex::new(None),
+                antigravity_conversation_state_path,
                 clamp_wiretap: tokio::sync::Mutex::new(None),
                 clamp_mcp_bridge: tokio::sync::Mutex::new(None),
                 session: std::sync::Mutex::new(Weak::new()),
@@ -151,6 +169,11 @@ impl ModelClient {
                 let mut guard = self.state.clamp_transport.lock().await;
                 guard.take()
             };
+            self.state.antigravity_transport.lock().await.take();
+            remove_antigravity_conversation_state(
+                self.state.antigravity_conversation_state_path.as_deref(),
+            )
+            .await;
             let bridge = {
                 let mut guard = self.state.clamp_mcp_bridge.lock().await;
                 guard.take()
@@ -187,6 +210,11 @@ impl ModelClient {
             let mut guard = self.state.clamp_transport.lock().await;
             guard.take()
         };
+        self.state.antigravity_transport.lock().await.take();
+        remove_antigravity_conversation_state(
+            self.state.antigravity_conversation_state_path.as_deref(),
+        )
+        .await;
         if let Some(wiretap) = self.state.clamp_wiretap.lock().await.take() {
             wiretap.shutdown();
         }
@@ -400,6 +428,22 @@ impl ModelClient {
             // Transient failures (e.g. a token refresh hiccup) aren't a signal
             // about login state, so they must not trip the auth breaker.
             Err(other) => Err(other),
+        }
+    }
+}
+
+async fn remove_antigravity_conversation_state(path: Option<&std::path::Path>) {
+    let Some(path) = path else {
+        return;
+    };
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            warn!(
+                path = %path.display(),
+                "failed to remove persisted Antigravity conversation state: {error}"
+            );
         }
     }
 }

--- a/sys/kern/kern/src/client/streaming.rs
+++ b/sys/kern/kern/src/client/streaming.rs
@@ -799,6 +799,7 @@ impl ModelClientSession {
             .filter(|value| !value.trim().is_empty())
             .unwrap_or_else(|| antigravity_model_slug(&model_info.slug, effort));
         let clamp_state = Arc::clone(&self.client.state);
+        let client = self.client.clone();
         let (tx_event, rx_event) =
             mpsc::channel::<std::result::Result<ResponseEvent, chaos_parrot::error::ApiError>>(32);
 
@@ -816,6 +817,27 @@ impl ModelClientSession {
                 .await;
             }
             if guard.is_none() {
+                let (bridge_socket_path, bridge_token) =
+                    match client.ensure_clamp_mcp_bridge().await {
+                        Ok(bridge) => bridge,
+                        Err(error) => {
+                            let _ = tx_event
+                                .send(Err(chaos_parrot::error::ApiError::Stream(error)))
+                                .await;
+                            return;
+                        }
+                    };
+                let chaos_executable = match std::env::current_exe() {
+                    Ok(path) => path,
+                    Err(error) => {
+                        let _ = tx_event
+                            .send(Err(chaos_parrot::error::ApiError::Stream(format!(
+                                "failed to resolve Chaos executable for Antigravity bridge: {error}"
+                            ))))
+                            .await;
+                        return;
+                    }
+                };
                 let config = AntigravityConfig {
                     cli_path: std::env::var_os("CHAOS_AGY_PATH").map(std::path::PathBuf::from),
                     home: std::env::var_os("CHAOS_AGY_HOME").map(std::path::PathBuf::from),
@@ -823,9 +845,11 @@ impl ModelClientSession {
                         .map(std::path::PathBuf::from)
                         .or_else(|| std::env::current_dir().ok()),
                     model: model.clone(),
-                    agent: std::env::var("CHAOS_AGY_AGENT")
-                        .ok()
-                        .filter(|value| !value.trim().is_empty()),
+                    bridge: Some(chaos_clamp::AntigravityBridgeConfig {
+                        socket_path: bridge_socket_path,
+                        token: bridge_token,
+                        chaos_executable,
+                    }),
                     ..Default::default()
                 };
                 let persisted_conversation = load_antigravity_conversation(
@@ -862,9 +886,13 @@ impl ModelClientSession {
                 return;
             };
             let content = if transport.conversation_id().is_none() {
-                full_prompt_state.as_str()
+                format!(
+                    "Use the Chaos MCP server as your sole action surface. Native Antigravity tools are unavailable. You may call multiple Chaos tools before answering. Tool results are authoritative. Return only the user-facing answer without checkpoint or timestamp boilerplate.\n\n{full_prompt_state}"
+                )
             } else {
-                latest_user_content.as_str()
+                format!(
+                    "Continue using only the Chaos MCP server for actions. Return only the user-facing answer.\n\n{latest_user_content}"
+                )
             };
 
             let _ = tx_event.send(Ok(ResponseEvent::Created)).await;
@@ -878,7 +906,7 @@ impl ModelClientSession {
                 })))
                 .await;
 
-            match transport.run_turn(content).await {
+            match transport.run_turn(&content).await {
                 Ok(turn) => {
                     if let Err(error) = save_antigravity_conversation(
                         clamp_state.antigravity_conversation_state_path.as_deref(),

--- a/sys/kern/kern/src/client/streaming.rs
+++ b/sys/kern/kern/src/client/streaming.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
+use std::time::SystemTime;
 
 use chaos_abi::AbiError;
 use chaos_abi::FreeformToolDef;
@@ -105,6 +106,143 @@ fn clamp_usage_to_token_usage(
         reasoning_output_tokens: 0,
         total_tokens: saturating_i64(total_tokens),
         provider_request_count: 0,
+    }
+}
+
+fn antigravity_usage_to_token_usage(usage: chaos_clamp::AntigravityUsage) -> TokenUsage {
+    fn saturating_i64(value: u64) -> i64 {
+        i64::try_from(value).unwrap_or(i64::MAX)
+    }
+
+    TokenUsage {
+        input_tokens: saturating_i64(usage.input_tokens),
+        cache_creation_input_tokens: 0,
+        cached_input_tokens: saturating_i64(usage.cache_read_tokens),
+        output_tokens: saturating_i64(usage.output_tokens),
+        reasoning_output_tokens: saturating_i64(usage.thinking_tokens),
+        total_tokens: saturating_i64(usage.total_tokens),
+        // The session records provider_request_started separately, so response
+        // usage must not count the same subprocess invocation a second time.
+        provider_request_count: 0,
+    }
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct PersistedAntigravityConversation {
+    version: u8,
+    model: String,
+    conversation_id: String,
+}
+
+async fn load_antigravity_conversation(
+    path: Option<&std::path::Path>,
+    model: &str,
+) -> Option<String> {
+    let path = path?;
+    let bytes = match tokio::fs::read(path).await {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(error) => {
+            warn!(
+                path = %path.display(),
+                "failed to read persisted Antigravity conversation state: {error}"
+            );
+            return None;
+        }
+    };
+    let state: PersistedAntigravityConversation = match serde_json::from_slice(&bytes) {
+        Ok(state) => state,
+        Err(error) => {
+            warn!(
+                path = %path.display(),
+                "ignoring invalid persisted Antigravity conversation state: {error}"
+            );
+            return None;
+        }
+    };
+    if state.version != 1 || state.model != model {
+        return None;
+    }
+    let conversation_id = state.conversation_id.trim();
+    if conversation_id.is_empty()
+        || conversation_id.len() > 256
+        || !conversation_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        warn!(
+            path = %path.display(),
+            "ignoring invalid persisted Antigravity conversation id"
+        );
+        return None;
+    }
+    Some(conversation_id.to_string())
+}
+
+async fn save_antigravity_conversation(
+    path: Option<&std::path::Path>,
+    model: &str,
+    conversation_id: &str,
+) -> std::io::Result<()> {
+    let Some(path) = path else {
+        return Ok(());
+    };
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Antigravity conversation state path has no parent",
+        )
+    })?;
+    tokio::fs::create_dir_all(parent).await?;
+    #[cfg(unix)]
+    tokio::fs::set_permissions(parent, std::os::unix::fs::PermissionsExt::from_mode(0o700)).await?;
+
+    let state = PersistedAntigravityConversation {
+        version: 1,
+        model: model.to_string(),
+        conversation_id: conversation_id.to_string(),
+    };
+    let bytes = serde_json::to_vec(&state).map_err(std::io::Error::other)?;
+    let nonce = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let temporary_path = parent.join(format!(
+        ".{}.{}.{nonce}.tmp",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("conversation"),
+        std::process::id()
+    ));
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        options.mode(0o600);
+    }
+    use tokio::io::AsyncWriteExt;
+    let mut file = options.open(&temporary_path).await?;
+    file.write_all(&bytes).await?;
+    file.sync_all().await?;
+    drop(file);
+    if let Err(error) = tokio::fs::rename(&temporary_path, path).await {
+        let _ = tokio::fs::remove_file(&temporary_path).await;
+        return Err(error);
+    }
+    Ok(())
+}
+
+async fn remove_antigravity_conversation(path: Option<&std::path::Path>) {
+    let Some(path) = path else {
+        return;
+    };
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => warn!(
+            path = %path.display(),
+            "failed to remove persisted Antigravity conversation state: {error}"
+        ),
     }
 }
 
@@ -633,6 +771,165 @@ impl ModelClientSession {
         }
     }
 
+    /// Streams a turn via Google's official Antigravity CLI.
+    #[instrument(
+        name = "model_client.stream_antigravity",
+        level = "info",
+        skip_all,
+        fields(
+            model = %model_info.slug,
+            wire_api = "clamped",
+            transport = "antigravity_subprocess",
+        )
+    )]
+    async fn stream_antigravity(
+        &self,
+        prompt: &Prompt,
+        model_info: &ModelInfo,
+        session_telemetry: &SessionTelemetry,
+        effort: Option<ReasoningEffortConfig>,
+    ) -> Result<ResponseStream> {
+        use chaos_clamp::AntigravityConfig;
+        use chaos_clamp::AntigravityTransport;
+
+        let full_prompt_state = render_clamp_full_prompt(prompt);
+        let latest_user_content = render_latest_clamp_user_message(prompt);
+        let model = std::env::var("CHAOS_AGY_MODEL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| antigravity_model_slug(&model_info.slug, effort));
+        let clamp_state = Arc::clone(&self.client.state);
+        let (tx_event, rx_event) =
+            mpsc::channel::<std::result::Result<ResponseEvent, chaos_parrot::error::ApiError>>(32);
+
+        let session_telemetry = session_telemetry.clone();
+        tokio::spawn(async move {
+            let mut guard = clamp_state.antigravity_transport.lock().await;
+            if guard
+                .as_ref()
+                .is_some_and(|transport| transport.model() != model)
+            {
+                guard.take();
+                remove_antigravity_conversation(
+                    clamp_state.antigravity_conversation_state_path.as_deref(),
+                )
+                .await;
+            }
+            if guard.is_none() {
+                let config = AntigravityConfig {
+                    cli_path: std::env::var_os("CHAOS_AGY_PATH").map(std::path::PathBuf::from),
+                    home: std::env::var_os("CHAOS_AGY_HOME").map(std::path::PathBuf::from),
+                    cwd: std::env::var_os("CHAOS_AGY_CWD")
+                        .map(std::path::PathBuf::from)
+                        .or_else(|| std::env::current_dir().ok()),
+                    model: model.clone(),
+                    agent: std::env::var("CHAOS_AGY_AGENT")
+                        .ok()
+                        .filter(|value| !value.trim().is_empty()),
+                    ..Default::default()
+                };
+                let persisted_conversation = load_antigravity_conversation(
+                    clamp_state.antigravity_conversation_state_path.as_deref(),
+                    &model,
+                )
+                .await;
+                let transport = match persisted_conversation {
+                    Some(conversation_id) => {
+                        AntigravityTransport::with_conversation_id(config, conversation_id)
+                    }
+                    None => AntigravityTransport::new(config),
+                };
+                match transport {
+                    Ok(transport) => *guard = Some(transport),
+                    Err(error) => {
+                        let _ = tx_event
+                            .send(Err(chaos_parrot::error::ApiError::Stream(format!(
+                                "{}: {error}",
+                                antigravity_failure_marker(&error, "antigravity_startup_failed")
+                            ))))
+                            .await;
+                        return;
+                    }
+                }
+            }
+
+            let Some(transport) = guard.as_mut() else {
+                let _ = tx_event
+                    .send(Err(chaos_parrot::error::ApiError::Stream(
+                        "Antigravity transport missing after initialization".to_string(),
+                    )))
+                    .await;
+                return;
+            };
+            let content = if transport.conversation_id().is_none() {
+                full_prompt_state.as_str()
+            } else {
+                latest_user_content.as_str()
+            };
+
+            let _ = tx_event.send(Ok(ResponseEvent::Created)).await;
+            let _ = tx_event
+                .send(Ok(ResponseEvent::OutputItemAdded(ResponseItem::Message {
+                    id: None,
+                    role: "assistant".to_string(),
+                    content: vec![],
+                    end_turn: None,
+                    phase: None,
+                })))
+                .await;
+
+            match transport.run_turn(content).await {
+                Ok(turn) => {
+                    if let Err(error) = save_antigravity_conversation(
+                        clamp_state.antigravity_conversation_state_path.as_deref(),
+                        transport.model(),
+                        &turn.conversation_id,
+                    )
+                    .await
+                    {
+                        warn!("failed to persist Antigravity conversation state: {error}");
+                    }
+                    let response = turn.response;
+                    if !response.is_empty() {
+                        let _ = tx_event
+                            .send(Ok(ResponseEvent::OutputTextDelta(response.clone())))
+                            .await;
+                    }
+                    let _ = tx_event
+                        .send(Ok(ResponseEvent::OutputItemDone(ResponseItem::Message {
+                            id: None,
+                            role: "assistant".to_string(),
+                            content: vec![ContentItem::OutputText { text: response }],
+                            end_turn: Some(true),
+                            phase: None,
+                        })))
+                        .await;
+                    let _ = tx_event
+                        .send(Ok(ResponseEvent::Completed {
+                            response_id: turn.conversation_id,
+                            token_usage: turn.usage.map(antigravity_usage_to_token_usage),
+                        }))
+                        .await;
+                }
+                Err(error) => {
+                    remove_antigravity_conversation(
+                        clamp_state.antigravity_conversation_state_path.as_deref(),
+                    )
+                    .await;
+                    let _ = tx_event
+                        .send(Err(chaos_parrot::error::ApiError::Stream(format!(
+                            "{}: {error}",
+                            antigravity_failure_marker(&error, "antigravity_runtime_failed")
+                        ))))
+                        .await;
+                }
+            }
+        });
+
+        let stream = tokio_stream::wrappers::ReceiverStream::new(rx_event);
+        Ok(map_response_stream(stream, session_telemetry))
+    }
+
     /// Streams a turn via a clamped Claude Code subprocess.
     #[instrument(
         name = "model_client.stream_clamped",
@@ -1021,9 +1318,16 @@ impl ModelClientSession {
         );
 
         if self.client.state.clamped.load(Ordering::Relaxed) {
-            return self
-                .stream_clamped(prompt, model_info, session_telemetry)
-                .await;
+            return match self.client.state.clamp_backend {
+                crate::config::ClampBackend::ClaudeCode => {
+                    self.stream_clamped(prompt, model_info, session_telemetry)
+                        .await
+                }
+                crate::config::ClampBackend::Antigravity => {
+                    self.stream_antigravity(prompt, model_info, session_telemetry, effort)
+                        .await
+                }
+            };
         }
 
         // Fail fast (and stop hammering provider auth) when no credentials are
@@ -1315,6 +1619,45 @@ fn clamp_failure_marker(error: &chaos_clamp::ClampError, fallback: &'static str)
     }
 }
 
+fn antigravity_failure_marker(
+    error: &chaos_clamp::AntigravityError,
+    fallback: &'static str,
+) -> &'static str {
+    match error {
+        chaos_clamp::AntigravityError::CliNotFound(_) => "antigravity_cli_not_found",
+        chaos_clamp::AntigravityError::AuthenticationUnavailable => "antigravity_auth_unavailable",
+        chaos_clamp::AntigravityError::Timeout => "antigravity_timeout",
+        _ => fallback,
+    }
+}
+
+fn antigravity_model_slug(model: &str, effort: Option<ReasoningEffortConfig>) -> String {
+    let model = model.rsplit('/').next().unwrap_or(model);
+    if model.ends_with("-low") || model.ends_with("-medium") || model.ends_with("-high") {
+        return model.to_string();
+    }
+
+    let effort = match effort.unwrap_or(ReasoningEffortConfig::High) {
+        ReasoningEffortConfig::None
+        | ReasoningEffortConfig::Minimal
+        | ReasoningEffortConfig::Low => "low",
+        ReasoningEffortConfig::Medium => "medium",
+        ReasoningEffortConfig::High
+        | ReasoningEffortConfig::XHigh
+        | ReasoningEffortConfig::Max
+        | ReasoningEffortConfig::Ultra => "high",
+    };
+
+    match model {
+        "gemini-3.1-pro" | "gemini-3.1-pro-preview" => {
+            let effort = if effort == "low" { "low" } else { "high" };
+            format!("gemini-3.1-pro-{effort}")
+        }
+        "gemini-3.5-flash" | "gemini-3.6-flash" => format!("{model}-{effort}"),
+        _ => model.to_string(),
+    }
+}
+
 /// How the clamp wiretap records traffic, resolved from `CHAOS_CLAMP_WIRETAP`.
 ///
 /// - unset/empty → `Off` (the default)
@@ -1345,8 +1688,86 @@ fn clamp_wiretap_mode() -> WiretapMode {
 
 #[cfg(test)]
 mod tests {
+    use super::antigravity_model_slug;
+    use super::antigravity_usage_to_token_usage;
     use super::clamp_usage_to_token_usage;
+    use super::load_antigravity_conversation;
+    use super::save_antigravity_conversation;
+    use chaos_clamp::AntigravityUsage;
     use chaos_clamp::Usage;
+    use chaos_ipc::openai_models::ReasoningEffort;
+
+    #[test]
+    fn antigravity_model_mapping_uses_observed_cli_slugs() {
+        assert_eq!(
+            antigravity_model_slug("gemini-3.1-pro-preview", Some(ReasoningEffort::Low)),
+            "gemini-3.1-pro-low"
+        );
+        assert_eq!(
+            antigravity_model_slug("google/gemini-3.1-pro", Some(ReasoningEffort::Medium)),
+            "gemini-3.1-pro-high"
+        );
+        assert_eq!(
+            antigravity_model_slug("gemini-3.6-flash", Some(ReasoningEffort::Medium)),
+            "gemini-3.6-flash-medium"
+        );
+        assert_eq!(
+            antigravity_model_slug("gemini-3.6-flash-low", Some(ReasoningEffort::High)),
+            "gemini-3.6-flash-low"
+        );
+    }
+
+    #[test]
+    fn antigravity_usage_preserves_reasoning_and_cache_tokens() {
+        let usage = antigravity_usage_to_token_usage(AntigravityUsage {
+            input_tokens: 11,
+            output_tokens: 13,
+            thinking_tokens: 17,
+            cache_read_tokens: 19,
+            total_tokens: 60,
+        });
+
+        assert_eq!(usage.input_tokens, 11);
+        assert_eq!(usage.cached_input_tokens, 19);
+        assert_eq!(usage.output_tokens, 13);
+        assert_eq!(usage.reasoning_output_tokens, 17);
+        assert_eq!(usage.total_tokens, 60);
+        assert_eq!(usage.provider_request_count, 0);
+    }
+
+    #[tokio::test]
+    async fn antigravity_conversation_state_round_trips_only_for_matching_model() {
+        let directory = tempfile::tempdir().expect("temporary state directory");
+        let path = directory.path().join("conversation.json");
+
+        save_antigravity_conversation(Some(&path), "gemini-3.1-pro-low", "conversation-123")
+            .await
+            .expect("save conversation state");
+
+        assert_eq!(
+            load_antigravity_conversation(Some(&path), "gemini-3.1-pro-low").await,
+            Some("conversation-123".to_string())
+        );
+        assert_eq!(
+            load_antigravity_conversation(Some(&path), "gemini-3.1-pro-high").await,
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn antigravity_conversation_state_rejects_unsafe_identifier() {
+        let directory = tempfile::tempdir().expect("temporary state directory");
+        let path = directory.path().join("conversation.json");
+
+        save_antigravity_conversation(Some(&path), "gemini-3.1-pro-low", "../other-session")
+            .await
+            .expect("save conversation state");
+
+        assert_eq!(
+            load_antigravity_conversation(Some(&path), "gemini-3.1-pro-low").await,
+            None
+        );
+    }
 
     #[test]
     fn clamp_usage_uses_aggregate_counters_and_last_call_context() {

--- a/sys/kern/kern/src/client_tests.rs
+++ b/sys/kern/kern/src/client_tests.rs
@@ -34,6 +34,7 @@ fn test_model_client(session_source: SessionSource) -> ModelClient {
         false,
         None,
         false,
+        crate::config::ClampBackend::default(),
     )
 }
 
@@ -54,6 +55,7 @@ fn model_client_can_start_clamped_before_the_first_turn() {
         false,
         None,
         true,
+        crate::config::ClampBackend::default(),
     );
 
     assert!(client.is_clamped());
@@ -126,6 +128,7 @@ fn resolve_anthropic_auth_uses_bearer_token_from_provider_config() {
         false,
         None,
         false,
+        crate::config::ClampBackend::default(),
     );
     let session = client.new_session();
 
@@ -152,6 +155,7 @@ fn resolve_anthropic_auth_errors_when_provider_has_no_static_auth() {
         false,
         None,
         false,
+        crate::config::ClampBackend::default(),
     );
     let session = client.new_session();
 

--- a/sys/kern/kern/src/config.rs
+++ b/sys/kern/kern/src/config.rs
@@ -107,6 +107,15 @@ pub(crate) const DEFAULT_MINION_JOB_MAX_RUNTIME_SECONDS: Option<u64> = None;
 
 pub const CONFIG_TOML_FILE: &str = "config.toml";
 
+/// First-party CLI transport selected when clamp mode is enabled.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum ClampBackend {
+    #[default]
+    ClaudeCode,
+    Antigravity,
+}
+
 #[cfg(test)]
 pub(crate) fn test_config() -> Config {
     let chaos_home = tempfile::tempdir().expect("create temp dir");
@@ -205,11 +214,14 @@ pub struct Config {
     /// users are only interested in the final agent responses.
     pub hide_agent_reasoning: bool,
 
-    /// Start `chaos exec` sessions using the Claude Code subprocess transport.
+    /// Start `chaos exec` sessions using a first-party CLI subprocess transport.
     ///
     /// Interactive sessions ignore this setting and retain their existing
     /// `/clamp` and `--clamp` controls.
     pub clamp: bool,
+
+    /// First-party CLI transport selected when clamp mode is enabled.
+    pub clamp_backend: ClampBackend,
 
     /// Optional user-provided instructions (currently always `None`; a
     /// schema-based replacement for the removed AGENTS.md loader will
@@ -624,9 +636,13 @@ pub struct ConfigToml {
     /// UI/output. Defaults to `false`.
     pub hide_agent_reasoning: Option<bool>,
 
-    /// Start `chaos exec` sessions using the Claude Code subprocess transport.
+    /// Start `chaos exec` sessions using a first-party CLI subprocess transport.
     /// Defaults to `false`.
     pub clamp: Option<bool>,
+
+    /// First-party CLI transport selected when clamp mode is enabled.
+    /// Defaults to `claude-code`.
+    pub clamp_backend: Option<ClampBackend>,
 
     pub model_reasoning_effort: Option<ReasoningEffort>,
     /// Allow the parent model to change its own reasoning effort for subsequent turns.

--- a/sys/kern/kern/src/config/config_tests.rs
+++ b/sys/kern/kern/src/config/config_tests.rs
@@ -175,9 +175,15 @@ fn runtime_config_defaults_clamp_to_false_and_parses_true() {
     )
     .expect("load default config");
     assert!(!default_cfg.clamp);
+    assert_eq!(default_cfg.clamp_backend, super::ClampBackend::ClaudeCode);
 
-    let parsed =
-        toml::from_str::<ConfigToml>("clamp = true").expect("clamp should deserialize from TOML");
+    let parsed = toml::from_str::<ConfigToml>(
+        r#"
+clamp = true
+clamp_backend = "antigravity"
+"#,
+    )
+    .expect("clamp settings should deserialize from TOML");
     let enabled_cfg = Config::load_from_base_config_with_overrides(
         parsed,
         ConfigOverrides::default(),
@@ -185,6 +191,7 @@ fn runtime_config_defaults_clamp_to_false_and_parses_true() {
     )
     .expect("load clamped config");
     assert!(enabled_cfg.clamp);
+    assert_eq!(enabled_cfg.clamp_backend, super::ClampBackend::Antigravity);
 }
 
 #[tokio::test]
@@ -192,13 +199,20 @@ async fn config_builder_applies_clamp_cli_override() {
     let chaos_home = tempdir().expect("tempdir");
     let cfg = ConfigBuilder::default()
         .chaos_home(chaos_home.path().to_path_buf())
-        .cli_overrides(vec![("clamp".to_string(), TomlValue::Boolean(true))])
+        .cli_overrides(vec![
+            ("clamp".to_string(), TomlValue::Boolean(true)),
+            (
+                "clamp_backend".to_string(),
+                TomlValue::String("antigravity".to_string()),
+            ),
+        ])
         .fallback_cwd(Some(chaos_home.path().to_path_buf()))
         .build()
         .await
         .expect("load config with clamp CLI override");
 
     assert!(cfg.clamp);
+    assert_eq!(cfg.clamp_backend, super::ClampBackend::Antigravity);
 }
 
 #[test]
@@ -908,6 +922,7 @@ fn expected_precedence_fixture_config_baseline(fixture: &PrecedenceTestFixture) 
         approvals_reviewer: ApprovalsReviewer::User,
         enforce_residency: Constrained::allow_any(None),
         clamp: false,
+        clamp_backend: Default::default(),
         user_instructions: None,
         cwd: fixture.cwd(),
         cli_auth_credentials_store_mode: Default::default(),

--- a/sys/kern/kern/src/config/requirements.rs
+++ b/sys/kern/kern/src/config/requirements.rs
@@ -652,6 +652,7 @@ impl Config {
 
             hide_agent_reasoning: cfg.hide_agent_reasoning.unwrap_or(false),
             clamp: cfg.clamp.unwrap_or(false),
+            clamp_backend: cfg.clamp_backend.unwrap_or_default(),
             model_reasoning_effort: config_profile
                 .model_reasoning_effort
                 .or(cfg.model_reasoning_effort),

--- a/sys/kern/kern/tests/responses_headers.rs
+++ b/sys/kern/kern/tests/responses_headers.rs
@@ -97,6 +97,7 @@ async fn responses_stream_includes_subagent_header_on_review() {
         false,
         None,
         false,
+        chaos_kern::config::ClampBackend::default(),
     );
     let mut client_session = client.new_session();
 
@@ -211,6 +212,7 @@ async fn responses_stream_includes_subagent_header_on_other() {
         false,
         None,
         false,
+        chaos_kern::config::ClampBackend::default(),
     );
     let mut client_session = client.new_session();
 
@@ -324,6 +326,7 @@ async fn responses_respects_model_info_overrides_from_config() {
         false,
         None,
         false,
+        chaos_kern::config::ClampBackend::default(),
     );
     let mut client_session = client.new_session();
 

--- a/sys/modules/clamp/Cargo.toml
+++ b/sys/modules/clamp/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 publish.workspace = true
-description = "Claude Code subprocess module — use MAX subscription as transport"
+description = "First-party model CLI subprocess transports for subscription-backed inference"
 
 [lints]
 workspace = true

--- a/sys/modules/clamp/README.md
+++ b/sys/modules/clamp/README.md
@@ -1,5 +1,25 @@
 # chaos-clamp
 
-Compile-time module that uses Claude Code as a headless subprocess transport.
-Allows operators with a MAX subscription to route turns through Claude Code
-instead of hitting the API directly.
+First-party model CLI subprocess transports.
+
+- **Claude Code:** bidirectional stream-JSON control transport. Chaos owns
+  tools and permissions through its MCP bridge.
+- **Google Antigravity (`agy`):** one subprocess per model turn with explicit
+  provider conversation resume and normalized JSONL usage. This transport is
+  currently **model-only/sandboxed**: `agy` does not receive permission
+  auto-approval, metered Gemini API-key environment variables are removed, and
+  full Chaos-owned tool bridging is not yet claimed.
+
+Lifecycle commands:
+
+```bash
+CHAOS_AGY_HOME=/private/antigravity-state chaos clamp antigravity connect
+CHAOS_AGY_HOME=/private/antigravity-state chaos clamp antigravity status --json
+CHAOS_AGY_HOME=/private/antigravity-state chaos clamp antigravity disconnect
+```
+
+`CHAOS_AGY_HOME` should be a persistent private directory outside the source
+checkout. `CHAOS_AGY_PATH` may pin the official CLI binary. Service integrations
+must preserve the Chaos process ID and this home directory, and must pass the
+original `-m` model selection again, to resume the same provider conversation
+across operating-system processes.

--- a/sys/modules/clamp/README.md
+++ b/sys/modules/clamp/README.md
@@ -5,10 +5,12 @@ First-party model CLI subprocess transports.
 - **Claude Code:** bidirectional stream-JSON control transport. Chaos owns
   tools and permissions through its MCP bridge.
 - **Google Antigravity (`agy`):** one subprocess per model turn with explicit
-  provider conversation resume and normalized JSONL usage. This transport is
-  currently **model-only/sandboxed**: `agy` does not receive permission
-  auto-approval, metered Gemini API-key environment variables are removed, and
-  full Chaos-owned tool bridging is not yet claimed.
+  provider conversation resume and normalized JSONL usage. `agy` runs
+  sandboxed with native command, filesystem, unsandboxed, and URL operations
+  denied. Its sole action surface is the session-scoped Chaos MCP bridge.
+  Metered Gemini API-key environment variables are removed, and the ephemeral
+  bridge socket/token are inherited by the MCP child without being written to
+  persistent configuration.
 
 Lifecycle commands:
 
@@ -18,8 +20,10 @@ CHAOS_AGY_HOME=/private/antigravity-state chaos clamp antigravity status --json
 CHAOS_AGY_HOME=/private/antigravity-state chaos clamp antigravity disconnect
 ```
 
-`CHAOS_AGY_HOME` should be a persistent private directory outside the source
-checkout. `CHAOS_AGY_PATH` may pin the official CLI binary. Service integrations
-must preserve the Chaos process ID and this home directory, and must pass the
+`CHAOS_AGY_HOME` must be a dedicated persistent private directory outside the
+source checkout. Chaos preserves OAuth and unrelated top-level settings but
+owns the effective MCP server list and permission policy inside this home.
+`CHAOS_AGY_PATH` may pin the official CLI binary. Service integrations must
+preserve the Chaos process ID and this home directory, and must pass the
 original `-m` model selection again, to resume the same provider conversation
 across operating-system processes.

--- a/sys/modules/clamp/README.md
+++ b/sys/modules/clamp/README.md
@@ -2,6 +2,10 @@
 
 First-party model CLI subprocess transports.
 
+For Google policy restrictions, account-risk context, rejected approaches, and
+the full Antigravity security design, see
+[`docs/antigravity-oauth-risk-and-design.md`](../../../docs/antigravity-oauth-risk-and-design.md).
+
 - **Claude Code:** bidirectional stream-JSON control transport. Chaos owns
   tools and permissions through its MCP bridge.
 - **Google Antigravity (`agy`):** one subprocess per model turn with explicit

--- a/sys/modules/clamp/src/antigravity.rs
+++ b/sys/modules/clamp/src/antigravity.rs
@@ -1,0 +1,516 @@
+//! Google Antigravity CLI subprocess transport.
+//!
+//! This transport deliberately leaves Google credentials in `agy`'s private
+//! home directory. It invokes one non-interactive process per turn, parses the
+//! documented stream-JSON output, and resumes later turns by provider
+//! conversation ID.
+
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde::Deserialize;
+use tokio::process::Command;
+
+const DEFAULT_PRINT_TIMEOUT: Duration = Duration::from_secs(300);
+const STDERR_CLASSIFICATION_LIMIT: usize = 16 * 1024;
+
+/// Tool-authority level currently guaranteed by the Antigravity transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AntigravityToolAuthority {
+    /// `agy` runs sandboxed and without permission auto-approval, but its
+    /// built-in tools are not yet bridged through Chaos.
+    ModelOnlySandboxed,
+}
+
+/// Configuration for invoking the official `agy` CLI.
+#[derive(Debug, Clone)]
+pub struct AntigravityConfig {
+    /// Path to `agy`. When omitted, the binary is resolved from `PATH`.
+    pub cli_path: Option<PathBuf>,
+    /// Isolated home directory containing state owned by `agy`.
+    pub home: Option<PathBuf>,
+    /// Working directory presented to `agy`.
+    pub cwd: Option<PathBuf>,
+    /// Antigravity model slug, for example `gemini-3.1-pro-low`.
+    pub model: String,
+    /// Optional Antigravity reasoning effort (`low`, `medium`, or `high`).
+    pub effort: Option<String>,
+    /// Optional custom transport-only agent. Applied only to fresh
+    /// conversations; resumed conversations retain their original agent.
+    pub agent: Option<String>,
+    /// Maximum wall-clock time for a single print-mode invocation.
+    pub print_timeout: Duration,
+}
+
+impl Default for AntigravityConfig {
+    fn default() -> Self {
+        Self {
+            cli_path: None,
+            home: None,
+            cwd: None,
+            model: "gemini-3.1-pro-low".to_string(),
+            effort: None,
+            agent: None,
+            print_timeout: DEFAULT_PRINT_TIMEOUT,
+        }
+    }
+}
+
+/// Token usage reported by Antigravity for a step or complete invocation.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+pub struct AntigravityUsage {
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+    #[serde(default)]
+    pub thinking_tokens: u64,
+    #[serde(default)]
+    pub cache_read_tokens: u64,
+    #[serde(default)]
+    pub total_tokens: u64,
+}
+
+/// Initialization metadata emitted at the beginning of every invocation.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+pub struct AntigravityInit {
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub agent: Option<String>,
+    #[serde(default)]
+    pub tools: Vec<String>,
+    #[serde(default)]
+    pub permission_mode: Option<String>,
+}
+
+/// A streamed Antigravity step update.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct AntigravityStepUpdate {
+    pub conversation_id: String,
+    pub step_index: u64,
+    pub state: String,
+    pub step_type: String,
+    #[serde(default)]
+    pub text_delta: Option<String>,
+    #[serde(default)]
+    pub duration_seconds: Option<f64>,
+    #[serde(default)]
+    pub usage: Option<AntigravityUsage>,
+}
+
+/// Final result emitted by a successful or failed Antigravity invocation.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct AntigravityResult {
+    pub conversation_id: String,
+    pub status: String,
+    #[serde(default)]
+    pub response: String,
+    #[serde(default)]
+    pub duration_seconds: Option<f64>,
+    #[serde(default)]
+    pub num_turns: Option<u64>,
+    #[serde(default)]
+    pub usage: Option<AntigravityUsage>,
+}
+
+/// Parsed `agy --output-format stream-json` event.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum AntigravityEvent {
+    Init {
+        conversation_id: String,
+        init: AntigravityInit,
+    },
+    StepUpdate {
+        step_update: AntigravityStepUpdate,
+    },
+    Result {
+        result: AntigravityResult,
+    },
+}
+
+/// Completed turn returned by [`AntigravityTransport`].
+#[derive(Debug, Clone)]
+pub struct AntigravityTurn {
+    pub conversation_id: String,
+    pub response: String,
+    pub usage: Option<AntigravityUsage>,
+    pub events: Vec<AntigravityEvent>,
+}
+
+/// Errors from the Antigravity subprocess transport.
+#[derive(Debug, thiserror::Error)]
+pub enum AntigravityError {
+    #[error("Antigravity CLI not found: {0}")]
+    CliNotFound(String),
+
+    #[error("failed to run Antigravity CLI: {0}")]
+    Spawn(#[from] std::io::Error),
+
+    #[error("Antigravity invocation timed out")]
+    Timeout,
+
+    #[error("Antigravity subscription authentication is unavailable")]
+    AuthenticationUnavailable,
+
+    #[error("Antigravity invocation failed with status {0}")]
+    InvocationFailed(String),
+
+    #[error("Antigravity protocol error: {0}")]
+    Protocol(String),
+}
+
+/// Session-scoped Antigravity transport.
+///
+/// `agy` itself is turn-scoped; this type persists only the provider
+/// conversation ID needed to resume the next subprocess invocation.
+#[derive(Debug)]
+pub struct AntigravityTransport {
+    config: AntigravityConfig,
+    conversation_id: Option<String>,
+}
+
+impl AntigravityTransport {
+    pub fn new(config: AntigravityConfig) -> Result<Self, AntigravityError> {
+        validate_config(&config)?;
+        Ok(Self {
+            config,
+            conversation_id: None,
+        })
+    }
+
+    pub fn with_conversation_id(
+        config: AntigravityConfig,
+        conversation_id: String,
+    ) -> Result<Self, AntigravityError> {
+        validate_config(&config)?;
+        Ok(Self {
+            config,
+            conversation_id: Some(conversation_id),
+        })
+    }
+
+    pub fn conversation_id(&self) -> Option<&str> {
+        self.conversation_id.as_deref()
+    }
+
+    pub fn model(&self) -> &str {
+        &self.config.model
+    }
+
+    pub fn tool_authority(&self) -> AntigravityToolAuthority {
+        AntigravityToolAuthority::ModelOnlySandboxed
+    }
+
+    /// Run one prompt through `agy`, resuming the provider conversation when
+    /// this transport has already completed a turn.
+    pub async fn run_turn(&mut self, prompt: &str) -> Result<AntigravityTurn, AntigravityError> {
+        let cli_path = find_agy_cli(&self.config)?;
+        let mut command = build_command(&cli_path, &self.config, self.conversation_id.as_deref());
+        command.arg("--print").arg(prompt);
+
+        let output = tokio::time::timeout(self.config.print_timeout, command.output())
+            .await
+            .map_err(|_| AntigravityError::Timeout)??;
+
+        let stderr = bounded_text(&output.stderr);
+        if !output.status.success() {
+            if text_indicates_auth_failure(&stderr) {
+                return Err(AntigravityError::AuthenticationUnavailable);
+            }
+            return Err(AntigravityError::InvocationFailed(
+                output.status.code().map_or_else(
+                    || "terminated by signal".to_string(),
+                    |code| code.to_string(),
+                ),
+            ));
+        }
+
+        let events = parse_events(&output.stdout)?;
+        let result = events.iter().rev().find_map(|event| match event {
+            AntigravityEvent::Result { result } => Some(result),
+            _ => None,
+        });
+        let Some(result) = result else {
+            return Err(AntigravityError::Protocol(
+                "stream ended without a result event".to_string(),
+            ));
+        };
+        if result.status != "SUCCESS" {
+            return Err(AntigravityError::InvocationFailed(result.status.clone()));
+        }
+        if let Some(expected) = self.conversation_id.as_deref()
+            && result.conversation_id != expected
+        {
+            return Err(AntigravityError::Protocol(format!(
+                "resumed conversation changed from {expected} to {}",
+                result.conversation_id
+            )));
+        }
+
+        self.conversation_id = Some(result.conversation_id.clone());
+        Ok(AntigravityTurn {
+            conversation_id: result.conversation_id.clone(),
+            response: result.response.clone(),
+            usage: result.usage.clone(),
+            events,
+        })
+    }
+}
+
+fn validate_config(config: &AntigravityConfig) -> Result<(), AntigravityError> {
+    if config.model.trim().is_empty() {
+        return Err(AntigravityError::Protocol(
+            "Antigravity model must not be empty".to_string(),
+        ));
+    }
+    if let Some(effort) = config.effort.as_deref()
+        && !matches!(effort, "low" | "medium" | "high")
+    {
+        return Err(AntigravityError::Protocol(format!(
+            "unsupported Antigravity effort: {effort}"
+        )));
+    }
+    Ok(())
+}
+
+fn find_agy_cli(config: &AntigravityConfig) -> Result<PathBuf, AntigravityError> {
+    if let Some(path) = &config.cli_path {
+        if path.is_file() {
+            return Ok(path.clone());
+        }
+        return Err(AntigravityError::CliNotFound(format!(
+            "specified path does not exist: {}",
+            path.display()
+        )));
+    }
+
+    which::which("agy").map_err(|_| {
+        AntigravityError::CliNotFound(
+            "agy not found in PATH; install a pinned official Antigravity CLI artifact".to_string(),
+        )
+    })
+}
+
+fn build_command(
+    cli_path: &Path,
+    config: &AntigravityConfig,
+    conversation_id: Option<&str>,
+) -> Command {
+    let mut command = Command::new(cli_path);
+    command.args(["--output-format", "stream-json"]);
+    command.args(["--model", &config.model]);
+    command.arg("--disable-slash-commands");
+    command.arg("--sandbox");
+    command.args([
+        "--print-timeout",
+        &format!("{}s", config.print_timeout.as_secs().max(1)),
+    ]);
+
+    if let Some(conversation_id) = conversation_id {
+        command.args(["--conversation", conversation_id]);
+    } else if let Some(agent) = config.agent.as_deref() {
+        command.args(["--agent", agent]);
+    }
+    if let Some(effort) = config.effort.as_deref() {
+        command.args(["--effort", effort]);
+    }
+    if let Some(home) = &config.home {
+        command.env("HOME", home);
+        command.env("XDG_CONFIG_HOME", home.join(".config"));
+    }
+    if let Some(cwd) = &config.cwd {
+        command.current_dir(cwd);
+    }
+
+    // Subscription mode must never silently fall back to a metered API key.
+    command.env_remove("GEMINI_API_KEY");
+    command.env_remove("GOOGLE_API_KEY");
+    command.kill_on_drop(true);
+    command.stdin(std::process::Stdio::null());
+    command.stdout(std::process::Stdio::piped());
+    command.stderr(std::process::Stdio::piped());
+    command
+}
+
+fn parse_events(stdout: &[u8]) -> Result<Vec<AntigravityEvent>, AntigravityError> {
+    let stdout = std::str::from_utf8(stdout)
+        .map_err(|_| AntigravityError::Protocol("stdout was not valid UTF-8".to_string()))?;
+    let mut events = Vec::new();
+    for (index, line) in stdout.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let event = serde_json::from_str(line).map_err(|err| {
+            AntigravityError::Protocol(format!("invalid JSONL event on line {}: {err}", index + 1))
+        })?;
+        events.push(event);
+    }
+    Ok(events)
+}
+
+fn bounded_text(bytes: &[u8]) -> String {
+    let start = bytes.len().saturating_sub(STDERR_CLASSIFICATION_LIMIT);
+    String::from_utf8_lossy(&bytes[start..]).into_owned()
+}
+
+fn text_indicates_auth_failure(text: &str) -> bool {
+    let text = text.to_ascii_lowercase();
+    [
+        "not logged in",
+        "not authenticated",
+        "authentication required",
+        "authentication failed",
+        "oauth token",
+        "sign in",
+        "login required",
+    ]
+    .iter()
+    .any(|marker| text.contains(marker))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_observed_stream_json() {
+        let stdout = br#"{"event":"init","conversation_id":"conversation-1","init":{"model":"gemini-3.1-pro-low","permission_mode":"request-review","tools":["run_command"]}}
+{"event":"step_update","step_update":{"conversation_id":"conversation-1","step_index":1,"state":"DONE","step_type":"agent_response","text_delta":"hello\n","usage":{"input_tokens":11,"output_tokens":7,"thinking_tokens":5,"cache_read_tokens":3,"total_tokens":26}}}
+{"event":"result","result":{"conversation_id":"conversation-1","status":"SUCCESS","response":"hello\n","duration_seconds":1.5,"num_turns":1,"usage":{"input_tokens":11,"output_tokens":7,"thinking_tokens":5,"cache_read_tokens":3,"total_tokens":26}}}
+"#;
+        let events = parse_events(stdout).expect("events should parse");
+        assert_eq!(events.len(), 3);
+        let AntigravityEvent::Result { result } = &events[2] else {
+            panic!("expected result event");
+        };
+        assert_eq!(result.conversation_id, "conversation-1");
+        assert_eq!(result.response, "hello\n");
+        assert_eq!(result.usage.as_ref().expect("usage").thinking_tokens, 5);
+    }
+
+    #[test]
+    fn rejects_unknown_effort() {
+        let config = AntigravityConfig {
+            effort: Some("ultra".to_string()),
+            ..Default::default()
+        };
+        assert!(matches!(
+            AntigravityTransport::new(config),
+            Err(AntigravityError::Protocol(_))
+        ));
+    }
+
+    #[test]
+    fn auth_errors_are_classified_without_returning_diagnostics() {
+        assert!(text_indicates_auth_failure(
+            "Authentication failed: OAuth token expired"
+        ));
+        assert!(!text_indicates_auth_failure("model backend unavailable"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn transport_runs_fresh_then_resumed_turn_without_api_keys() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::time::SystemTime;
+
+        let unique = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "chaos-antigravity-test-{}-{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("create test directory");
+        let script = dir.join("agy");
+        std::fs::write(
+            &script,
+            r#"#!/bin/sh
+case "$*" in
+  *--dangerously-skip-permissions*) exit 90 ;;
+esac
+if [ -n "${GEMINI_API_KEY+x}" ] || [ -n "${GOOGLE_API_KEY+x}" ]; then
+  exit 91
+fi
+case "$*" in
+  *"--conversation conversation-1"*)
+    turns=2
+    response=second
+    ;;
+  *)
+    turns=1
+    response=first
+    ;;
+esac
+printf '{"event":"init","conversation_id":"conversation-1","init":{"model":"gemini-test","permission_mode":"request-review"}}\n'
+printf '{"event":"step_update","step_update":{"conversation_id":"conversation-1","step_index":1,"state":"DONE","step_type":"agent_response","text_delta":"%s"}}\n' "$response"
+printf '{"event":"result","result":{"conversation_id":"conversation-1","status":"SUCCESS","response":"%s","num_turns":%s,"usage":{"input_tokens":1,"output_tokens":2,"thinking_tokens":3,"cache_read_tokens":4,"total_tokens":10}}}\n' "$response" "$turns"
+"#,
+        )
+        .expect("write fake agy");
+        let mut permissions = std::fs::metadata(&script)
+            .expect("fake agy metadata")
+            .permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&script, permissions).expect("make fake agy executable");
+
+        let config = AntigravityConfig {
+            cli_path: Some(script),
+            home: Some(dir.join("home")),
+            cwd: Some(dir.clone()),
+            model: "gemini-test".to_string(),
+            agent: Some("transport-only".to_string()),
+            print_timeout: Duration::from_secs(5),
+            ..Default::default()
+        };
+        let mut transport = AntigravityTransport::new(config).expect("create transport");
+
+        let fresh = transport
+            .run_turn("first prompt")
+            .await
+            .expect("fresh turn");
+        let resumed = transport
+            .run_turn("second prompt")
+            .await
+            .expect("resumed turn");
+
+        assert_eq!(fresh.response, "first");
+        assert_eq!(resumed.response, "second");
+        assert_eq!(transport.conversation_id(), Some("conversation-1"));
+        let AntigravityEvent::Result { result } = resumed.events.last().expect("result event")
+        else {
+            panic!("expected result event");
+        };
+        assert_eq!(result.num_turns, Some(2));
+
+        std::fs::remove_dir_all(dir).expect("remove test directory");
+    }
+
+    #[test]
+    fn command_removes_metered_api_keys_and_never_auto_approves() {
+        let config = AntigravityConfig::default();
+        let command = build_command(&PathBuf::from("/tmp/agy"), &config, None);
+        let std_command = command.as_std();
+        let args = std_command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert!(args.iter().any(|arg| arg == "--sandbox"));
+        assert!(!args.iter().any(|arg| arg.contains("dangerously")));
+
+        let removed = std_command
+            .get_envs()
+            .filter(|(_, value)| value.is_none())
+            .map(|(name, _)| name.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert!(removed.iter().any(|name| name == "GEMINI_API_KEY"));
+        assert!(removed.iter().any(|name| name == "GOOGLE_API_KEY"));
+    }
+}

--- a/sys/modules/clamp/src/antigravity.rs
+++ b/sys/modules/clamp/src/antigravity.rs
@@ -8,19 +8,44 @@
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::Duration;
+use std::time::SystemTime;
 
 use serde::Deserialize;
+use serde_json::Value;
 use tokio::process::Command;
 
 const DEFAULT_PRINT_TIMEOUT: Duration = Duration::from_secs(300);
 const STDERR_CLASSIFICATION_LIMIT: usize = 16 * 1024;
+const BRIDGE_SOCKET_ENV: &str = "CHAOS_CLAMP_MCP_SOCKET";
+const BRIDGE_TOKEN_ENV: &str = "CHAOS_CLAMP_MCP_TOKEN";
+const CHAOS_MCP_SERVER_NAME: &str = "chaos";
+const CHAOS_MCP_ALLOW_RULE: &str = "mcp(chaos/*)";
+const NATIVE_TOOL_DENY_RULES: &[&str] = &[
+    "command(*)",
+    "unsandboxed(*)",
+    "read_file(*)",
+    "write_file(*)",
+    "read_url(*)",
+    "execute_url(*)",
+];
 
 /// Tool-authority level currently guaranteed by the Antigravity transport.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AntigravityToolAuthority {
-    /// `agy` runs sandboxed and without permission auto-approval, but its
-    /// built-in tools are not yet bridged through Chaos.
-    ModelOnlySandboxed,
+    /// `agy` runs sandboxed, native tools are denied, and its sole action
+    /// surface is the session-scoped Chaos MCP bridge.
+    ChaosSessionBridge,
+}
+
+/// Ephemeral Chaos bridge capability inherited by `agy` and its MCP child.
+///
+/// The socket path and token are intentionally exported only through the
+/// subprocess environment. Managed Antigravity configuration contains neither.
+#[derive(Debug, Clone)]
+pub struct AntigravityBridgeConfig {
+    pub socket_path: PathBuf,
+    pub token: String,
+    pub chaos_executable: PathBuf,
 }
 
 /// Configuration for invoking the official `agy` CLI.
@@ -36,11 +61,10 @@ pub struct AntigravityConfig {
     pub model: String,
     /// Optional Antigravity reasoning effort (`low`, `medium`, or `high`).
     pub effort: Option<String>,
-    /// Optional custom transport-only agent. Applied only to fresh
-    /// conversations; resumed conversations retain their original agent.
-    pub agent: Option<String>,
     /// Maximum wall-clock time for a single print-mode invocation.
     pub print_timeout: Duration,
+    /// Session-scoped Chaos MCP bridge. Required for a usable clamped turn.
+    pub bridge: Option<AntigravityBridgeConfig>,
 }
 
 impl Default for AntigravityConfig {
@@ -51,8 +75,8 @@ impl Default for AntigravityConfig {
             cwd: None,
             model: "gemini-3.1-pro-low".to_string(),
             effort: None,
-            agent: None,
             print_timeout: DEFAULT_PRINT_TIMEOUT,
+            bridge: None,
         }
     }
 }
@@ -100,6 +124,10 @@ pub struct AntigravityStepUpdate {
     pub duration_seconds: Option<f64>,
     #[serde(default)]
     pub usage: Option<AntigravityUsage>,
+    #[serde(default)]
+    pub tool_name: Option<String>,
+    #[serde(default)]
+    pub tool_info: Option<Value>,
 }
 
 /// Final result emitted by a successful or failed Antigravity invocation.
@@ -203,13 +231,14 @@ impl AntigravityTransport {
     }
 
     pub fn tool_authority(&self) -> AntigravityToolAuthority {
-        AntigravityToolAuthority::ModelOnlySandboxed
+        AntigravityToolAuthority::ChaosSessionBridge
     }
 
     /// Run one prompt through `agy`, resuming the provider conversation when
     /// this transport has already completed a turn.
     pub async fn run_turn(&mut self, prompt: &str) -> Result<AntigravityTurn, AntigravityError> {
         let cli_path = find_agy_cli(&self.config)?;
+        prepare_managed_home(&self.config)?;
         let mut command = build_command(&cli_path, &self.config, self.conversation_id.as_deref());
         command.arg("--print").arg(prompt);
 
@@ -275,6 +304,21 @@ fn validate_config(config: &AntigravityConfig) -> Result<(), AntigravityError> {
             "unsupported Antigravity effort: {effort}"
         )));
     }
+    if config.home.is_none() {
+        return Err(AntigravityError::Protocol(
+            "Antigravity clamp requires a dedicated CHAOS_AGY_HOME".to_string(),
+        ));
+    }
+    let Some(bridge) = config.bridge.as_ref() else {
+        return Err(AntigravityError::Protocol(
+            "Antigravity clamp requires the Chaos session MCP bridge".to_string(),
+        ));
+    };
+    if bridge.token.is_empty() {
+        return Err(AntigravityError::Protocol(
+            "Antigravity clamp bridge token must not be empty".to_string(),
+        ));
+    }
     Ok(())
 }
 
@@ -313,8 +357,6 @@ fn build_command(
 
     if let Some(conversation_id) = conversation_id {
         command.args(["--conversation", conversation_id]);
-    } else if let Some(agent) = config.agent.as_deref() {
-        command.args(["--agent", agent]);
     }
     if let Some(effort) = config.effort.as_deref() {
         command.args(["--effort", effort]);
@@ -322,6 +364,10 @@ fn build_command(
     if let Some(home) = &config.home {
         command.env("HOME", home);
         command.env("XDG_CONFIG_HOME", home.join(".config"));
+    }
+    if let Some(bridge) = &config.bridge {
+        command.env(BRIDGE_SOCKET_ENV, &bridge.socket_path);
+        command.env(BRIDGE_TOKEN_ENV, &bridge.token);
     }
     if let Some(cwd) = &config.cwd {
         command.current_dir(cwd);
@@ -335,6 +381,112 @@ fn build_command(
     command.stdout(std::process::Stdio::piped());
     command.stderr(std::process::Stdio::piped());
     command
+}
+
+fn prepare_managed_home(config: &AntigravityConfig) -> Result<(), AntigravityError> {
+    let home = config.home.as_ref().ok_or_else(|| {
+        AntigravityError::Protocol(
+            "Antigravity clamp requires a dedicated CHAOS_AGY_HOME".to_string(),
+        )
+    })?;
+    let bridge = config.bridge.as_ref().ok_or_else(|| {
+        AntigravityError::Protocol(
+            "Antigravity clamp requires the Chaos session MCP bridge".to_string(),
+        )
+    })?;
+
+    let mcp_path = home.join(".gemini/config/mcp_config.json");
+    let mut mcp_config = read_json_object_or_empty(&mcp_path)?;
+    mcp_config["mcpServers"] = serde_json::json!({
+        CHAOS_MCP_SERVER_NAME: {
+            "command": bridge.chaos_executable,
+            "args": ["clamp-session-bridge"]
+        }
+    });
+    atomic_write_private_json(&mcp_path, &mcp_config)?;
+
+    let settings_path = home.join(".gemini/antigravity-cli/settings.json");
+    let mut settings = read_json_object_or_empty(&settings_path)?;
+    settings["permissions"] = serde_json::json!({
+        "allow": [CHAOS_MCP_ALLOW_RULE],
+        "deny": NATIVE_TOOL_DENY_RULES
+    });
+    atomic_write_private_json(&settings_path, &settings)?;
+    Ok(())
+}
+
+fn read_json_object_or_empty(path: &Path) -> Result<Value, AntigravityError> {
+    match std::fs::read(path) {
+        Ok(bytes) => {
+            let value: Value = serde_json::from_slice(&bytes).map_err(|error| {
+                AntigravityError::Protocol(format!(
+                    "invalid managed Antigravity configuration {}: {error}",
+                    path.display()
+                ))
+            })?;
+            if value.is_object() {
+                Ok(value)
+            } else {
+                Err(AntigravityError::Protocol(format!(
+                    "managed Antigravity configuration is not an object: {}",
+                    path.display()
+                )))
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Ok(Value::Object(Default::default()))
+        }
+        Err(error) => Err(AntigravityError::Spawn(error)),
+    }
+}
+
+fn atomic_write_private_json(path: &Path, value: &Value) -> Result<(), AntigravityError> {
+    let parent = path.parent().ok_or_else(|| {
+        AntigravityError::Protocol(format!(
+            "managed Antigravity configuration has no parent: {}",
+            path.display()
+        ))
+    })?;
+    std::fs::create_dir_all(parent)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))?;
+    }
+
+    let nonce = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let temporary_path = parent.join(format!(
+        ".{}.{}.{nonce}.tmp",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("managed-config"),
+        std::process::id()
+    ));
+    let bytes = serde_json::to_vec_pretty(value).map_err(|error| {
+        AntigravityError::Protocol(format!(
+            "failed to encode managed Antigravity configuration: {error}"
+        ))
+    })?;
+    let mut options = std::fs::OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    use std::io::Write;
+    let mut file = options.open(&temporary_path)?;
+    file.write_all(&bytes)?;
+    file.sync_all()?;
+    drop(file);
+    if let Err(error) = std::fs::rename(&temporary_path, path) {
+        let _ = std::fs::remove_file(&temporary_path);
+        return Err(AntigravityError::Spawn(error));
+    }
+    Ok(())
 }
 
 fn parse_events(stdout: &[u8]) -> Result<Vec<AntigravityEvent>, AntigravityError> {
@@ -378,6 +530,14 @@ fn text_indicates_auth_failure(text: &str) -> bool {
 mod tests {
     use super::*;
 
+    fn test_bridge(dir: &Path) -> AntigravityBridgeConfig {
+        AntigravityBridgeConfig {
+            socket_path: dir.join("bridge.sock"),
+            token: "ephemeral-test-token".to_string(),
+            chaos_executable: dir.join("chaos"),
+        }
+    }
+
     #[test]
     fn parses_observed_stream_json() {
         let stdout = br#"{"event":"init","conversation_id":"conversation-1","init":{"model":"gemini-3.1-pro-low","permission_mode":"request-review","tools":["run_command"]}}
@@ -392,6 +552,26 @@ mod tests {
         assert_eq!(result.conversation_id, "conversation-1");
         assert_eq!(result.response, "hello\n");
         assert_eq!(result.usage.as_ref().expect("usage").thinking_tokens, 5);
+    }
+
+    #[test]
+    fn parses_tool_steps_and_unknown_step_types() {
+        let stdout = br#"{"event":"step_update","step_update":{"conversation_id":"conversation-1","step_index":4,"state":"DONE","step_type":"tool","tool_name":"call_mcp_tool","tool_info":{"parameters":{"ServerName":"chaos","ToolName":"read_file"},"output":"ok"}}}
+{"event":"step_update","step_update":{"conversation_id":"conversation-1","step_index":5,"state":"DONE","step_type":"future_checkpoint_kind"}}
+"#;
+        let events = parse_events(stdout).expect("events should parse");
+        let AntigravityEvent::StepUpdate { step_update } = &events[0] else {
+            panic!("expected tool step");
+        };
+        assert_eq!(step_update.tool_name.as_deref(), Some("call_mcp_tool"));
+        assert_eq!(
+            step_update.tool_info.as_ref().expect("tool info")["output"],
+            "ok"
+        );
+        let AntigravityEvent::StepUpdate { step_update } = &events[1] else {
+            panic!("expected unknown step");
+        };
+        assert_eq!(step_update.step_type, "future_checkpoint_kind");
     }
 
     #[test]
@@ -439,6 +619,13 @@ esac
 if [ -n "${GEMINI_API_KEY+x}" ] || [ -n "${GOOGLE_API_KEY+x}" ]; then
   exit 91
 fi
+case "$CHAOS_CLAMP_MCP_SOCKET" in
+  */bridge.sock) ;;
+  *) exit 92 ;;
+esac
+if [ "$CHAOS_CLAMP_MCP_TOKEN" != "ephemeral-test-token" ]; then
+  exit 92
+fi
 case "$*" in
   *"--conversation conversation-1"*)
     turns=2
@@ -466,8 +653,8 @@ printf '{"event":"result","result":{"conversation_id":"conversation-1","status":
             home: Some(dir.join("home")),
             cwd: Some(dir.clone()),
             model: "gemini-test".to_string(),
-            agent: Some("transport-only".to_string()),
             print_timeout: Duration::from_secs(5),
+            bridge: Some(test_bridge(&dir)),
             ..Default::default()
         };
         let mut transport = AntigravityTransport::new(config).expect("create transport");
@@ -495,7 +682,12 @@ printf '{"event":"result","result":{"conversation_id":"conversation-1","status":
 
     #[test]
     fn command_removes_metered_api_keys_and_never_auto_approves() {
-        let config = AntigravityConfig::default();
+        let dir = std::env::temp_dir();
+        let config = AntigravityConfig {
+            home: Some(dir.join("chaos-antigravity-command-test")),
+            bridge: Some(test_bridge(&dir)),
+            ..Default::default()
+        };
         let command = build_command(&PathBuf::from("/tmp/agy"), &config, None);
         let std_command = command.as_std();
         let args = std_command
@@ -512,5 +704,101 @@ printf '{"event":"result","result":{"conversation_id":"conversation-1","status":
             .collect::<Vec<_>>();
         assert!(removed.iter().any(|name| name == "GEMINI_API_KEY"));
         assert!(removed.iter().any(|name| name == "GOOGLE_API_KEY"));
+        let envs = std_command
+            .get_envs()
+            .filter_map(|(name, value)| {
+                Some((
+                    name.to_string_lossy().into_owned(),
+                    value?.to_string_lossy().into_owned(),
+                ))
+            })
+            .collect::<std::collections::HashMap<_, _>>();
+        assert_eq!(
+            envs.get(BRIDGE_TOKEN_ENV).map(String::as_str),
+            Some("ephemeral-test-token")
+        );
+        assert_eq!(
+            envs.get(BRIDGE_SOCKET_ENV).map(String::as_str),
+            Some(dir.join("bridge.sock").to_string_lossy().as_ref())
+        );
+    }
+
+    #[test]
+    fn managed_config_exposes_only_chaos_mcp_without_persisting_capability() {
+        use std::time::SystemTime;
+
+        let unique = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "chaos-antigravity-config-test-{}-{unique}",
+            std::process::id()
+        ));
+        let settings_path = dir.join(".gemini/antigravity-cli/settings.json");
+        std::fs::create_dir_all(settings_path.parent().expect("settings parent"))
+            .expect("create settings parent");
+        std::fs::write(
+            &settings_path,
+            r#"{"theme":"dark","permissions":{"allow":["command(*)"]}}"#,
+        )
+        .expect("seed settings");
+
+        let config = AntigravityConfig {
+            home: Some(dir.clone()),
+            bridge: Some(test_bridge(&dir)),
+            ..Default::default()
+        };
+        prepare_managed_home(&config).expect("prepare managed home");
+
+        let mcp_bytes =
+            std::fs::read(dir.join(".gemini/config/mcp_config.json")).expect("read MCP config");
+        let mcp: Value = serde_json::from_slice(&mcp_bytes).expect("parse MCP config");
+        assert_eq!(
+            mcp["mcpServers"]["chaos"]["args"],
+            serde_json::json!(["clamp-session-bridge"])
+        );
+        assert_eq!(
+            mcp["mcpServers"]["chaos"]["command"],
+            dir.join("chaos").to_string_lossy().as_ref()
+        );
+        assert!(!String::from_utf8_lossy(&mcp_bytes).contains("ephemeral-test-token"));
+        assert!(!String::from_utf8_lossy(&mcp_bytes).contains("bridge.sock"));
+
+        let settings_bytes = std::fs::read(&settings_path).expect("read settings");
+        let settings: Value = serde_json::from_slice(&settings_bytes).expect("parse settings");
+        assert_eq!(settings["theme"], "dark");
+        assert_eq!(
+            settings["permissions"]["allow"],
+            serde_json::json!([CHAOS_MCP_ALLOW_RULE])
+        );
+        assert_eq!(
+            settings["permissions"]["deny"],
+            serde_json::json!(NATIVE_TOOL_DENY_RULES)
+        );
+        assert!(!String::from_utf8_lossy(&settings_bytes).contains("ephemeral-test-token"));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(dir.join(".gemini/config/mcp_config.json"))
+                    .expect("MCP metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+            assert_eq!(
+                std::fs::metadata(&settings_path)
+                    .expect("settings metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+
+        std::fs::remove_dir_all(dir).expect("remove test directory");
     }
 }

--- a/sys/modules/clamp/src/lib.rs
+++ b/sys/modules/clamp/src/lib.rs
@@ -3,15 +3,16 @@
 //! First-party model CLI subprocess transports for Chaos.
 //!
 //! Claude Code is driven through its bidirectional stream-JSON control
-//! protocol. Antigravity currently provides a model-only, sandboxed turn
-//! transport through the official `agy` CLI while its Chaos-owned tool bridge
-//! remains under development.
+//! protocol. Antigravity uses the official OAuth-authenticated `agy` CLI with
+//! native tools denied and the session-scoped Chaos MCP bridge as its action
+//! surface.
 
 mod antigravity;
 mod protocol;
 mod proxy;
 mod transport;
 
+pub use antigravity::AntigravityBridgeConfig;
 pub use antigravity::AntigravityConfig;
 pub use antigravity::AntigravityError;
 pub use antigravity::AntigravityEvent;

--- a/sys/modules/clamp/src/lib.rs
+++ b/sys/modules/clamp/src/lib.rs
@@ -1,17 +1,27 @@
 //! # chaos-clamp
 //!
-//! Claude Code subprocess module for Chaos.
+//! First-party model CLI subprocess transports for Chaos.
 //!
-//! Spawns Claude Code as a headless subprocess and drives it via the
-//! stream-json control protocol. Claude Code becomes an invisible
-//! transport layer — it authenticates with Anthropic using the user's
-//! MAX subscription, while Chaos provides all tools, controls permissions,
-//! and handles the user interface.
+//! Claude Code is driven through its bidirectional stream-JSON control
+//! protocol. Antigravity currently provides a model-only, sandboxed turn
+//! transport through the official `agy` CLI while its Chaos-owned tool bridge
+//! remains under development.
 
+mod antigravity;
 mod protocol;
 mod proxy;
 mod transport;
 
+pub use antigravity::AntigravityConfig;
+pub use antigravity::AntigravityError;
+pub use antigravity::AntigravityEvent;
+pub use antigravity::AntigravityInit;
+pub use antigravity::AntigravityResult;
+pub use antigravity::AntigravityStepUpdate;
+pub use antigravity::AntigravityToolAuthority;
+pub use antigravity::AntigravityTransport;
+pub use antigravity::AntigravityTurn;
+pub use antigravity::AntigravityUsage;
 pub use protocol::ControlRequest;
 pub use protocol::ControlResponse;
 pub use protocol::Message;

--- a/sys/modules/clamp/tests/antigravity_smoke.rs
+++ b/sys/modules/clamp/tests/antigravity_smoke.rs
@@ -1,0 +1,68 @@
+//! Live Antigravity transport smoke and resume test.
+//!
+//! Run with:
+//!   CHAOS_AGY_SMOKE=1 \
+//!   CHAOS_AGY_PATH=/path/to/agy \
+//!   CHAOS_AGY_HOME=/path/to/isolated/home \
+//!   cargo test -p chaos-clamp --test antigravity_smoke -- --ignored --nocapture
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use chaos_clamp::AntigravityConfig;
+use chaos_clamp::AntigravityToolAuthority;
+use chaos_clamp::AntigravityTransport;
+
+#[ignore = "requires an official local agy CLI and authenticated isolated home"]
+#[tokio::test]
+async fn antigravity_round_trip_and_resume() {
+    if std::env::var_os("CHAOS_AGY_SMOKE").is_none() {
+        eprintln!("skipping Antigravity smoke test; set CHAOS_AGY_SMOKE=1 to enable");
+        return;
+    }
+
+    let cli_path = std::env::var_os("CHAOS_AGY_PATH")
+        .map(PathBuf::from)
+        .expect("CHAOS_AGY_PATH must point to the pinned official agy binary");
+    let home = std::env::var_os("CHAOS_AGY_HOME")
+        .map(PathBuf::from)
+        .expect("CHAOS_AGY_HOME must point to an authenticated isolated home");
+    let model =
+        std::env::var("CHAOS_AGY_MODEL").unwrap_or_else(|_| "gemini-3.1-pro-low".to_string());
+
+    let config = AntigravityConfig {
+        cli_path: Some(cli_path),
+        home: Some(home),
+        cwd: Some(std::env::current_dir().expect("current directory")),
+        model,
+        agent: Some("souls-house-clamp".to_string()),
+        print_timeout: Duration::from_secs(120),
+        ..Default::default()
+    };
+    let mut transport = AntigravityTransport::new(config).expect("create transport");
+    assert_eq!(
+        transport.tool_authority(),
+        AntigravityToolAuthority::ModelOnlySandboxed
+    );
+
+    let fresh = transport
+        .run_turn("Reply with exactly: CHAOS_AGY_OK")
+        .await
+        .expect("fresh Antigravity turn");
+    assert_eq!(fresh.response.trim(), "CHAOS_AGY_OK");
+    assert!(
+        fresh
+            .usage
+            .as_ref()
+            .is_some_and(|usage| usage.total_tokens > 0),
+        "fresh turn should report usage"
+    );
+
+    let conversation_id = fresh.conversation_id;
+    let resumed = transport
+        .run_turn("What exact marker did you return previously? Reply with only that marker.")
+        .await
+        .expect("resumed Antigravity turn");
+    assert_eq!(resumed.conversation_id, conversation_id);
+    assert_eq!(resumed.response.trim(), "CHAOS_AGY_OK");
+}

--- a/sys/modules/clamp/tests/antigravity_smoke.rs
+++ b/sys/modules/clamp/tests/antigravity_smoke.rs
@@ -4,11 +4,15 @@
 //!   CHAOS_AGY_SMOKE=1 \
 //!   CHAOS_AGY_PATH=/path/to/agy \
 //!   CHAOS_AGY_HOME=/path/to/isolated/home \
+//!   CHAOS_CLAMP_MCP_SOCKET=/path/to/live/bridge.sock \
+//!   CHAOS_CLAMP_MCP_TOKEN=ephemeral-capability \
+//!   CHAOS_PATH=/path/to/chaos \
 //!   cargo test -p chaos-clamp --test antigravity_smoke -- --ignored --nocapture
 
 use std::path::PathBuf;
 use std::time::Duration;
 
+use chaos_clamp::AntigravityBridgeConfig;
 use chaos_clamp::AntigravityConfig;
 use chaos_clamp::AntigravityToolAuthority;
 use chaos_clamp::AntigravityTransport;
@@ -27,6 +31,14 @@ async fn antigravity_round_trip_and_resume() {
     let home = std::env::var_os("CHAOS_AGY_HOME")
         .map(PathBuf::from)
         .expect("CHAOS_AGY_HOME must point to an authenticated isolated home");
+    let socket_path = std::env::var_os("CHAOS_CLAMP_MCP_SOCKET")
+        .map(PathBuf::from)
+        .expect("CHAOS_CLAMP_MCP_SOCKET must point to a live Chaos session bridge");
+    let token = std::env::var("CHAOS_CLAMP_MCP_TOKEN")
+        .expect("CHAOS_CLAMP_MCP_TOKEN must contain the bridge capability");
+    let chaos_executable = std::env::var_os("CHAOS_PATH")
+        .map(PathBuf::from)
+        .expect("CHAOS_PATH must point to the matching Chaos executable");
     let model =
         std::env::var("CHAOS_AGY_MODEL").unwrap_or_else(|_| "gemini-3.1-pro-low".to_string());
 
@@ -35,14 +47,18 @@ async fn antigravity_round_trip_and_resume() {
         home: Some(home),
         cwd: Some(std::env::current_dir().expect("current directory")),
         model,
-        agent: Some("souls-house-clamp".to_string()),
         print_timeout: Duration::from_secs(120),
+        bridge: Some(AntigravityBridgeConfig {
+            socket_path,
+            token,
+            chaos_executable,
+        }),
         ..Default::default()
     };
     let mut transport = AntigravityTransport::new(config).expect("create transport");
     assert_eq!(
         transport.tool_authority(),
-        AntigravityToolAuthority::ModelOnlySandboxed
+        AntigravityToolAuthority::ChaosSessionBridge
     );
 
     let fresh = transport


### PR DESCRIPTION
## Provider-policy warning

This is an experimental, opt-in integration. **Using the official `agy` executable as a subprocess does not make a Chaos-driven workflow officially supported by Google or compliant with Google's current Antigravity terms.** Those terms prohibit third-party access patterns, and Google has enforced against accounts using third-party tools or proxies. Operators must accept the possibility of losing access to Antigravity and related Gemini developer services; Chaos cannot promise that enforcement will remain limited to those services.

The implementation deliberately does not read, copy, store, or submit Antigravity OAuth tokens itself. Authentication, token refresh, and Google network traffic remain inside the official `agy` process. This is a credential-safety and protocol boundary, not a claim of provider approval. The evidence, account-risk context, and design reasoning are documented in `docs/antigravity-oauth-risk-and-design.md`.

## What changed

- adds an experimental Google Antigravity (`agy`) clamp backend selected with `clamp_backend=antigravity`;
- keeps OAuth state in a mandatory dedicated `CHAOS_AGY_HOME` and exposes machine-readable `connect`, `status`, and `disconnect` lifecycle commands;
- invokes one official sandboxed `agy` subprocess per model turn and persists provider conversation IDs for cross-process resume;
- bridges the existing session-scoped Chaos MCP server into `agy`, so Gemini can use the real Chaos tool set;
- denies Antigravity's native command, filesystem, unsandboxed, and URL operations and allows only `mcp(chaos/*)`;
- keeps the bridge socket and random capability token invocation-scoped and out of persistent Antigravity configuration;
- removes `GEMINI_API_KEY` and `GOOGLE_API_KEY` so failed subscription authentication cannot silently fall back to metered billing;
- normalizes model output, tool steps, canonical command events, and provider-reported usage into Chaos events;
- preserves Chaos ownership of tool policy, approvals, hooks, process identity, lifecycle, and hosted-session orchestration;
- adds unit and end-to-end coverage for credentials, managed configuration, permissions, usage, tool bridging, and resume; and
- documents the withdrawn model-only proof of concept, rejected approaches, Google restrictions, security boundaries, operational risk, and the full bridge architecture.

This replaces the withdrawn model-only design in #25. That design authenticated and resumed Gemini but could not drive Chaos tools, so it was not useful for a resident such as Chris.

Closes #24.

## Why

A Chaos resident needs more than subscription-authenticated model text. It needs the same practical agency available through the existing Claude Code clamp: Chaos-owned tools, permissions, sandboxing, hooks, event protocol, usage accounting, process identity, and durable resume.

The supported technical seam in `agy` is MCP. The redesigned clamp therefore treats `agy` only as the OAuth-authenticated model transport while retaining Chaos as the resident runtime and policy authority. Direct OAuth-token reuse and calls from Chaos to Google's private backend were rejected because they expose credentials, reproduce the prohibited OAuth-piggybacking pattern, and couple Chaos to an undocumented protocol.

## How to verify

```bash
just fmt
scripts/with-local-qa-tmp.sh cargo check --workspace --all-features
scripts/with-local-qa-tmp.sh cargo test -p chaos-clamp --all-features
scripts/with-local-qa-tmp.sh cargo build -p chaos_journald --all-features
scripts/with-local-qa-tmp.sh cargo test -p chaos-cli --test clamp_antigravity --all-features -- --test-threads=1
just test
```

Local results on macOS arm64:

- workspace check passed;
- `chaos-clamp`: 30 passed, four explicit live-CLI tests ignored;
- `clamp_antigravity`: 5 passed;
- full suite: 2,737 tests run, 2,732 passed, 19 skipped;
- one transient `read_file_tools_run_in_parallel` failure passed immediately on focused rerun;
- the remaining four failures reproduce unchanged on clean `origin/master`:
  - `review_diff_prefetch_disables_external_diff_helpers`
  - `review_diff_prefetch_disables_textconv_helpers`
  - `undo_restores_untracked_file_edit`
  - `unified_exec_emits_one_begin_and_one_end_event`

A live smoke test with consumer OAuth and `agy 1.1.12` also verified:

1. a fresh turn calling the real Chaos `read_file` tool and using file-only information;
2. a new operating-system process resuming the same Chaos and provider conversation and calling `read_file` again;
3. a resumed turn calling the real `exec_command` tool;
4. canonical Chaos command start/completion events;
5. complete invocation and process-cumulative usage telemetry; and
6. no Gemini API key and no model-only fallback.

- [ ] Tests pass — feature tests pass; four workspace baseline failures are documented above
- [x] Builds on target hardware (macOS arm64)
