### PR TITLE
feat(config): add ChatGPT context-window preset

### DIFF
--- a/bin/console/src/app/event_dispatch.rs
+++ b/bin/console/src/app/event_dispatch.rs
@@ -726,6 +726,33 @@ impl App {
                     ));
                 }
             }
+            AppEvent::PersistChatgptContextWindow(preset) => {
+                let edit = ConfigEdit::SetPath {
+                    segments: vec!["chatgpt_context_window".to_string()],
+                    value: preset.config_value().into(),
+                };
+                if let Err(err) = ConfigEditsBuilder::new(&self.config.chaos_home)
+                    .with_edits([edit])
+                    .apply()
+                    .await
+                {
+                    tracing::error!(error = %err, "failed to persist ChatGPT context window");
+                    self.chat_widget.add_error_message(format!(
+                        "Failed to save ChatGPT context window preference: {err}"
+                    ));
+                } else {
+                    self.chat_widget.add_info_message(
+                        format!(
+                            "Saved ChatGPT context window preset: {}.",
+                            preset.config_value()
+                        ),
+                        Some(
+                            "The new context window applies when you start a new Chaos session."
+                                .to_string(),
+                        ),
+                    );
+                }
+            }
             AppEvent::OpenApprovalsPopup => {
                 self.chat_widget.open_approvals_popup();
             }

--- a/lib/libui/app_event.rs
+++ b/lib/libui/app_event.rs
@@ -27,6 +27,7 @@ use chaos_ipc::config_types::Personality;
 use chaos_ipc::openai_models::ReasoningEffort;
 use chaos_ipc::protocol::ApprovalPolicy;
 use chaos_ipc::protocol::SandboxPolicy;
+use chaos_kern::config::ChatgptContextWindow;
 use chaos_kern::config::types::ApprovalsReviewer;
 
 /// Imperative UI commands sent over the app-event bus.
@@ -230,6 +231,9 @@ pub enum AppEvent {
 
     /// Persist the dynamic parent effort preference.
     PersistDynamicParentEffort(bool),
+
+    /// Persist the ChatGPT context-window preset for newly started sessions.
+    PersistChatgptContextWindow(ChatgptContextWindow),
 
     /// Re-open the approval presets popup.
     OpenApprovalsPopup,

--- a/lib/libui/bottom_pane/chat_composer/chat_composer_tests.rs
+++ b/lib/libui/bottom_pane/chat_composer/chat_composer_tests.rs
@@ -1948,7 +1948,7 @@ fn slash_tab_completion_moves_cursor_to_end() {
         false,
     );
 
-    type_chars_humanlike(&mut composer, &['/', 'c']);
+    type_chars_humanlike(&mut composer, &['/', 'c', 'o', 'm']);
 
     let (_result, _needs_redraw) =
         composer.handle_key_event(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));

--- a/lib/libui/chatwidget.rs
+++ b/lib/libui/chatwidget.rs
@@ -54,6 +54,7 @@ use chaos_ipc::protocol::TokenUsage;
 use chaos_ipc::protocol::TokenUsageInfo;
 use chaos_ipc::user_input::TextElement;
 use chaos_ipc::user_input::UserInput;
+use chaos_kern::config::ChatgptContextWindow;
 use chaos_kern::config::Config;
 use chaos_kern::config::ConstraintResult;
 use chaos_kern::config::types::ApprovalsReviewer;

