### PR TITLE
feat(compaction): give agents an early continuity reflex

### DIFF
--- a/man/chaos-providers.7.md
+++ b/man/chaos-providers.7.md
@@ -90,6 +90,16 @@ An explicit `model_context_window` disables the named preset. An explicit
 `model_auto_compact_token_limit` overrides the preset's 350,000-token
 compaction point.
 
+Before automatic compaction, Chaos uses the reserve between the compaction
+threshold and the hard context window to inject a once-per-window,
+model-visible continuity reflex. The agent receives the notice in ordinary
+conversation history and sees it on the next normal model iteration with its
+usual tools, allowing it to perform its configured journaling, memory, or
+operational continuity practices. If token usage has already crossed the soft
+compaction threshold while remaining below the 90% safety ceiling, Chaos grants
+one immediate iteration before compacting. The reflex is directed to the agent
+rather than emitted as a user-facing compaction warning.
+
 ### xAI (Grok)
 
 Bundled — no config needed. Just export the key:

--- a/sys/kern/kern/src/chaos/session/tokens.rs
+++ b/sys/kern/kern/src/chaos/session/tokens.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
 use chaos_ipc::models::BaseInstructions;
+use chaos_ipc::models::DeveloperInstructions;
+use chaos_ipc::models::ResponseItem;
 use chaos_ipc::protocol::TokenCountEvent;
 use chaos_ipc::protocol::TokenUsage;
 use chaos_ipc::protocol::TokenUsageInfo;
@@ -9,6 +11,41 @@ use crate::context_manager::TotalTokenUsageBreakdown;
 
 use super::Session;
 use crate::chaos::TurnContext;
+
+fn compaction_reflex_reserve(context_window: i64, compaction_token_limit: i64) -> i64 {
+    let soft_to_hard_gap = context_window.saturating_sub(compaction_token_limit).max(1);
+    let proportional_lead = compaction_token_limit.saturating_div(4).max(1);
+    soft_to_hard_gap.min(proportional_lead)
+}
+
+fn compaction_reflex_due(remaining: i64, context_window: i64, compaction_token_limit: i64) -> bool {
+    remaining <= compaction_reflex_reserve(context_window, compaction_token_limit)
+}
+
+fn compaction_reflex_follow_up_allowed(active_tokens: i64, context_window: i64) -> bool {
+    active_tokens < context_window.saturating_mul(9).saturating_div(10)
+}
+
+fn compaction_reflex_instructions(
+    window_id: &str,
+    window_number: i64,
+    active_tokens: i64,
+    tokens_until_compaction: i64,
+    compaction_token_limit: i64,
+    context_window: i64,
+) -> String {
+    format!(
+        "<compaction_reflex window_id=\"{window_id}\" window_number=\"{window_number}\">\n\
+Automatic context compaction is approaching. This notice is for you, the continuing agent, not merely for the user.\n\n\
+Current context: approximately {active_tokens} active tokens.\n\
+Automatic compaction threshold: {compaction_token_limit} tokens.\n\
+Hard context window: {context_window} tokens.\n\
+Estimated tokens remaining before automatic compaction: {tokens_until_compaction}.\n\n\
+Before continuing substantive work, pause and consider whether anything should be preserved across compaction. Use your normal tools now to perform any continuity practices required by your existing instructions: for example, recording current commitments or operational state, updating memory, or writing a personal journal entry when there is genuine narrative shape. Do not manufacture memories or journal entries when your instructions say no action is warranted. Do not substitute a generic user-facing summary for the practices available to you.\n\n\
+After completing or deliberately declining those actions, continue the current turn normally.\n\
+</compaction_reflex>"
+    )
+}
 
 impl Session {
     /// Measures the current context load against the model's allotments,
@@ -32,6 +69,70 @@ impl Session {
                 context_window: turn_context.model_context_window(),
             },
         )
