### PR TITLE
feat(mcp): persist personal tool approvals

### DIFF
--- a/etc/sysctl/src/types.rs
+++ b/etc/sysctl/src/types.rs
@@ -581,6 +581,27 @@ pub struct AppsConfigToml {
     pub apps: HashMap<String, AppConfig>,
 }
 
+/// Personal approval settings for tools exposed by one MCP server.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct McpToolApprovalServerConfig {
+    /// Approval mode for this server unless a per-tool override exists.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval_mode: Option<AppToolApproval>,
+
+    /// Per-tool approval modes keyed by the name advertised by the server.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub tools: HashMap<String, AppToolApproval>,
+}
+
+/// Personal MCP approval settings keyed by server name.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct McpToolApprovalsToml {
+    #[serde(default, flatten)]
+    pub servers: HashMap<String, McpToolApprovalServerConfig>,
+}
+
 // ===== OTEL configuration =====
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]

--- a/etc/sysctl/src/types_tests.rs
+++ b/etc/sysctl/src/types_tests.rs
@@ -213,6 +213,31 @@ fn deserialize_required_server_config() {
 }
 
 #[test]
+fn deserialize_personal_mcp_tool_approval_modes() {
+    let cfg: McpToolApprovalsToml = toml::from_str(
+        r#"
+            [chrome]
+            approval_mode = "approve"
+
+            [chrome.tools]
+            navigate = "approve"
+            evaluate = "prompt"
+        "#,
+    )
+    .expect("should deserialize personal MCP approval modes");
+
+    let chrome = cfg.servers.get("chrome").expect("chrome config");
+    assert_eq!(chrome.approval_mode, Some(AppToolApproval::Approve));
+    assert_eq!(
+        chrome.tools,
+        HashMap::from([
+            ("navigate".to_string(), AppToolApproval::Approve),
+            ("evaluate".to_string(), AppToolApproval::Prompt),
+        ])
+    );
+}
+
+#[test]
 fn deserialize_streamable_http_server_config_variants() {
     for case in [
         SuccessfulServerCase {

--- a/man/chaos-mcp.7.md
+++ b/man/chaos-mcp.7.md
@@ -61,6 +61,31 @@ with FreeChaOS, Claude Code, and other MCP-aware tools:
 }
 ```
 
+### Persistent tool approvals
+
+Personal MCP trust decisions belong in `~/.chaos/config.toml`, separate from
+shared project server definitions:
+
+```toml
+[mcp_tool_approvals.browser]
+approval_mode = "approve"
+
+[mcp_tool_approvals.browser.tools]
+evaluate = "prompt"
+```
+
+The modes are:
+
+- `auto` — use the tool's MCP annotations to decide whether to ask.
+- `prompt` — always ask before running the tool.
+- `approve` — skip the ordinary approval prompt. Safety monitoring can still
+  interrupt or ask for confirmation when it detects unusual risk.
+
+Per-tool settings take precedence over the server default. Selecting **Allow
+and don't ask me again** in an approval prompt persists `approve` for that
+specific server and tool in `~/.chaos/config.toml`. Connector/app approvals use
+their existing `[apps]` entries in the same file.
+
 #### Stdio server options
 
 ```bash

--- a/sys/kern/kern/src/config.rs
+++ b/sys/kern/kern/src/config.rs
@@ -859,6 +859,10 @@ pub struct ConfigToml {
     #[serde(default)]
     pub apps: Option<AppsConfigToml>,
 
+    /// Personal approval settings for tools exposed by MCP servers.
+    #[serde(default)]
+    pub mcp_tool_approvals: Option<crate::config::types::McpToolApprovalsToml>,
+
     /// OTEL configuration.
     pub otel: Option<crate::config::types::OtelConfigToml>,
 

--- a/sys/kern/kern/src/mcp_tool_call.rs
+++ b/sys/kern/kern/src/mcp_tool_call.rs
@@ -15,7 +15,11 @@ use crate::chaos::Session;
 use crate::chaos::TurnContext;
 use crate::config::edit::ConfigEdit;
 use crate::config::edit::ConfigEditsBuilder;
+use crate::config::types::AppConfig;
 use crate::config::types::AppToolApproval;
+use crate::config::types::AppsConfigToml;
+use crate::config::types::McpToolApprovalServerConfig;
+use crate::config::types::McpToolApprovalsToml;
 use crate::mcp_tool_approval_templates::RenderedMcpToolApprovalParam;
 use crate::mcp_tool_approval_templates::render_mcp_tool_approval_template;
 use crate::protocol::EventMsg;
@@ -89,6 +93,8 @@ pub(crate) async fn handle_mcp_tool_call(
     let metadata =
         lookup_mcp_tool_metadata(sess.as_ref(), turn_context.as_ref(), &server, &tool_name).await;
     let request_meta = build_mcp_tool_call_request_meta(&server, metadata.as_ref());
+    let approval_mode =
+        configured_mcp_tool_approval_mode(turn_context, &invocation, metadata.as_ref());
 
     let tool_call_begin_event = EventMsg::McpToolCallBegin(McpToolCallBeginEvent {
         call_id: call_id.clone(),
@@ -102,7 +108,7 @@ pub(crate) async fn handle_mcp_tool_call(
         &call_id,
         &invocation,
         metadata.as_ref(),
-        AppToolApproval::Auto,
+        approval_mode,
     )
     .await
     {
@@ -564,7 +570,68 @@ fn persistent_mcp_tool_approval_key(
     approval_mode: AppToolApproval,
 ) -> Option<McpToolApprovalKey> {
     session_mcp_tool_approval_key(invocation, metadata, approval_mode)
-        .filter(|key| key.connector_id.is_some())
+}
+
+fn configured_mcp_tool_approval_mode(
+    turn_context: &TurnContext,
+    invocation: &McpInvocation,
+    metadata: Option<&McpToolApprovalMetadata>,
+) -> AppToolApproval {
+    let Some(user_config) = turn_context
+        .config
+        .config_layer_stack
+        .get_user_layer()
+        .map(|layer| &layer.config)
+    else {
+        return AppToolApproval::Auto;
+    };
+    let connector = metadata
+        .and_then(|metadata| metadata.connector_id.as_deref())
+        .and_then(|connector_id| configured_connector(user_config, connector_id));
+    let personal = configured_personal_mcp_approval(user_config, &invocation.server);
+    resolve_mcp_tool_approval_mode(connector.as_ref(), personal.as_ref(), &invocation.tool)
+}
+
+fn configured_connector(user_config: &toml::Value, connector_id: &str) -> Option<AppConfig> {
+    let apps: AppsConfigToml = user_config.get("apps")?.clone().try_into().ok()?;
+    apps.apps.get(connector_id).cloned()
+}
+
+fn configured_personal_mcp_approval(
+    user_config: &toml::Value,
+    server_name: &str,
+) -> Option<McpToolApprovalServerConfig> {
+    let approvals: McpToolApprovalsToml = user_config
+        .get("mcp_tool_approvals")?
+        .clone()
+        .try_into()
+        .ok()?;
+    approvals.servers.get(server_name).cloned()
+}
+
+fn resolve_mcp_tool_approval_mode(
+    connector: Option<&AppConfig>,
+    personal: Option<&McpToolApprovalServerConfig>,
+    tool_name: &str,
+) -> AppToolApproval {
+    connector
+        .and_then(|app| {
+            app.tools
+                .as_ref()
+                .and_then(|tools| tools.tools.get(tool_name))
+                .and_then(|tool| tool.approval_mode)
+                .or(app.default_tools_approval_mode)
+        })
+        .or_else(|| {
+            personal.and_then(|server| {
+                server
+                    .tools
+                    .get(tool_name)
+                    .copied()
+                    .or(server.approval_mode)
+            })
+        })
+        .unwrap_or_default()
 }
 
 fn is_full_access_mode(turn_context: &TurnContext) -> bool {
@@ -996,21 +1063,25 @@ async fn maybe_persist_mcp_tool_approval(
     turn_context: &TurnContext,
     key: McpToolApprovalKey,
 ) {
-    let Some(connector_id) = key.connector_id.clone() else {
-        remember_mcp_tool_approval(sess, key).await;
-        return;
-    };
+    let connector_id = key.connector_id.clone();
+    let server_name = key.server.clone();
     let tool_name = key.tool_name.clone();
 
-    if let Err(err) =
-        persist_codex_app_tool_approval(&turn_context.config.chaos_home, &connector_id, &tool_name)
+    let result = if let Some(connector_id) = connector_id.as_deref() {
+        persist_codex_app_tool_approval(&turn_context.config.chaos_home, connector_id, &tool_name)
             .await
-    {
+    } else {
+        persist_mcp_server_tool_approval(&turn_context.config.chaos_home, &server_name, &tool_name)
+            .await
+    };
+
+    if let Err(err) = result {
         error!(
             error = %err,
-            connector_id,
+            server_name,
+            connector_id = ?connector_id,
             tool_name,
-            "failed to persist chaos app tool approval"
+            "failed to persist MCP tool approval"
         );
         remember_mcp_tool_approval(sess, key).await;
         return;
@@ -1018,6 +1089,25 @@ async fn maybe_persist_mcp_tool_approval(
 
     sess.reload_user_config_layer().await;
     remember_mcp_tool_approval(sess, key).await;
+}
+
+async fn persist_mcp_server_tool_approval(
+    chaos_home: &Path,
+    server_name: &str,
+    tool_name: &str,
+) -> anyhow::Result<()> {
+    ConfigEditsBuilder::new(chaos_home)
+        .with_edits([ConfigEdit::SetPath {
+            segments: vec![
+                "mcp_tool_approvals".to_string(),
+                server_name.to_string(),
+                "tools".to_string(),
+                tool_name.to_string(),
+            ],
+            value: value("approve"),
+        }])
+        .apply()
+        .await
 }
 
 async fn persist_codex_app_tool_approval(
@@ -1111,6 +1201,8 @@ pub(crate) async fn handle_mcp_tool_call_async(
     let metadata =
         lookup_mcp_tool_metadata(sess.as_ref(), turn_context.as_ref(), &server, &tool).await;
     let request_meta = build_mcp_tool_call_request_meta(&server, metadata.as_ref());
+    let approval_mode =
+        configured_mcp_tool_approval_mode(turn_context, &invocation, metadata.as_ref());
 
     notify_mcp_tool_call_event(
         sess.as_ref(),
@@ -1128,7 +1220,7 @@ pub(crate) async fn handle_mcp_tool_call_async(
         &call_id,
         &invocation,
         metadata.as_ref(),
-        AppToolApproval::Auto,
+        approval_mode,
     )
     .await
     {

--- a/sys/kern/kern/src/mcp_tool_call_tests.rs
+++ b/sys/kern/kern/src/mcp_tool_call_tests.rs
@@ -10,7 +10,14 @@ use crate::config::types::AppConfig;
 use crate::config::types::AppToolConfig;
 use crate::config::types::AppToolsConfig;
 use crate::config::types::AppsConfigToml;
+use crate::config::types::McpToolApprovalServerConfig;
+use chaos_ipc::api::ConfigLayerSource;
+use chaos_realpath::AbsolutePathBuf;
 use chaos_sysctl::CONFIG_TOML_FILE;
+use chaos_sysctl::ConfigLayerEntry;
+use chaos_sysctl::ConfigLayerStack;
+use chaos_sysctl::ConfigRequirements;
+use chaos_sysctl::ConfigRequirementsToml;
 use pretty_assertions::assert_eq;
 use serde::Deserialize;
 use serial_test::serial;
@@ -213,13 +220,13 @@ async fn approval_elicitation_request_uses_message_override_and_preserves_tool_p
 }
 
 #[test]
-fn custom_mcp_tool_question_mentions_server_name() {
+fn custom_mcp_tool_question_mentions_server_and_offers_persistence() {
     let question = build_mcp_tool_approval_question(
         "q".to_string(),
         "custom_server",
         "run_action",
         None,
-        prompt_options(false, false),
+        prompt_options(true, true),
         None,
     );
 
@@ -229,7 +236,7 @@ fn custom_mcp_tool_question_mentions_server_name() {
         "Allow the custom_server MCP server to run tool \"run_action\"?"
     );
     assert!(
-        !question
+        question
             .options
             .expect("options")
             .into_iter()
@@ -316,7 +323,7 @@ fn custom_mcp_tool_question_offers_session_remember_without_always_allow() {
 }
 
 #[test]
-fn custom_servers_keep_session_remember_without_persistent_approval() {
+fn custom_servers_support_persistent_approval() {
     let invocation = McpInvocation {
         server: "custom_server".to_string(),
         tool: "run_action".to_string(),
@@ -330,11 +337,171 @@ fn custom_servers_keep_session_remember_without_persistent_approval() {
 
     assert_eq!(
         session_mcp_tool_approval_key(&invocation, None, AppToolApproval::Auto),
-        Some(expected)
+        Some(expected.clone())
     );
     assert_eq!(
         persistent_mcp_tool_approval_key(&invocation, None, AppToolApproval::Auto),
-        None
+        Some(expected)
+    );
+}
+
+#[test]
+fn personal_and_connector_approval_modes_resolve_from_most_specific_to_default() {
+    let personal = McpToolApprovalServerConfig {
+        approval_mode: Some(AppToolApproval::Approve),
+        tools: HashMap::from([("evaluate".to_string(), AppToolApproval::Prompt)]),
+    };
+    let connector = AppConfig {
+        enabled: true,
+        destructive_enabled: None,
+        open_world_enabled: None,
+        default_tools_approval_mode: Some(AppToolApproval::Prompt),
+        default_tools_enabled: None,
+        tools: Some(AppToolsConfig {
+            tools: HashMap::from([(
+                "evaluate".to_string(),
+                AppToolConfig {
+                    enabled: None,
+                    approval_mode: Some(AppToolApproval::Auto),
+                },
+            )]),
+        }),
+    };
+
+    assert_eq!(
+        resolve_mcp_tool_approval_mode(None, Some(&personal), "evaluate"),
+        AppToolApproval::Prompt
+    );
+    assert_eq!(
+        resolve_mcp_tool_approval_mode(None, Some(&personal), "navigate"),
+        AppToolApproval::Approve
+    );
+    assert_eq!(
+        resolve_mcp_tool_approval_mode(Some(&connector), Some(&personal), "evaluate"),
+        AppToolApproval::Auto
+    );
+    assert_eq!(
+        resolve_mcp_tool_approval_mode(Some(&connector), Some(&personal), "navigate"),
+        AppToolApproval::Prompt
+    );
+}
+
+#[test]
+fn configured_approvals_are_read_from_user_config() {
+    let user_config: toml::Value = toml::from_str(
+        r#"
+        [apps.calendar]
+        default_tools_approval_mode = "prompt"
+
+        [apps.calendar.tools.create_event]
+        approval_mode = "approve"
+
+        [mcp_tool_approvals.chrome]
+        approval_mode = "approve"
+
+        [mcp_tool_approvals.chrome.tools]
+        evaluate = "prompt"
+        "#,
+    )
+    .expect("valid effective config");
+
+    let connector = configured_connector(&user_config, "calendar").expect("calendar connector");
+    let personal =
+        configured_personal_mcp_approval(&user_config, "chrome").expect("chrome approvals");
+
+    assert_eq!(
+        resolve_mcp_tool_approval_mode(Some(&connector), None, "create_event"),
+        AppToolApproval::Approve
+    );
+    assert_eq!(
+        resolve_mcp_tool_approval_mode(Some(&connector), None, "list_events"),
+        AppToolApproval::Prompt
+    );
+    assert_eq!(
+        resolve_mcp_tool_approval_mode(None, Some(&personal), "evaluate"),
+        AppToolApproval::Prompt
+    );
+    assert_eq!(
+        resolve_mcp_tool_approval_mode(None, Some(&personal), "navigate"),
+        AppToolApproval::Approve
+    );
+}
+
+#[tokio::test]
+async fn personal_mcp_approvals_only_use_the_user_config_layer() {
+    let tmp = tempdir().expect("tempdir");
+    let user_config_path =
+        AbsolutePathBuf::try_from(tmp.path().join("config.toml")).expect("absolute user config");
+    let project_config_dir =
+        AbsolutePathBuf::try_from(tmp.path().join("project/.chaos")).expect("absolute project dir");
+    let user_config: toml::Value = toml::from_str(
+        r#"
+        [apps.calendar]
+        default_tools_approval_mode = "prompt"
+
+        [mcp_tool_approvals.chrome.tools]
+        navigate = "prompt"
+        "#,
+    )
+    .expect("valid user config");
+    let project_config: toml::Value = toml::from_str(
+        r#"
+        [apps.calendar]
+        default_tools_approval_mode = "approve"
+
+        [mcp_tool_approvals.chrome.tools]
+        navigate = "approve"
+        "#,
+    )
+    .expect("valid project config");
+    let stack = ConfigLayerStack::new(
+        vec![
+            ConfigLayerEntry::new(
+                ConfigLayerSource::User {
+                    file: user_config_path,
+                },
+                user_config,
+            ),
+            ConfigLayerEntry::new(
+                ConfigLayerSource::Project {
+                    dot_codex_folder: project_config_dir,
+                },
+                project_config,
+            ),
+        ],
+        ConfigRequirements::default(),
+        ConfigRequirementsToml::default(),
+    )
+    .expect("valid layer stack");
+
+    let (_, mut turn_context) = make_session_and_context().await;
+    let mut config = (*turn_context.config).clone();
+    config.config_layer_stack = stack;
+    turn_context.config = Arc::new(config);
+    let invocation = McpInvocation {
+        server: "chrome".to_string(),
+        tool: "navigate".to_string(),
+        arguments: None,
+    };
+
+    assert_eq!(
+        configured_mcp_tool_approval_mode(&turn_context, &invocation, None),
+        AppToolApproval::Prompt
+    );
+
+    let connector_metadata =
+        approval_metadata(Some("calendar"), Some("Calendar"), None, None, None);
+    assert_eq!(
+        configured_mcp_tool_approval_mode(
+            &turn_context,
+            &McpInvocation {
+                server: CHAOS_APPS_MCP_SERVER_NAME.to_string(),
+                tool: "create_event".to_string(),
+                arguments: None,
+            },
+            Some(&connector_metadata),
+        ),
+        AppToolApproval::Prompt
     );
 }
 
@@ -704,6 +871,31 @@ async fn persist_codex_app_tool_approval_writes_tool_override() {
         })
     );
     assert!(contents.contains("[apps.calendar.tools.\"calendar/list_events\"]"));
+}
+
+#[tokio::test]
+async fn persist_mcp_server_tool_approval_writes_personal_tool_override() {
+    let tmp = tempdir().expect("tempdir");
+
+    persist_mcp_server_tool_approval(tmp.path(), "chrome", "navigate")
+        .await
+        .expect("persist approval");
+
+    let contents = std::fs::read_to_string(tmp.path().join(CONFIG_TOML_FILE)).expect("read config");
+    let parsed: ConfigToml = toml::from_str(&contents).expect("parse config");
+    let chrome = parsed
+        .mcp_tool_approvals
+        .expect("MCP approvals")
+        .servers
+        .remove("chrome")
+        .expect("chrome approval");
+
+    assert_eq!(chrome.approval_mode, None);
+    assert_eq!(
+        chrome.tools,
+        HashMap::from([("navigate".to_string(), AppToolApproval::Approve)])
+    );
+    assert!(contents.contains("[mcp_tool_approvals.chrome.tools]"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What changed

- allow ordinary MCP servers to offer **Allow and don't ask me again**
- persist exact server/tool approvals in the user's `~/.chaos/config.toml`
- honor previously persisted connector/app approval modes during synchronous and asynchronous MCP calls
- add server-level defaults and per-tool overrides under `mcp_tool_approvals`
- restrict approval grants to the user config layer so project configuration cannot silently elevate MCP permissions
- retain ARC monitoring for auto-approved actions that would ordinarily require confirmation
- document the configuration and add parsing, precedence, persistence, reload, source-isolation, and safety-monitor tests

Closes #37.

## Why

Non-connector MCP approvals were remembered only for the current session, so routine browser and service tools prompted again after every restart. Connector approvals were written to config but never consulted by the production dispatch path.

This makes persistent trust decisions actually persistent while keeping them personal, narrowly scoped, and subject to the existing safety monitor.

## How to verify

1. Configure a tool manually:

   ```toml
   [mcp_tool_approvals.chrome.tools]
   navigate = "approve"
   ```

2. Restart Chaos and invoke the configured tool. The ordinary approval prompt should be skipped.
3. Invoke an unconfigured tool and choose **Allow and don't ask me again**. Confirm an exact per-tool entry is written to `~/.chaos/config.toml` and remains effective after restart.
4. Put a conflicting approval in project config and confirm it cannot override the user-layer decision.

- [ ] Tests pass
- [x] Builds on target hardware

Verification performed:

- `just fmt` passes
- all 35 focused MCP approval tests pass
- `cargo check --workspace --all-features` passes
- local release installation and live Chrome MCP navigation succeeded across a restarted session
- `just test`: 2,800/2,805 passed; four pre-existing unrelated failures reproduced, plus `mixed_parallel_tools_run_in_parallel` failed once in the full parallel suite and passed immediately when rerun alone

AI review: Mira reviewed the final diff after rebasing onto `origin/master`; no additional findings.
