### PR TITLE
feat(hooks): expose structured agent provenance

### DIFF
--- a/share/dtrace/schema/generated/before-turn.command.input.schema.json
+++ b/share/dtrace/schema/generated/before-turn.command.input.schema.json
@@ -10,6 +10,19 @@
     }
   },
   "properties": {
+    "agent_depth": {
+      "format": "int32",
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "agent_id": {
+      "$ref": "#/definitions/NullableString"
+    },
+    "agent_type": {
+      "$ref": "#/definitions/NullableString"
+    },
     "cwd": {
       "type": "string"
     },
@@ -23,8 +36,14 @@
       },
       "type": "array"
     },
+    "is_subagent": {
+      "type": "boolean"
+    },
     "model": {
       "type": "string"
+    },
+    "parent_session_id": {
+      "$ref": "#/definitions/NullableString"
     },
     "permission_mode": {
       "enum": [
@@ -44,10 +63,14 @@
     }
   },
   "required": [
+    "agent_id",
+    "agent_type",
     "cwd",
     "hook_event_name",
     "input_messages",
+    "is_subagent",
     "model",
+    "parent_session_id",
     "permission_mode",
     "session_id",
     "transcript_path",

--- a/share/dtrace/schema/generated/session-start.command.input.schema.json
+++ b/share/dtrace/schema/generated/session-start.command.input.schema.json
@@ -10,6 +10,19 @@
     }
   },
   "properties": {
+    "agent_depth": {
+      "format": "int32",
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "agent_id": {
+      "$ref": "#/definitions/NullableString"
+    },
+    "agent_type": {
+      "$ref": "#/definitions/NullableString"
+    },
     "cwd": {
       "type": "string"
     },
@@ -17,8 +30,14 @@
       "const": "SessionStart",
       "type": "string"
     },
+    "is_subagent": {
+      "type": "boolean"
+    },
     "model": {
       "type": "string"
+    },
+    "parent_session_id": {
+      "$ref": "#/definitions/NullableString"
     },
     "permission_mode": {
       "enum": [
@@ -43,9 +62,13 @@
     }
   },
   "required": [
+    "agent_id",
+    "agent_type",
     "cwd",
     "hook_event_name",
+    "is_subagent",
     "model",
+    "parent_session_id",
     "permission_mode",
     "session_id",
     "source",

--- a/share/dtrace/schema/generated/stop.command.input.schema.json
+++ b/share/dtrace/schema/generated/stop.command.input.schema.json
@@ -10,6 +10,19 @@
     }
   },
   "properties": {
+    "agent_depth": {
+      "format": "int32",
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "agent_id": {
+      "$ref": "#/definitions/NullableString"
+    },
+    "agent_type": {
+      "$ref": "#/definitions/NullableString"
+    },
     "cwd": {
       "type": "string"
     },
@@ -17,11 +30,17 @@
       "const": "Stop",
       "type": "string"
     },
+    "is_subagent": {
+      "type": "boolean"
+    },
     "last_assistant_message": {
       "$ref": "#/definitions/NullableString"
     },
     "model": {
       "type": "string"
+    },
+    "parent_session_id": {
+      "$ref": "#/definitions/NullableString"
     },
     "permission_mode": {
       "enum": [
@@ -41,10 +60,14 @@
     }
   },
   "required": [
+    "agent_id",
+    "agent_type",
     "cwd",
     "hook_event_name",
+    "is_subagent",
     "last_assistant_message",
     "model",
+    "parent_session_id",
     "permission_mode",
     "session_id",
     "stop_hook_active",

--- a/share/dtrace/src/agent.rs
+++ b/share/dtrace/src/agent.rs
@@ -1,0 +1,8 @@
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct HookAgentContext {
+    pub is_subagent: bool,
+    pub agent_id: Option<String>,
+    pub agent_type: Option<String>,
+    pub parent_session_id: Option<String>,
+    pub agent_depth: Option<i32>,
+}

--- a/share/dtrace/src/events/before_turn.rs
+++ b/share/dtrace/src/events/before_turn.rs
@@ -5,6 +5,7 @@ use chaos_ipc::protocol::HookCompletedEvent;
 use chaos_ipc::protocol::HookEventName;
 use chaos_ipc::protocol::HookRunSummary;
 
+use crate::HookAgentContext;
 use crate::engine::CommandShell;
 use crate::engine::ConfiguredHandler;
 use crate::engine::command_runner::CommandRunResult;
@@ -21,6 +22,7 @@ pub struct BeforeTurnRequest {
     pub model: String,
     pub permission_mode: String,
     pub input_messages: Vec<String>,
+    pub agent_context: HookAgentContext,
 }
 
 #[derive(Debug)]
@@ -77,6 +79,7 @@ pub(crate) async fn run(
         request.model.clone(),
         request.permission_mode.clone(),
         request.input_messages.clone(),
+        request.agent_context.clone(),
     )) {
         Ok(input_json) => input_json,
         Err(error) => {
@@ -308,6 +311,7 @@ mod integration_tests {
             model: "test-model".to_string(),
             permission_mode: "default".to_string(),
             input_messages: vec!["hello".to_string()],
+            agent_context: crate::HookAgentContext::default(),
         }
     }
 

--- a/share/dtrace/src/events/session_start.rs
+++ b/share/dtrace/src/events/session_start.rs
@@ -5,6 +5,7 @@ use chaos_ipc::protocol::HookCompletedEvent;
 use chaos_ipc::protocol::HookEventName;
 use chaos_ipc::protocol::HookRunSummary;
 
+use crate::HookAgentContext;
 use crate::engine::CommandShell;
 use crate::engine::ConfiguredHandler;
 use crate::engine::command_runner::CommandRunResult;
@@ -35,6 +36,7 @@ pub struct SessionStartRequest {
     pub model: String,
     pub permission_mode: String,
     pub source: SessionStartSource,
+    pub agent_context: HookAgentContext,
 }
 
 #[derive(Debug)]
@@ -93,6 +95,7 @@ pub(crate) async fn run(
         request.model.clone(),
         request.permission_mode.clone(),
         request.source.as_str().to_string(),
+        request.agent_context.clone(),
     )) {
         Ok(input_json) => input_json,
         Err(error) => {

--- a/share/dtrace/src/events/stop.rs
+++ b/share/dtrace/src/events/stop.rs
@@ -8,6 +8,7 @@ use chaos_ipc::protocol::HookOutputEntryKind;
 use chaos_ipc::protocol::HookRunStatus;
 use chaos_ipc::protocol::HookRunSummary;
 
+use crate::HookAgentContext;
 use crate::engine::CommandShell;
 use crate::engine::ConfiguredHandler;
 use crate::engine::command_runner::CommandRunResult;
@@ -25,6 +26,7 @@ pub struct StopRequest {
     pub permission_mode: String,
     pub stop_hook_active: bool,
     pub last_assistant_message: Option<String>,
+    pub agent_context: HookAgentContext,
 }
 
 #[derive(Debug)]
@@ -82,6 +84,7 @@ pub(crate) async fn run(
         request.permission_mode.clone(),
         request.stop_hook_active,
         request.last_assistant_message.clone(),
+        request.agent_context.clone(),
     )) {
         Ok(input_json) => input_json,
         Err(error) => {

--- a/share/dtrace/src/lib.rs
+++ b/share/dtrace/src/lib.rs
@@ -1,9 +1,11 @@
+mod agent;
 mod engine;
 pub mod events;
 mod registry;
 mod schema;
 mod types;
 
+pub use agent::HookAgentContext;
 pub use events::before_turn::BeforeTurnOutcome;
 pub use events::before_turn::BeforeTurnRequest;
 pub use events::session_start::SessionStartOutcome;

--- a/share/dtrace/src/schema.rs
+++ b/share/dtrace/src/schema.rs
@@ -11,6 +11,8 @@ use schemars::Schema;
 use schemars::SchemaGenerator;
 use schemars::generate::SchemaSettings;
 
+use crate::HookAgentContext;
+
 const GENERATED_DIR: &str = "generated";
 const BEFORE_TURN_INPUT_FIXTURE: &str = "before-turn.command.input.schema.json";
 const BEFORE_TURN_OUTPUT_FIXTURE: &str = "before-turn.command.output.schema.json";
@@ -30,6 +32,28 @@ impl NullableString {
 
     fn from_string(value: Option<String>) -> Self {
         Self(value)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct HookAgentCommandInput {
+    pub is_subagent: bool,
+    pub agent_id: NullableString,
+    pub agent_type: NullableString,
+    pub parent_session_id: NullableString,
+    pub agent_depth: Option<i32>,
+}
+
+impl From<HookAgentContext> for HookAgentCommandInput {
+    fn from(value: HookAgentContext) -> Self {
+        Self {
+            is_subagent: value.is_subagent,
+            agent_id: NullableString::from_string(value.agent_id),
+            agent_type: NullableString::from_string(value.agent_type),
+            parent_session_id: NullableString::from_string(value.parent_session_id),
+            agent_depth: value.agent_depth,
+        }
     }
 }
 
@@ -150,6 +174,8 @@ pub(crate) struct SessionStartCommandInput {
     pub permission_mode: String,
     #[schemars(schema_with = "session_start_source_schema")]
     pub source: String,
+    #[serde(flatten)]
+    pub agent_context: HookAgentCommandInput,
 }
 
 impl SessionStartCommandInput {
@@ -160,6 +186,7 @@ impl SessionStartCommandInput {
         model: impl Into<String>,
         permission_mode: impl Into<String>,
         source: impl Into<String>,
+        agent_context: HookAgentContext,
     ) -> Self {
         Self {
             session_id: session_id.into(),
@@ -169,6 +196,7 @@ impl SessionStartCommandInput {
             model: model.into(),
             permission_mode: permission_mode.into(),
             source: source.into(),
+            agent_context: agent_context.into(),
         }
     }
 }
@@ -187,6 +215,8 @@ pub(crate) struct BeforeTurnCommandInput {
     #[schemars(schema_with = "permission_mode_schema")]
     pub permission_mode: String,
     pub input_messages: Vec<String>,
+    #[serde(flatten)]
+    pub agent_context: HookAgentCommandInput,
 }
 
 impl BeforeTurnCommandInput {
@@ -198,6 +228,7 @@ impl BeforeTurnCommandInput {
         model: impl Into<String>,
         permission_mode: impl Into<String>,
         input_messages: Vec<String>,
+        agent_context: HookAgentContext,
     ) -> Self {
         Self {
             session_id: session_id.into(),
@@ -208,6 +239,7 @@ impl BeforeTurnCommandInput {
             model: model.into(),
             permission_mode: permission_mode.into(),
             input_messages,
+            agent_context: agent_context.into(),
         }
     }
 }
@@ -226,6 +258,8 @@ pub(crate) struct StopCommandInput {
     pub permission_mode: String,
     pub stop_hook_active: bool,
     pub last_assistant_message: NullableString,
+    #[serde(flatten)]
+    pub agent_context: HookAgentCommandInput,
 }
 
 impl StopCommandInput {
@@ -237,6 +271,7 @@ impl StopCommandInput {
         permission_mode: impl Into<String>,
         stop_hook_active: bool,
         last_assistant_message: Option<String>,
+        agent_context: HookAgentContext,
     ) -> Self {
         Self {
             session_id: session_id.into(),
@@ -247,6 +282,7 @@ impl StopCommandInput {
             permission_mode: permission_mode.into(),
             stop_hook_active,
             last_assistant_message: NullableString::from_string(last_assistant_message),
+            agent_context: agent_context.into(),
         }
     }
 }
@@ -412,12 +448,17 @@ fn default_continue() -> bool {
 mod tests {
     use super::BEFORE_TURN_INPUT_FIXTURE;
     use super::BEFORE_TURN_OUTPUT_FIXTURE;
+    use super::BeforeTurnCommandInput;
     use super::SESSION_START_INPUT_FIXTURE;
     use super::SESSION_START_OUTPUT_FIXTURE;
     use super::STOP_INPUT_FIXTURE;
     use super::STOP_OUTPUT_FIXTURE;
+    use super::SessionStartCommandInput;
+    use super::StopCommandInput;
     use super::write_schema_fixtures;
+    use crate::HookAgentContext;
     use pretty_assertions::assert_eq;
+    use serde_json::Value;
     use tempfile::TempDir;
 
     fn expected_fixture(name: &str) -> &'static str {
@@ -471,5 +512,73 @@ mod tests {
             let actual = normalize_newlines(&actual);
             assert_eq!(expected, actual, "fixture should match generated schema");
         }
+    }
+
+    fn subagent_context() -> HookAgentContext {
+        HookAgentContext {
+            is_subagent: true,
+            agent_id: Some("child-session".to_string()),
+            agent_type: Some("scout".to_string()),
+            parent_session_id: Some("parent-session".to_string()),
+            agent_depth: Some(2),
+        }
+    }
+
+    fn assert_subagent_context(value: &Value) {
+        assert_eq!(value["is_subagent"], true);
+        assert_eq!(value["agent_id"], "child-session");
+        assert_eq!(value["agent_type"], "scout");
+        assert_eq!(value["parent_session_id"], "parent-session");
+        assert_eq!(value["agent_depth"], 2);
+    }
+
+    #[test]
+    fn session_start_input_serializes_structured_subagent_identity() {
+        let value = serde_json::to_value(SessionStartCommandInput::new(
+            "child-session",
+            None,
+            "/tmp/project",
+            "test-model",
+            "default",
+            "startup",
+            subagent_context(),
+        ))
+        .expect("serialize session start hook input");
+
+        assert_subagent_context(&value);
+    }
+
+    #[test]
+    fn before_turn_input_serializes_structured_subagent_identity() {
+        let value = serde_json::to_value(BeforeTurnCommandInput::new(
+            "child-session",
+            None,
+            "/tmp/project",
+            "turn-1",
+            "test-model",
+            "default",
+            vec!["hello".to_string()],
+            subagent_context(),
+        ))
+        .expect("serialize before turn hook input");
+
+        assert_subagent_context(&value);
+    }
+
+    #[test]
+    fn stop_input_serializes_structured_subagent_identity() {
+        let value = serde_json::to_value(StopCommandInput::new(
+            "child-session",
+            None,
+            "/tmp/project",
+            "test-model",
+            "default",
+            false,
+            Some("done".to_string()),
+            subagent_context(),
+        ))
+        .expect("serialize stop hook input");
+
+        assert_subagent_context(&value);
     }
 }

--- a/sys/kern/kern/src/chaos/turn.rs
+++ b/sys/kern/kern/src/chaos/turn.rs
@@ -15,6 +15,8 @@ use chaos_ipc::protocol::ApprovalPolicy;
 use chaos_ipc::protocol::EventMsg;
 use chaos_ipc::protocol::HookCompletedEvent;
 use chaos_ipc::protocol::HookRunSummary;
+use chaos_ipc::protocol::SessionSource;
+use chaos_ipc::protocol::SubAgentSource;
 use chaos_ipc::protocol::TurnStartedEvent;
 use chaos_ipc::protocol::WarningEvent;
 use chaos_ipc::user_input::UserInput;
@@ -62,6 +64,92 @@ struct ContextHookOutcome {
     completed_events: Vec<HookCompletedEvent>,
     should_stop: bool,
     additional_context: Option<String>,
+}
+
+fn hook_agent_context(
+    session_id: chaos_ipc::ProcessId,
+    session_source: &SessionSource,
+) -> chaos_dtrace::HookAgentContext {
+    let SessionSource::SubAgent(source) = session_source else {
+        return chaos_dtrace::HookAgentContext::default();
+    };
+
+    let mut context = chaos_dtrace::HookAgentContext {
+        is_subagent: true,
+        agent_id: Some(session_id.to_string()),
+        ..Default::default()
+    };
+
+    match source {
+        SubAgentSource::Review => context.agent_type = Some("review".to_string()),
+        SubAgentSource::Compact => context.agent_type = Some("compact".to_string()),
+        SubAgentSource::ProcessSpawn {
+            parent_process_id,
+            depth,
+            agent_nickname: _,
+            agent_role,
+        } => {
+            context.parent_session_id = Some(parent_process_id.to_string());
+            context.agent_depth = Some(*depth);
+            context.agent_type = agent_role
+                .clone()
+                .or_else(|| Some("process_spawn".to_string()));
+        }
+        SubAgentSource::MemoryConsolidation => {
+            context.agent_type = Some("memory_consolidation".to_string());
+        }
+        SubAgentSource::Other(agent_type) => {
+            context.agent_type = Some(agent_type.clone());
+        }
+    }
+
+    context
+}
+
+#[cfg(test)]
+mod hook_agent_context_tests {
+    use chaos_ipc::ProcessId;
+    use chaos_ipc::protocol::SessionSource;
+    use chaos_ipc::protocol::SubAgentSource;
+
+    use super::hook_agent_context;
+
+    #[test]
+    fn root_sessions_have_no_agent_identity() {
+        let context = hook_agent_context(ProcessId::default(), &SessionSource::Cli);
+
+        assert!(!context.is_subagent);
+        assert!(context.agent_id.is_none());
+        assert!(context.agent_type.is_none());
+        assert!(context.parent_session_id.is_none());
+        assert!(context.agent_depth.is_none());
+    }
+
+    #[test]
+    fn spawned_subagents_preserve_parent_role_and_depth() {
+        let child_id = ProcessId::default();
+        let parent_id = ProcessId::default();
+        let context = hook_agent_context(
+            child_id,
+            &SessionSource::SubAgent(SubAgentSource::ProcessSpawn {
+                parent_process_id: parent_id,
+                depth: 2,
+                agent_nickname: Some("swift-otter".to_string()),
+                agent_role: Some("scout".to_string()),
+            }),
+        );
+        let child_id = child_id.to_string();
+        let parent_id = parent_id.to_string();
+
+        assert!(context.is_subagent);
+        assert_eq!(context.agent_id.as_deref(), Some(child_id.as_str()));
+        assert_eq!(context.agent_type.as_deref(), Some("scout"));
+        assert_eq!(
+            context.parent_session_id.as_deref(),
+            Some(parent_id.as_str())
+        );
+        assert_eq!(context.agent_depth, Some(2));
+    }
 }
 
 impl From<chaos_dtrace::SessionStartOutcome> for ContextHookOutcome {
@@ -221,6 +309,7 @@ pub(crate) async fn run_turn(
             _ => None,
         })
         .unwrap_or_default();
+    let agent_context = hook_agent_context(sess.conversation_id, &sess.session_source().await);
     sess.record_user_prompt_and_emit_turn_item(turn_context.as_ref(), &input, response_item)
         .await;
     // Track the previous-turn baseline from the regular user-turn path only so
@@ -239,6 +328,7 @@ pub(crate) async fn run_turn(
         model: turn_context.model_info.slug.clone(),
         permission_mode: hook_permission_mode(turn_context.approval_policy.value()).to_string(),
         input_messages: before_turn_input_messages,
+        agent_context: agent_context.clone(),
     });
 
     sess.maybe_start_ghost_snapshot(Arc::clone(&turn_context), cancellation_token.child_token())
@@ -270,6 +360,7 @@ pub(crate) async fn run_turn(
                 permission_mode: hook_permission_mode(turn_context.approval_policy.value())
                     .to_string(),
                 source: session_start_source,
+                agent_context: agent_context.clone(),
             };
             let previews = sess.hooks().preview_session_start(&session_start_request);
             emit_hook_started_events(&sess, &turn_context, previews).await;
@@ -414,6 +505,7 @@ pub(crate) async fn run_turn(
                             .to_string(),
                         stop_hook_active,
                         last_assistant_message: last_agent_message.clone(),
+                        agent_context: agent_context.clone(),
                     };
                     for run in sess.hooks().preview_stop(&stop_request) {
                         sess.send_event(


### PR DESCRIPTION
## What changed

- add structured agent provenance to the existing `SessionStart`, `BeforeTurn`, and `Stop` command-hook payloads
- expose `is_subagent`, `agent_id`, `agent_type`, `parent_session_id`, and `agent_depth` as top-level JSON fields
- derive the values from `SessionSource`/`SubAgentSource`, including spawned-agent role, parent process, and nesting depth
- update the generated input schemas and add serialization and kernel mapping tests

## Why

Hook consumers currently have to infer root-vs-delegated identity from prompt text or maintain a parallel session registry. The kernel already owns the authoritative lifecycle information, so emitting it at the hook boundary makes memory, policy, provenance, and audit behavior reliable across delegated tasks.

This is intentionally limited to provenance on the three existing lifecycle hooks. It does not add asynchronous hooks, new tool events, or status rendering.

Closes #39.

## How to verify

- `just fmt`
- `cargo test -p chaos-dtrace` — 26 passed
- `cargo test -p chaos-kern hook_agent_context_tests` — 2 passed
- `CI=1 just test` — 2,806 passed, 4 failed, 19 skipped

The four full-suite failures are existing baseline failures reproduced on a clean `master` worktree:

- `review_diff_prefetch_disables_external_diff_helpers`
- `review_diff_prefetch_disables_textconv_helpers`
- `undo_restores_untracked_file_edit`
- `unified_exec_emits_one_begin_and_one_end_event`

- [ ] Tests pass (the affected tests pass; full-suite baseline failures are listed above)
- [x] Builds on target hardware