+    }
+
+    /// Inject a model-visible, tool-compatible continuity reflex at most once
+    /// per pressure window when the session enters the reserve band before
+    /// automatic compaction.
+    pub(crate) async fn maybe_inject_compaction_reflex(
+        &self,
+        turn_context: &TurnContext,
+    ) -> (chaos_context::allotment::AllotmentStatus, bool, bool) {
+        let (allotment, instructions, follow_up_allowed) = {
+            let mut state = self.state.lock().await;
+            let active_tokens = state.get_total_token_usage(state.server_reasoning_included());
+            let baseline = state
+                .pressure
+                .baseline()
+                .map(chaos_context::pressure::Baseline::tokens);
+            let compaction_token_limit = turn_context.model_info.auto_compact_token_limit();
+            let context_window = turn_context.model_context_window();
+            let allotment = chaos_context::allotment::status(
+                turn_context.config.model_auto_compact_token_limit_scope,
+                active_tokens,
+                baseline,
+                chaos_context::allotment::Limits {
+                    auto_distill_token_limit: compaction_token_limit,
+                    context_window,
+                },
+            );
+
+            let instructions = match (
+                compaction_token_limit,
+                context_window,
+                allotment.tokens_until_distillation,
+            ) {
+                (Some(compaction_token_limit), Some(context_window), Some(remaining))
+                    if compaction_reflex_due(remaining, context_window, compaction_token_limit)
+                        && active_tokens < context_window
+                        && state.pressure.claim_reminder() =>
+                {
+                    Some(compaction_reflex_instructions(
+                        &state.pressure.window_id().to_string(),
+                        i64::try_from(state.pressure.window_number()).unwrap_or(i64::MAX),
+                        active_tokens,
+                        remaining,
+                        compaction_token_limit,
+                        context_window,
+                    ))
+                }
+                _ => None,
+            };
+            let follow_up_allowed = instructions.is_some()
+                && context_window.is_some_and(|context_window| {
+                    compaction_reflex_follow_up_allowed(active_tokens, context_window)
+                });
+            (allotment, instructions, follow_up_allowed)
+        };
+
+        let injected = if let Some(instructions) = instructions {
+            let item: ResponseItem = DeveloperInstructions::new(instructions).into();
+            self.record_conversation_items(turn_context, &[item]).await;
+            true
+        } else {
+            false
+        };
+        (allotment, injected, follow_up_allowed)
     }
 
     pub(crate) async fn get_total_token_usage_breakdown(&self) -> TotalTokenUsageBreakdown {
@@ -217,5 +318,49 @@ impl Session {
             state.set_token_usage_full(context_window);
         }
         self.send_token_count_event(turn_context).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compaction_reflex_uses_the_soft_to_hard_limit_gap() {
+        assert_eq!(compaction_reflex_reserve(400_000, 350_000), 50_000);
+        assert!(!compaction_reflex_due(50_001, 400_000, 350_000));
+        assert!(compaction_reflex_due(50_000, 400_000, 350_000));
+    }
+
+    #[test]
+    fn compaction_reflex_keeps_a_minimum_reserve() {
+        assert_eq!(compaction_reflex_reserve(100, 100), 1);
+        assert!(compaction_reflex_due(1, 100, 100));
+    }
+
+    #[test]
+    fn compaction_reflex_does_not_fire_immediately_for_a_low_soft_limit() {
+        assert_eq!(compaction_reflex_reserve(400_000, 100_000), 25_000);
+        assert!(!compaction_reflex_due(100_000, 400_000, 100_000));
+        assert!(compaction_reflex_due(25_000, 400_000, 100_000));
+    }
+
+    #[test]
+    fn compaction_reflex_follow_up_stays_below_the_ninety_percent_ceiling() {
+        assert!(compaction_reflex_follow_up_allowed(359_999, 400_000));
+        assert!(!compaction_reflex_follow_up_allowed(360_000, 400_000));
+        assert!(!compaction_reflex_follow_up_allowed(400_000, 400_000));
+    }
+
+    #[test]
+    fn compaction_reflex_addresses_the_agent_and_preserves_choice() {
+        let instructions =
+            compaction_reflex_instructions("window-1", 2, 300_000, 50_000, 350_000, 400_000);
+
+        assert!(instructions.contains("for you, the continuing agent"));
+        assert!(instructions.contains("Use your normal tools now"));
+        assert!(instructions.contains("Do not manufacture memories"));
+        assert!(instructions.contains("window_id=\"window-1\""));
+        assert!(instructions.contains("window_number=\"2\""));
     }
 }

--- a/sys/kern/kern/src/chaos/turn.rs
+++ b/sys/kern/kern/src/chaos/turn.rs
@@ -355,7 +355,9 @@ pub(crate) async fn run_turn(
                     needs_follow_up,
                     last_agent_message: sampling_request_last_agent_message,
                 } = sampling_request_output;
-                let allotment = sess.allotment_status(turn_context.as_ref()).await;
+                let (allotment, compaction_reflex_injected, compaction_reflex_follow_up_allowed) =
+                    sess.maybe_inject_compaction_reflex(turn_context.as_ref())
+                        .await;
                 let token_limit_reached = allotment.limit_reached;
 
                 let estimated_token_count =
@@ -368,8 +370,21 @@ pub(crate) async fn run_turn(
                     estimated_token_count = ?estimated_token_count,
                     token_limit_reached,
                     needs_follow_up,
+                    compaction_reflex_injected,
+                    compaction_reflex_follow_up_allowed,
                     "post sampling token usage"
                 );
