### PR TITLE
feat(compaction): emit pending context warnings

### DIFF
--- a/lib/libcontract/ipc/src/protocol/event_msg.rs
+++ b/lib/libcontract/ipc/src/protocol/event_msg.rs
@@ -78,6 +78,7 @@ use super::CollabResumeBeginEvent;
 use super::CollabResumeEndEvent;
 use super::CollabWaitingBeginEvent;
 use super::CollabWaitingEndEvent;
+use super::CompactionPendingEvent;
 
 /// Event Queue Entry - events from agent
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -120,6 +121,9 @@ pub enum EventMsg {
 
     /// Conversation history was compacted (either automatically or manually).
     ContextCompacted(ContextCompactedEvent),
+
+    /// The active context is approaching automatic compaction.
+    CompactionPending(CompactionPendingEvent),
 
     /// Conversation history was rolled back by dropping the last N user turns.
     #[serde(rename = "process_rolled_back")]

--- a/lib/libcontract/ipc/src/protocol/events_agent.rs
+++ b/lib/libcontract/ipc/src/protocol/events_agent.rs
@@ -34,6 +34,25 @@ pub struct ParentEffortChangedEvent {
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, TS)]
 pub struct ContextCompactedEvent;
 
+/// Advance notice that the current context window is approaching automatic
+/// compaction. Emitted at most once per pressure window.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+pub struct CompactionPendingEvent {
+    pub window_id: String,
+    #[ts(type = "number")]
+    pub window_number: i64,
+    #[ts(type = "number")]
+    pub active_tokens: i64,
+    #[ts(type = "number")]
+    pub scope_tokens: i64,
+    #[ts(type = "number")]
+    pub tokens_until_compaction: i64,
+    #[ts(type = "number")]
+    pub compaction_token_limit: i64,
+    #[ts(type = "number")]
+    pub context_window: i64,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, TS)]
 pub struct TurnCompleteEvent {
     pub turn_id: String,

--- a/lib/libui/chatwidget/events/protocol_dispatch/dispatch.rs
+++ b/lib/libui/chatwidget/events/protocol_dispatch/dispatch.rs
@@ -209,6 +209,13 @@ impl ChatWidget {
             }
             EventMsg::ExitedReviewMode(review) => self.on_exited_review_mode(review),
             EventMsg::ContextCompacted(_) => self.on_agent_message("Context compacted".to_owned()),
+            EventMsg::CompactionPending(event) => self.on_warning(format!(
+                "Automatic compaction is approaching: {} tokens remain ({} active, {} threshold, {} context window).",
+                event.tokens_until_compaction,
+                event.active_tokens,
+                event.compaction_token_limit,
+                event.context_window
+            )),
             EventMsg::CollabAgentSpawnBegin(CollabAgentSpawnBeginEvent {
                 call_id,
                 model,

--- a/man/chaos-providers.7.md
+++ b/man/chaos-providers.7.md
@@ -90,6 +90,13 @@ An explicit `model_context_window` disables the named preset. An explicit
 `model_auto_compact_token_limit` overrides the preset's 350,000-token
 compaction point.
 
+As a context window approaches automatic compaction, Chaos emits a durable
+`compaction_pending` event once for that pressure window. The TUI shows the
+remaining token count, active token count, configured compaction threshold, and
+hard context window. The warning begins when the session enters the reserve
+band between the automatic compaction threshold and the hard context limit. It
+does not itself change or defer compaction.
+
 ### xAI (Grok)
 
 Bundled — no config needed. Just export the key:

--- a/srv/mcpd/src/chaos_runner.rs
+++ b/srv/mcpd/src/chaos_runner.rs
@@ -349,6 +349,7 @@ async fn run_event_loop(
                     // Events forwarded as notifications — no special handling.
                     EventMsg::PlanDelta(_)
                     | EventMsg::Warning(_)
+                    | EventMsg::CompactionPending(_)
                     | EventMsg::SessionConfigured(_)
                     | EventMsg::McpStartupUpdate(_)
                     | EventMsg::McpStartupComplete(_)

--- a/sys/exec/fork/src/event_processor_with_human_output/helpers.rs
+++ b/sys/exec/fork/src/event_processor_with_human_output/helpers.rs
@@ -132,6 +132,7 @@ impl EventProcessorWithHumanOutput {
             msg,
             EventMsg::Error(_)
                 | EventMsg::Warning(_)
+                | EventMsg::CompactionPending(_)
                 | EventMsg::DeprecationNotice(_)
                 | EventMsg::StreamError(_)
                 | EventMsg::TurnComplete(_)

--- a/sys/exec/fork/src/event_processor_with_human_output/processor.rs
+++ b/sys/exec/fork/src/event_processor_with_human_output/processor.rs
@@ -121,6 +121,17 @@ impl EventProcessor for EventProcessorWithHumanOutput {
                     "warning:".style(self.yellow).style(self.bold)
                 );
             }
+            EventMsg::CompactionPending(event) => {
+                ts_msg!(
+                    self,
+                    "{} automatic compaction is approaching: {} tokens remain ({} active, {} threshold, {} context window)",
+                    "warning:".style(self.yellow).style(self.bold),
+                    event.tokens_until_compaction,
+                    event.active_tokens,
+                    event.compaction_token_limit,
+                    event.context_window
+                );
+            }
 
             EventMsg::ModelReroute(_) | EventMsg::ParentEffortChanged(_) => {}
             EventMsg::DeprecationNotice(DeprecationNoticeEvent { summary, details }) => {

--- a/sys/kern/kern/src/chaos/session/tokens.rs
+++ b/sys/kern/kern/src/chaos/session/tokens.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
 use chaos_ipc::models::BaseInstructions;
+use chaos_ipc::protocol::CompactionPendingEvent;
+use chaos_ipc::protocol::EventMsg;
 use chaos_ipc::protocol::TokenCountEvent;
 use chaos_ipc::protocol::TokenUsage;
 use chaos_ipc::protocol::TokenUsageInfo;
@@ -9,6 +11,18 @@ use crate::context_manager::TotalTokenUsageBreakdown;
 
 use super::Session;
 use crate::chaos::TurnContext;
+
+fn compaction_warning_reserve(context_window: i64, compaction_token_limit: i64) -> i64 {
+    context_window.saturating_sub(compaction_token_limit).max(1)
+}
+
+fn compaction_warning_due(
+    remaining: i64,
+    context_window: i64,
+    compaction_token_limit: i64,
+) -> bool {
+    remaining <= compaction_warning_reserve(context_window, compaction_token_limit)
+}
 
 impl Session {
     /// Measures the current context load against the model's allotments,
@@ -32,6 +46,70 @@ impl Session {
                 context_window: turn_context.model_context_window(),
             },
         )
+    }
+
+    /// Emits at most one durable warning per pressure window when the session
+    /// enters the reserve band immediately before automatic compaction.
+    ///
+    /// The reserve band is the gap between the configured automatic
+    /// compaction threshold and the model's hard context window. For example,
+    /// a 350k threshold in a 400k window warns with 50k tokens remaining.
+    pub(crate) async fn maybe_emit_compaction_pending(
+        &self,
+        turn_context: &TurnContext,
+    ) -> chaos_context::allotment::AllotmentStatus {
+        let (allotment, pending) = {
+            let mut state = self.state.lock().await;
+            let active_tokens = state.get_total_token_usage(state.server_reasoning_included());
+            let baseline = state
+                .pressure
+                .baseline()
+                .map(chaos_context::pressure::Baseline::tokens);
+            let auto_compact_token_limit = turn_context.model_info.auto_compact_token_limit();
+            let context_window = turn_context.model_context_window();
+            let allotment = chaos_context::allotment::status(
+                turn_context.config.model_auto_compact_token_limit_scope,
+                active_tokens,
+                baseline,
+                chaos_context::allotment::Limits {
+                    auto_distill_token_limit: auto_compact_token_limit,
+                    context_window,
+                },
+            );
+
+            let pending = match (
+                auto_compact_token_limit,
+                context_window,
+                allotment.tokens_until_distillation,
+            ) {
+                (Some(compaction_token_limit), Some(context_window), Some(remaining)) => {
+                    if compaction_warning_due(remaining, context_window, compaction_token_limit)
+                        && state.pressure.claim_reminder()
+                    {
+                        Some(CompactionPendingEvent {
+                            window_id: state.pressure.window_id().to_string(),
+                            window_number: i64::try_from(state.pressure.window_number())
+                                .unwrap_or(i64::MAX),
+                            active_tokens,
+                            scope_tokens: allotment.scope_tokens,
+                            tokens_until_compaction: remaining,
+                            compaction_token_limit,
+                            context_window,
+                        })
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            };
+            (allotment, pending)
+        };
+
+        if let Some(pending) = pending {
+            self.send_event(turn_context, EventMsg::CompactionPending(pending))
+                .await;
+        }
+        allotment
     }
 
     pub(crate) async fn get_total_token_usage_breakdown(&self) -> TotalTokenUsageBreakdown {
@@ -217,5 +295,31 @@ impl Session {
             state.set_token_usage_full(context_window);
         }
         self.send_token_count_event(turn_context).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compaction_warning_due;
+    use super::compaction_warning_reserve;
+
+    #[test]
+    fn compaction_warning_uses_the_soft_to_hard_limit_gap() {
+        assert_eq!(compaction_warning_reserve(400_000, 350_000), 50_000);
+        assert_eq!(compaction_warning_reserve(272_000, 244_800), 27_200);
+        assert_eq!(compaction_warning_reserve(272_000, 217_600), 54_400);
+    }
+
+    #[test]
+    fn compaction_warning_keeps_a_minimum_reserve() {
+        assert_eq!(compaction_warning_reserve(100, 100), 1);
+        assert_eq!(compaction_warning_reserve(100, 110), 1);
+    }
+
+    #[test]
+    fn compaction_warning_starts_at_the_reserve_boundary() {
+        assert!(!compaction_warning_due(50_001, 400_000, 350_000));
+        assert!(compaction_warning_due(50_000, 400_000, 350_000));
+        assert!(compaction_warning_due(0, 400_000, 350_000));
     }
 }

--- a/sys/kern/kern/src/chaos/turn.rs
+++ b/sys/kern/kern/src/chaos/turn.rs
@@ -355,7 +355,9 @@ pub(crate) async fn run_turn(
                     needs_follow_up,
                     last_agent_message: sampling_request_last_agent_message,
                 } = sampling_request_output;
-                let allotment = sess.allotment_status(turn_context.as_ref()).await;
+                let allotment = sess
+                    .maybe_emit_compaction_pending(turn_context.as_ref())
+                    .await;
                 let token_limit_reached = allotment.limit_reached;
 
                 let estimated_token_count =

--- a/sys/kern/kern/src/chaos/turn/preparation.rs
+++ b/sys/kern/kern/src/chaos/turn/preparation.rs
@@ -90,6 +90,10 @@ pub(super) async fn run_auto_compact(
     turn_context: &Arc<TurnContext>,
     initial_context_injection: InitialContextInjection,
 ) -> ChaosResult<()> {
+    // The ordinary post-sampling path emits this while there is still a reserve
+    // band available. This call is the last-resort path for resumed sessions,
+    // pre-turn compaction, and model switches that arrive already at the limit.
+    sess.maybe_emit_compaction_pending(turn_context).await;
     if should_use_remote_distill_task(&turn_context.provider) {
         run_inline_remote_auto_distill_task(
             Arc::clone(sess),

--- a/sys/kern/kern/src/rollout/policy.rs
+++ b/sys/kern/kern/src/rollout/policy.rs
@@ -58,6 +58,7 @@ fn event_msg_persistence_mode(ev: &EventMsg) -> Option<EventPersistenceMode> {
         | EventMsg::AgentReasoning(_)
         | EventMsg::AgentReasoningRawContent(_)
         | EventMsg::TokenCount(_)
+        | EventMsg::CompactionPending(_)
         | EventMsg::ContextCompacted(_)
         | EventMsg::EnteredReviewMode(_)
         | EventMsg::ExitedReviewMode(_)
@@ -140,6 +141,7 @@ fn event_msg_persistence_mode(ev: &EventMsg) -> Option<EventPersistenceMode> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chaos_ipc::protocol::CompactionPendingEvent;
     use chaos_ipc::protocol::TurnProgressEvent;
 
     #[test]
@@ -154,6 +156,24 @@ mod tests {
         assert!(!should_persist_event_msg(
             &event,
             EventPersistenceMode::Extended
+        ));
+    }
+
+    #[test]
+    fn compaction_pending_is_persisted_in_limited_mode() {
+        let event = EventMsg::CompactionPending(CompactionPendingEvent {
+            window_id: "window-1".to_string(),
+            window_number: 0,
+            active_tokens: 310_000,
+            scope_tokens: 310_000,
+            tokens_until_compaction: 40_000,
+            compaction_token_limit: 350_000,
+            context_window: 400_000,
+        });
+
+        assert!(should_persist_event_msg(
+            &event,
+            EventPersistenceMode::Limited
         ));
     }
 }


### PR DESCRIPTION
## What?

Add a durable `CompactionPending` lifecycle event that reports the current pressure-window identity, token usage, configured threshold, hard context window, and remaining countdown.

## Why?

Automatic compaction currently arrives without a persistent, machine-readable warning. Agents and frontends need enough notice to surface pressure and prepare continuity work before history replacement begins.

## How?

- emit once when a pressure window enters the reserve band before auto-compaction
- persist the event in rollout history
- provide a last-resort emission immediately before compaction for resumed or already-over-limit sessions
- render it in TUI and headless output and forward it through `mcpd`
- document and test the lifecycle behavior

Closes #34 in part; later PRs add checkpoints, a durability barrier, and archive access.

## Verification

- `just fmt`
- focused kernel, protocol, TUI, headless, and mcpd tests
- `cargo check --workspace --all-features`
- full `just test`: 2,793 passed; four failures reproduced as unrelated baseline failures (review-diff prefetch x2, undo restoring an untracked edit, unified-exec lifecycle)