--- a/lib/libui/chatwidget/dispatch.rs
+++ b/lib/libui/chatwidget/dispatch.rs
@@ -6,6 +6,23 @@ use chaos_ipc::product::OS_NAME;
 
 use super::*;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ContextWindowArg {
+    Status,
+    Preset(ChatgptContextWindow),
+}
+
+fn parse_context_window_arg(arg: &str) -> Result<ContextWindowArg, ()> {
+    match arg.trim().to_ascii_lowercase().as_str() {
+        "catalog" | "default" => Ok(ContextWindowArg::Preset(ChatgptContextWindow::Catalog)),
+        "observed-400k" | "400k" => {
+            Ok(ContextWindowArg::Preset(ChatgptContextWindow::Observed400k))
+        }
+        "status" => Ok(ContextWindowArg::Status),
+        _ => Err(()),
+    }
+}
+
 impl ChatWidget {
     pub(super) fn dispatch_command(&mut self, cmd: SlashCommand) {
         if !cmd.available_during_task() && self.bottom_pane.is_task_running() {
@@ -45,6 +62,9 @@ impl ChatWidget {
             }
             SlashCommand::Model => {
                 self.open_model_popup();
+            }
+            SlashCommand::ContextWindow => {
+                self.show_chatgpt_context_window_status();
             }
             SlashCommand::DynamicEffort => {
                 self.show_dynamic_effort_status();
@@ -344,6 +364,26 @@ impl ChatWidget {
                 );
                 self.bottom_pane.drain_pending_submission_state();
             }
+            SlashCommand::ContextWindow if !trimmed.is_empty() => {
+                let preset = match parse_context_window_arg(trimmed) {
+                    Ok(ContextWindowArg::Preset(preset)) => preset,
+                    Ok(ContextWindowArg::Status) => {
+                        self.show_chatgpt_context_window_status();
+                        self.bottom_pane.drain_pending_submission_state();
+                        return;
+                    }
+                    _ => {
+                        self.add_error_message(
+                            "Usage: /context-window catalog|observed-400k|status".to_string(),
+                        );
+                        self.bottom_pane.drain_pending_submission_state();
+                        return;
+                    }
+                };
+                self.app_event_tx
+                    .send(AppEvent::PersistChatgptContextWindow(preset));
+                self.bottom_pane.drain_pending_submission_state();
+            }
             SlashCommand::Review if !trimmed.is_empty() => {
                 let Some((prepared_args, _prepared_elements)) = self
                     .bottom_pane
@@ -410,5 +450,52 @@ impl ChatWidget {
             ),
             Some("Use /dynamic-effort on|off|status.".to_string()),
         );
+    }
+
+    fn show_chatgpt_context_window_status(&mut self) {
+        self.add_info_message(
+            format!(
+                "ChatGPT context window preset: {}.",
+                self.config.chatgpt_context_window.config_value()
+            ),
+            Some(
+                "Use /context-window catalog|observed-400k. Changes apply to new sessions."
+                    .to_string(),
+            ),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_window_arg_accepts_documented_presets_and_aliases() {
+        assert_eq!(
+            parse_context_window_arg("catalog"),
+            Ok(ContextWindowArg::Preset(ChatgptContextWindow::Catalog))
+        );
+        assert_eq!(
+            parse_context_window_arg("default"),
+            Ok(ContextWindowArg::Preset(ChatgptContextWindow::Catalog))
+        );
+        assert_eq!(
+            parse_context_window_arg("observed-400k"),
+            Ok(ContextWindowArg::Preset(ChatgptContextWindow::Observed400k))
+        );
+        assert_eq!(
+            parse_context_window_arg("400K"),
+            Ok(ContextWindowArg::Preset(ChatgptContextWindow::Observed400k))
+        );
+        assert_eq!(
+            parse_context_window_arg("status"),
+            Ok(ContextWindowArg::Status)
+        );
+    }
+
+    #[test]
+    fn context_window_arg_rejects_unknown_preset() {
+        assert_eq!(parse_context_window_arg("huge"), Err(()));
     }
 }

--- a/lib/libui/chatwidget/tests.rs
+++ b/lib/libui/chatwidget/tests.rs
@@ -108,6 +108,7 @@ use chaos_ipc::user_input::TextElement;
 use chaos_ipc::user_input::UserInput;
 use chaos_kern::ChaosAuth;
 use chaos_kern::config::ApprovalsReviewer;
+use chaos_kern::config::ChatgptContextWindow;
 use chaos_kern::config::Config;
 use chaos_kern::config::ConfigBuilder;
 #[cfg(feature = "vt100-tests")]
@@ -314,6 +315,8 @@ pub(crate) async fn chatwidget_suite() {
     Box::pin(set_reasoning_effort_updates_active_collaboration_mask()).await;
     Box::pin(backtab_mode_switch_refreshes_wpn_statusline_effort()).await;
     Box::pin(set_reasoning_effort_does_not_override_active_plan_override()).await;
+    Box::pin(slash_context_window_observed_400k_requests_persistence()).await;
+    Box::pin(slash_context_window_rejects_unknown_preset()).await;
     Box::pin(slash_quit_requests_exit()).await;
     Box::pin(slash_copy_state_tracks_turn_complete_final_reply()).await;
     Box::pin(slash_copy_state_tracks_plan_item_completion()).await;
@@ -5643,6 +5646,35 @@ async fn slash_quit_requests_exit() {
     chat.dispatch_command(SlashCommand::Quit);
 
     assert_matches!(rx.try_recv(), Ok(AppEvent::Exit(ExitMode::ShutdownFirst)));
+}
+
+#[cfg(test)]
+async fn slash_context_window_observed_400k_requests_persistence() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
+
+    chat.dispatch_command_with_args(SlashCommand::ContextWindow, "400k".to_string(), Vec::new());
+
+    assert_matches!(
+        rx.try_recv(),
+        Ok(AppEvent::PersistChatgptContextWindow(
+            ChatgptContextWindow::Observed400k
+        ))
+    );
+}
+
+#[cfg(test)]
+async fn slash_context_window_rejects_unknown_preset() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
+
+    chat.dispatch_command_with_args(SlashCommand::ContextWindow, "huge".to_string(), Vec::new());
+
+    let cells = drain_insert_history(&mut rx);
+    assert_eq!(cells.len(), 1, "expected one usage error");
+    let rendered = lines_to_single_string(&cells[0]);
+    assert!(
+        rendered.contains("Usage: /context-window catalog|observed-400k|status"),
+        "expected context-window usage, got {rendered:?}"
+    );
 }
 
 #[cfg(test)]

--- a/lib/libui/slash_command.rs
+++ b/lib/libui/slash_command.rs
@@ -14,6 +14,7 @@ pub enum SlashCommand {
     // DO NOT ALPHA-SORT! Enum order is presentation order in the popup, so
     // more frequently used commands should be listed first.
     Model,
+    ContextWindow,
     DynamicEffort,
     Approvals,
     Permissions,
@@ -86,6 +87,9 @@ impl SlashCommand {
             SlashCommand::MemoryDrop => "DO NOT USE".into(),
             SlashCommand::MemoryUpdate => "DO NOT USE".into(),
             SlashCommand::Model => "choose what model and reasoning effort to use".into(),
+            SlashCommand::ContextWindow => {
+                "choose the ChatGPT context window used for new sessions".into()
+            }
             SlashCommand::DynamicEffort => {
                 "allow or disallow model-controlled effort changes".into()
             }
@@ -130,6 +134,7 @@ impl SlashCommand {
             SlashCommand::Review
                 | SlashCommand::Rename
                 | SlashCommand::Plan
+                | SlashCommand::ContextWindow
                 | SlashCommand::DynamicEffort
                 | SlashCommand::SandboxReadRoot
         )
@@ -143,6 +148,7 @@ impl SlashCommand {
             | SlashCommand::Fork
             | SlashCommand::Compact
             | SlashCommand::Model
+            | SlashCommand::ContextWindow
             | SlashCommand::DynamicEffort
             | SlashCommand::ElevateSandbox
             | SlashCommand::SandboxReadRoot
@@ -225,6 +231,7 @@ pub(crate) mod tests {
         stop_command_is_canonical_name();
         clean_alias_parses_to_stop_command();
         dynamic_effort_accepts_inline_args();
+        context_window_accepts_inline_args();
     }
     #[cfg(test)]
     fn stop_command_is_canonical_name() {
@@ -243,5 +250,14 @@ pub(crate) mod tests {
             Ok(SlashCommand::DynamicEffort)
         );
         assert!(SlashCommand::DynamicEffort.supports_inline_args());
+    }
+
+    #[test]
+    fn context_window_accepts_inline_args() {
+        assert_eq!(
+            SlashCommand::from_str("context-window"),
+            Ok(SlashCommand::ContextWindow)
+        );
+        assert!(SlashCommand::ContextWindow.supports_inline_args());
     }
 }

--- a/man/chaos-providers.7.md
+++ b/man/chaos-providers.7.md
@@ -47,6 +47,49 @@ environment, and go.
 
 ## EXAMPLES
 
+### OpenAI ChatGPT context window
+
+For GPT-5.6 Sol, Chaos uses the context window advertised by the provider
+catalog by default:
+
+```toml
+chatgpt_context_window = "catalog"
+```
+
+The ChatGPT OAuth route has also been observed accepting more context than its
+catalog advertises. Users who prefer the experimentally observed window can
+opt in:
+
+```toml
+chatgpt_context_window = "observed-400k"
+```
+
+You can also persist either choice from the TUI:
+
+```text
+/context-window catalog
+/context-window observed-400k
+```
+
+Run `/context-window` or `/context-window status` to show the active preset.
+Changes made through the command apply to newly started Chaos sessions.
+
+For `gpt-5.6-sol` on the built-in OpenAI provider, this selects a 400,000-token
+window and automatic compaction at 350,000 tokens. It does not change other
+models or providers. The provider may change its accepted limit independently
+of Chaos, so `catalog` remains the default.
+
+The lower-level numeric settings remain available for advanced use:
+
+```toml
+model_context_window = 400000
+model_auto_compact_token_limit = 350000
+```
+
+An explicit `model_context_window` disables the named preset. An explicit
+`model_auto_compact_token_limit` overrides the preset's 350,000-token
+compaction point.
+
 ### xAI (Grok)
 
 Bundled — no config needed. Just export the key:

--- a/sys/kern/kern/src/config.rs
+++ b/sys/kern/kern/src/config.rs
@@ -107,6 +107,33 @@ pub(crate) const DEFAULT_MINION_JOB_MAX_RUNTIME_SECONDS: Option<u64> = None;
 
 pub const CONFIG_TOML_FILE: &str = "config.toml";
 
+pub const OBSERVED_CHATGPT_CONTEXT_WINDOW_TOKENS: i64 = 400_000;
+pub const OBSERVED_CHATGPT_AUTO_COMPACT_TOKEN_LIMIT: i64 = 350_000;
+
+/// Selects whether Chaos trusts the provider catalog's ChatGPT context window
+/// or uses a larger empirically verified window for supported models.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum ChatgptContextWindow {
+    /// Use the context window and compaction threshold supplied by the model
+    /// catalog. This preserves the existing behavior.
+    #[default]
+    Catalog,
+    /// For GPT-5.6 Sol on the OpenAI provider, use the 400k window observed on
+    /// the ChatGPT OAuth route and compact conservatively at 350k.
+    #[serde(rename = "observed-400k")]
+    Observed400k,
+}
+
+impl ChatgptContextWindow {
+    pub const fn config_value(self) -> &'static str {
+        match self {
+            Self::Catalog => "catalog",
+            Self::Observed400k => "observed-400k",
+        }
+    }
+}
+
 /// First-party CLI transport selected when clamp mode is enabled.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
@@ -257,6 +284,9 @@ pub struct Config {
 
     /// Size of the context window for the model, in tokens.
     pub model_context_window: Option<i64>,
+
+    /// Context-window preset for GPT-5.6 Sol on the OpenAI ChatGPT route.
+    pub chatgpt_context_window: ChatgptContextWindow,
 
     /// Token usage threshold triggering auto-compaction of conversation history.
     pub model_auto_compact_token_limit: Option<i64>,
@@ -577,6 +607,16 @@ pub struct ConfigToml {
 
     /// Size of the context window for the model, in tokens.
     pub model_context_window: Option<i64>,
+
+    /// Context-window preset for GPT-5.6 Sol on the OpenAI ChatGPT route.
+    ///
+    /// `"catalog"` (the default) preserves provider-advertised behavior.
+    /// `"observed-400k"` uses a 400,000-token context window and a conservative
+    /// 350,000-token auto-compaction threshold. Explicit
+    /// `model_context_window` and `model_auto_compact_token_limit` values take
+    /// precedence.
+    #[serde(default)]
+    pub chatgpt_context_window: Option<ChatgptContextWindow>,
 
     /// Token usage threshold triggering auto-compaction of conversation history.
     pub model_auto_compact_token_limit: Option<i64>,

--- a/sys/kern/kern/src/config/config_tests.rs
+++ b/sys/kern/kern/src/config/config_tests.rs
@@ -913,6 +913,7 @@ fn expected_precedence_fixture_config_baseline(fixture: &PrecedenceTestFixture) 
         model: Some("o3".to_string()),
         review_model: None,
         model_context_window: None,
+        chatgpt_context_window: ChatgptContextWindow::Catalog,
         model_auto_compact_token_limit: None,
         model_auto_compact_token_limit_scope: Default::default(),
         service_tier: None,

--- a/sys/kern/kern/src/config/config_tests/compact_and_catalog.rs
+++ b/sys/kern/kern/src/config/config_tests/compact_and_catalog.rs
@@ -1,6 +1,60 @@
 use super::*;
 
 #[test]
+fn chatgpt_context_window_defaults_to_catalog() -> std::io::Result<()> {
+    let chaos_home = TempDir::new()?;
+    let config = Config::load_from_base_config_with_overrides(
+        ConfigToml::default(),
+        ConfigOverrides::default(),
+        chaos_home.path().to_path_buf(),
+    )?;
+
+    assert_eq!(config.chatgpt_context_window, ChatgptContextWindow::Catalog);
+    Ok(())
+}
+
+#[test]
+fn chatgpt_context_window_loads_observed_400k_preset() -> std::io::Result<()> {
+    let chaos_home = TempDir::new()?;
+    let config = Config::load_from_base_config_with_overrides(
+        ConfigToml {
+            chatgpt_context_window: Some(ChatgptContextWindow::Observed400k),
+            ..Default::default()
+        },
+        ConfigOverrides::default(),
+        chaos_home.path().to_path_buf(),
+    )?;
+
+    assert_eq!(
+        config.chatgpt_context_window,
+        ChatgptContextWindow::Observed400k
+    );
+    Ok(())
+}
+
+#[test]
+fn chatgpt_context_window_deserializes_observed_400k_name() {
+    let config: ConfigToml =
+        toml::from_str(r#"chatgpt_context_window = "observed-400k""#).expect("valid preset");
+
+    assert_eq!(
+        config.chatgpt_context_window,
+        Some(ChatgptContextWindow::Observed400k)
+    );
+}
+
+#[test]
+fn config_schema_exposes_chatgpt_context_window_presets() {
+    let schema =
+        String::from_utf8(crate::config::schema::config_schema_json().expect("valid schema"))
+            .expect("UTF-8 schema");
+
+    assert!(schema.contains(r#""chatgpt_context_window""#));
+    assert!(schema.contains(r#""catalog""#));
+    assert!(schema.contains(r#""observed-400k""#));
+}
+
+#[test]
 fn cli_override_sets_compact_prompt() -> std::io::Result<()> {
     let chaos_home = TempDir::new()?;
     let overrides = ConfigOverrides {

--- a/sys/kern/kern/src/config/requirements.rs
+++ b/sys/kern/kern/src/config/requirements.rs
@@ -616,6 +616,7 @@ impl Config {
             service_tier,
             review_model,
             model_context_window: cfg.model_context_window,
+            chatgpt_context_window: cfg.chatgpt_context_window.unwrap_or_default(),
             model_auto_compact_token_limit: cfg.model_auto_compact_token_limit,
             model_auto_compact_token_limit_scope: cfg
                 .model_auto_compact_token_limit_scope

--- a/sys/kern/kern/src/models_manager/model_info.rs
+++ b/sys/kern/kern/src/models_manager/model_info.rs
@@ -1,6 +1,9 @@
 use chaos_ipc::openai_models::ModelInfo;
 
+use crate::config::ChatgptContextWindow;
 use crate::config::Config;
+use crate::config::OBSERVED_CHATGPT_AUTO_COMPACT_TOKEN_LIMIT;
+use crate::config::OBSERVED_CHATGPT_CONTEXT_WINDOW_TOKENS;
 use crate::truncate::approx_bytes_for_tokens;
 
 // Re-export pure ABI conversion from the catalog crate.
@@ -14,11 +17,20 @@ pub(crate) fn with_config_overrides(mut model: ModelInfo, config: &Config) -> Mo
     {
         model.supports_reasoning_summaries = true;
     }
+    let use_observed_chatgpt_window = config.model_context_window.is_none()
+        && config.chatgpt_context_window == ChatgptContextWindow::Observed400k
+        && config.model_provider.is_openai()
+        && model.slug == "gpt-5.6-sol";
+
     if let Some(context_window) = config.model_context_window {
         model.context_window = Some(context_window);
+    } else if use_observed_chatgpt_window {
+        model.context_window = Some(OBSERVED_CHATGPT_CONTEXT_WINDOW_TOKENS);
     }
     if let Some(auto_compact_token_limit) = config.model_auto_compact_token_limit {
         model.auto_compact_token_limit = Some(auto_compact_token_limit);
+    } else if use_observed_chatgpt_window {
+        model.auto_compact_token_limit = Some(OBSERVED_CHATGPT_AUTO_COMPACT_TOKEN_LIMIT);
     }
     if let Some(token_limit) = config.tool_output_token_limit {
         use chaos_ipc::openai_models::TruncationMode;

--- a/sys/kern/kern/src/models_manager/model_info_tests.rs
+++ b/sys/kern/kern/src/models_manager/model_info_tests.rs
@@ -1,4 +1,7 @@
 use super::*;
+use crate::config::ChatgptContextWindow;
+use crate::config::OBSERVED_CHATGPT_AUTO_COMPACT_TOKEN_LIMIT;
+use crate::config::OBSERVED_CHATGPT_CONTEXT_WINDOW_TOKENS;
 use crate::config::test_config;
 use chaos_abi::AbiModelInfo;
 
@@ -37,6 +40,75 @@ fn unknown_model() -> ModelInfo {
         supports_reasoning_effort: false,
         native_server_side_tools: vec![],
     })
+}
+
+fn sol_model() -> ModelInfo {
+    let mut model = unknown_model();
+    model.slug = "gpt-5.6-sol".to_string();
+    model.context_window = Some(272_000);
+    model.auto_compact_token_limit = None;
+    model
+}
+
+#[test]
+fn observed_chatgpt_window_expands_sol_and_sets_conservative_compaction() {
+    let model = sol_model();
+    let mut config = test_config();
+    config.chatgpt_context_window = ChatgptContextWindow::Observed400k;
+
+    let updated = with_config_overrides(model, &config);
+
+    assert_eq!(
+        updated.context_window,
+        Some(OBSERVED_CHATGPT_CONTEXT_WINDOW_TOKENS)
+    );
+    assert_eq!(
+        updated.auto_compact_token_limit,
+        Some(OBSERVED_CHATGPT_AUTO_COMPACT_TOKEN_LIMIT)
+    );
+}
+
+#[test]
+fn observed_chatgpt_window_does_not_change_other_models() {
+    let mut model = unknown_model();
+    model.context_window = Some(272_000);
+    model.auto_compact_token_limit = None;
+    let mut config = test_config();
+    config.chatgpt_context_window = ChatgptContextWindow::Observed400k;
+
+    let updated = with_config_overrides(model, &config);
+
+    assert_eq!(updated.context_window, Some(272_000));
+    assert_eq!(updated.auto_compact_token_limit, None);
+}
+
+#[test]
+fn explicit_context_window_disables_observed_chatgpt_preset() {
+    let model = sol_model();
+    let mut config = test_config();
+    config.chatgpt_context_window = ChatgptContextWindow::Observed400k;
+    config.model_context_window = Some(500_000);
+
+    let updated = with_config_overrides(model, &config);
+
+    assert_eq!(updated.context_window, Some(500_000));
+    assert_eq!(updated.auto_compact_token_limit, None);
+}
+
+#[test]
+fn explicit_compaction_limit_overrides_observed_chatgpt_preset() {
+    let model = sol_model();
+    let mut config = test_config();
+    config.chatgpt_context_window = ChatgptContextWindow::Observed400k;
+    config.model_auto_compact_token_limit = Some(340_000);
+
+    let updated = with_config_overrides(model, &config);
+
+    assert_eq!(
+        updated.context_window,
+        Some(OBSERVED_CHATGPT_CONTEXT_WINDOW_TOKENS)
+    );
+    assert_eq!(updated.auto_compact_token_limit, Some(340_000));
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- add a `chatgpt_context_window` preset with the unchanged `catalog` default and an opt-in `observed-400k` mode
- apply the 400k window and a 350k auto-compaction threshold only to `gpt-5.6-sol` on the built-in OpenAI provider
- add `/context-window catalog|observed-400k|status`, persisted for new sessions
- document precedence and cover config, model-selection, command parsing, and dispatch behavior with tests

## Why

The ChatGPT OAuth route accepted substantially more context than the catalog currently advertises in graceful boundary tests. Users should be able to choose between the conservative catalog value and the empirically observed limit instead of having Chaos enforce one policy for everyone.

Closes #32.

## How to verify

- `just fmt`
- targeted config, model override, slash-command, UI-dispatch, and console build checks pass
- `cargo nextest run -p libui -E 'test(chat_composer_slash_suite)'` passes
- `just test`: 2,791 passed; 3 unrelated failures reproduce individually on the current `master` code paths:
  - `review_diff_prefetch_disables_external_diff_helpers`
  - `review_diff_prefetch_disables_textconv_helpers`
  - `undo_restores_untracked_file_edit`

- [ ] Tests pass (targeted tests pass; workspace exceptions listed above)
- [x] Builds on target hardware