+
+                // Ordinarily the persisted reflex rides into the next natural
+                // sampling iteration or user turn. If this response already
+                // crossed the soft threshold, grant one immediate iteration
+                // so the agent sees the notice before automatic compaction.
+                if compaction_reflex_injected
+                    && token_limit_reached
+                    && compaction_reflex_follow_up_allowed
+                {
+                    continue;
+                }
 
                 // as long as compaction works well in getting us way below the token limit, we
                 // shouldn't worry about being in an infinite loop.

--- a/sys/kern/kern/src/chaos_tests/early_session.rs
+++ b/sys/kern/kern/src/chaos_tests/early_session.rs
@@ -408,6 +408,75 @@ async fn recompute_token_usage_updates_model_context_window() {
 }
 
 #[tokio::test]
+async fn compaction_reflex_is_model_visible_once_per_pressure_window() {
+    let (session, mut turn_context) = make_session_and_context().await;
+    turn_context.model_info.context_window = Some(400_000);
+    turn_context.model_info.auto_compact_token_limit = Some(350_000);
+    turn_context.model_info.effective_context_window_percent = 100;
+    {
+        let mut state = session.state.lock().await;
+        state.set_token_info(Some(TokenUsageInfo {
+            total_token_usage: TokenUsage::default(),
+            last_token_usage: TokenUsage {
+                total_tokens: 300_000,
+                ..Default::default()
+            },
+            model_context_window: Some(400_000),
+        }));
+    }
+
+    let (_, first_injected, first_follow_up_allowed) =
+        session.maybe_inject_compaction_reflex(&turn_context).await;
+    let (_, second_injected, _) = session.maybe_inject_compaction_reflex(&turn_context).await;
+
+    assert!(first_injected);
+    assert!(first_follow_up_allowed);
+    assert!(!second_injected);
+    let history = session.clone_history().await;
+    let prompt_items = history.for_prompt(&turn_context.model_info.input_modalities);
+    let reflex_count = prompt_items
+        .iter()
+        .filter(|item| match item {
+            ResponseItem::Message { role, content, .. } if role == "system" => {
+                content.iter().any(|content| {
+                    matches!(
+                        content,
+                        ContentItem::InputText { text }
+                            if text.starts_with("<compaction_reflex ")
+                    )
+                })
+            }
+            _ => false,
+        })
+        .count();
+    assert_eq!(reflex_count, 1);
+
+    {
+        let mut state = session.state.lock().await;
+        state.pressure.advance();
+    }
+    let (_, next_window_injected, _) = session.maybe_inject_compaction_reflex(&turn_context).await;
+    assert!(next_window_injected);
+
+    {
+        let mut state = session.state.lock().await;
+        state.pressure.advance();
+        state.set_token_info(Some(TokenUsageInfo {
+            total_token_usage: TokenUsage::default(),
+            last_token_usage: TokenUsage {
+                total_tokens: 400_000,
+                ..Default::default()
+            },
+            model_context_window: Some(400_000),
+        }));
+    }
+    let (_, hard_limit_injected, hard_limit_follow_up_allowed) =
+        session.maybe_inject_compaction_reflex(&turn_context).await;
+    assert!(!hard_limit_injected);
+    assert!(!hard_limit_follow_up_allowed);
+}
+
+#[tokio::test]
 async fn record_initial_history_reconstructs_forked_transcript() {
     let (session, turn_context) = make_session_and_context().await;
     let (rollout_items, mut expected) = sample_rollout(&session, &turn_context).await;


### PR DESCRIPTION
## What changed

- inject a once-per-pressure-window developer instruction before automatic compaction
- make the notice part of ordinary model-visible history, with normal tool access
- grant one immediate ordinary model iteration if the soft threshold was crossed, while retaining a 90% hard-window safety ceiling
- document the behavior and cover thresholding, once-per-window delivery, prompt visibility, and the hard-limit guard

This supersedes the user/client-facing warning approach from #35. It deliberately does not include the parked operational-checkpoint or durability-barrier experiments.

## Why

The useful recipient of an imminent-compaction notice is the continuing agent, not merely the user interface. The agent needs a genuine opportunity to apply its existing continuity practices—journaling, memory, or operational notes—before its active context is replaced, without Chaos inventing a second memory system or forcing a checkpoint when there is no meaningful state to preserve.

This is the first focused implementation layer for #34.

## How to verify

- [ ] Tests pass
- [x] Builds on target hardware

Commands run:

- `just fmt`
- `cargo test -p chaos-kern compaction_reflex --lib` — 6 passed
- `cargo check --workspace --all-features` — passed (one pre-existing unused-import warning)
- `git diff --check` — passed
- `just test` — completed all 2,800 tests: 2,796 passed, 19 skipped, 4 failed in known unrelated baseline tests:
  - `review_diff_prefetch_disables_external_diff_helpers`
  - `review_diff_prefetch_disables_textconv_helpers`
  - `undo_restores_untracked_file_edit`
  - `unified_exec_emits_one_begin_and_one_end_event`
