### PR TITLE
feat(compaction): add bounded agent timing control

### DIFF
--- a/lib/libcontract/ipc/src/protocol/session.rs
+++ b/lib/libcontract/ipc/src/protocol/session.rs
@@ -266,8 +266,32 @@ pub enum RolloutItem {
     SessionMeta(SessionMetaLine),
     ResponseItem(ResponseItem),
     Compacted(CompactedItem),
+    CompactionControl(CompactionControlItem),
     TurnContext(TurnContextItem),
     EventMsg(EventMsg),
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, JsonSchema, TS)]
+#[serde(rename_all = "snake_case")]
+#[ts(rename_all = "snake_case")]
+pub enum CompactionControlAction {
+    CompactNow,
+    DeferOnce,
+}
+
+/// Durable record of an accepted agent decision for one compaction-pressure
+/// window. The monotonically increasing window number is the resume-stable
+/// identity; the UUID is retained only for tracing and stale live-call checks.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, TS)]
+pub struct CompactionControlItem {
+    pub window_number: u64,
+    pub window_id: String,
+    pub action: CompactionControlAction,
+    pub model: String,
+    pub effective_context_window: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deferral_ceiling: Option<i64>,
+    pub active_tokens: i64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, TS)]

--- a/man/chaos-providers.7.md
+++ b/man/chaos-providers.7.md
@@ -100,6 +100,29 @@ compaction threshold while remaining below the 90% safety ceiling, Chaos grants
 one immediate iteration before compacting. The reflex is directed to the agent
 rather than emitted as a user-facing compaction warning.
 
+Users can optionally give the agent bounded timing control:
+
+```toml
+agent_compaction_control = "bounded"
+```
+
+The default is `"disabled"`. In bounded mode, Chaos exposes a
+`compaction_control` tool. The agent may request immediate compaction at the
+next safe turn-loop boundary, or defer the current pressure window once after
+receiving its reflex. A deferral cannot stack or change its own limits: Chaos
+keeps an absolute ceiling equal to the smaller of 90% of the raw model window
+and the effective input window minus a 20,000-token distillation reserve.
+For the `observed-400k` preset, that ceiling is 360,000 tokens, so deferral
+extends the normal 350,000-token threshold by only 10,000 tokens. Models whose
+catalog window is reduced to an 80% effective input window can have a larger
+usable band.
+Doing nothing retains normal automatic compaction. Accepted decisions are
+persisted for resume continuity; forks inherit transcript history but not a
+pending decision made by the source agent.
+
+The user-facing term *compaction* corresponds to the kernel's internal
+*distillation* implementation.
+
 ### xAI (Grok)
 
 Bundled — no config needed. Just export the key:

--- a/srv/journald/src/sqlite.rs
+++ b/srv/journald/src/sqlite.rs
@@ -810,6 +810,7 @@ fn journal_item_type(item: &RolloutItem) -> &'static str {
         RolloutItem::SessionMeta(_) => "session_meta",
         RolloutItem::ResponseItem(_) => "response_item",
         RolloutItem::Compacted(_) => "compacted",
+        RolloutItem::CompactionControl(_) => "compaction_control",
         RolloutItem::TurnContext(_) => "turn_context",
         RolloutItem::EventMsg(_) => "event_msg",
     }

--- a/sys/kern/context/src/allotment.rs
+++ b/sys/kern/context/src/allotment.rs
@@ -34,6 +34,9 @@ pub struct Limits {
     /// Full context window of the model; reaching it forces distillation
     /// regardless of scope.
     pub context_window: Option<i64>,
+    /// Absolute active-token ceiling used while the current pressure window is
+    /// under a one-time agent deferral.
+    pub deferral_ceiling: Option<i64>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -56,23 +59,27 @@ pub fn status(
     active_tokens: i64,
     baseline: Option<i64>,
     limits: Limits,
+    deferred: bool,
 ) -> AllotmentStatus {
     let scope_tokens = match scope {
         Scope::Total => active_tokens,
         Scope::BodyAfterPrefix => active_tokens.saturating_sub(baseline.unwrap_or(active_tokens)),
     };
-    let scope_limit_reached = limits
-        .auto_distill_token_limit
-        .is_some_and(|limit| scope_tokens >= limit);
-    let window_limit_reached = limits
-        .context_window
-        .is_some_and(|window| active_tokens >= window);
+    let scope_limit_reached = !deferred
+        && limits
+            .auto_distill_token_limit
+            .is_some_and(|limit| scope_tokens >= limit);
+    let active_limit = if deferred {
+        limits.deferral_ceiling.or(limits.context_window)
+    } else {
+        limits.context_window
+    };
+    let window_limit_reached = active_limit.is_some_and(|window| active_tokens >= window);
     let scope_remaining = limits
         .auto_distill_token_limit
         .map(|limit| limit.saturating_sub(scope_tokens).max(0));
-    let window_remaining = limits
-        .context_window
-        .map(|window| window.saturating_sub(active_tokens).max(0));
+    let window_remaining = active_limit.map(|window| window.saturating_sub(active_tokens).max(0));
+    let scope_remaining = (!deferred).then_some(scope_remaining).flatten();
     let tokens_until_distillation = match (scope_remaining, window_remaining) {
         (Some(scope), Some(window)) => Some(scope.min(window)),
         (scope, window) => scope.or(window),

--- a/sys/kern/context/src/allotment_tests.rs
+++ b/sys/kern/context/src/allotment_tests.rs
@@ -322,6 +322,7 @@ fn allotment_status_covers_scopes_limits_and_remaining_tokens() {
     let limits = Limits {
         auto_distill_token_limit: Some(1_000),
         context_window: Some(4_000),
+        deferral_ceiling: Some(3_500),
     };
 
     // Total scope: under, at, and over the distill limit.
@@ -329,18 +330,18 @@ fn allotment_status_covers_scopes_limits_and_remaining_tokens() {
         scope_tokens,
         limit_reached,
         tokens_until_distillation,
-    } = status(Scope::Total, 900, None, limits);
+    } = status(Scope::Total, 900, None, limits, false);
     assert_eq!((scope_tokens, limit_reached), (900, false));
     assert_eq!(tokens_until_distillation, Some(100));
-    assert!(status(Scope::Total, 1_000, None, limits).limit_reached);
+    assert!(status(Scope::Total, 1_000, None, limits, false).limit_reached);
 
     // BodyAfterPrefix: growth since the baseline is what counts; without a
     // baseline the growth measures zero.
-    let grown = status(Scope::BodyAfterPrefix, 3_200, Some(2_500), limits);
+    let grown = status(Scope::BodyAfterPrefix, 3_200, Some(2_500), limits, false);
     assert_eq!((grown.scope_tokens, grown.limit_reached), (700, false));
     assert_eq!(grown.tokens_until_distillation, Some(300));
-    assert!(status(Scope::BodyAfterPrefix, 3_600, Some(2_500), limits).limit_reached);
-    let no_baseline = status(Scope::BodyAfterPrefix, 3_600, None, limits);
+    assert!(status(Scope::BodyAfterPrefix, 3_600, Some(2_500), limits, false).limit_reached);
+    let no_baseline = status(Scope::BodyAfterPrefix, 3_600, None, limits, false);
     assert_eq!(
         (no_baseline.scope_tokens, no_baseline.limit_reached),
         (0, false)
@@ -348,17 +349,27 @@ fn allotment_status_covers_scopes_limits_and_remaining_tokens() {
 
     // Reaching the full context window forces distillation in any scope, and
     // the window can be the binding constraint on remaining tokens.
-    assert!(status(Scope::BodyAfterPrefix, 4_000, Some(3_900), limits).limit_reached);
+    assert!(status(Scope::BodyAfterPrefix, 4_000, Some(3_900), limits, false).limit_reached);
     let window_only = Limits {
         auto_distill_token_limit: None,
         context_window: Some(4_000),
+        deferral_ceiling: None,
     };
-    let window_bound = status(Scope::Total, 3_950, None, window_only);
+    let window_bound = status(Scope::Total, 3_950, None, window_only, false);
     assert_eq!(window_bound.tokens_until_distillation, Some(50));
     assert!(!window_bound.limit_reached);
 
     // No limits configured: never triggers, no countdown.
-    let unlimited = status(Scope::Total, 10_000, None, Limits::default());
+    let unlimited = status(Scope::Total, 10_000, None, Limits::default(), false);
     assert!(!unlimited.limit_reached);
     assert_eq!(unlimited.tokens_until_distillation, None);
+
+    // A one-time deferral suppresses the scoped soft limit, but never the
+    // absolute ceiling. This remains true for a prefix-relative scope.
+    let deferred = status(Scope::Total, 1_200, None, limits, true);
+    assert!(!deferred.limit_reached);
+    assert_eq!(deferred.tokens_until_distillation, Some(2_300));
+    assert!(status(Scope::Total, 3_500, None, limits, true).limit_reached);
+    assert!(!status(Scope::BodyAfterPrefix, 3_400, Some(3_300), limits, true).limit_reached);
+    assert!(status(Scope::BodyAfterPrefix, 3_500, Some(3_400), limits, true).limit_reached);
 }

--- a/sys/kern/context/src/pressure.rs
+++ b/sys/kern/context/src/pressure.rs
@@ -6,6 +6,27 @@
 
 use uuid::Uuid;
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Deferral {
+    pub model: String,
+    pub effective_context_window: i64,
+    pub ceiling: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompactRequest {
+    pub model: String,
+    pub effective_context_window: i64,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum Control {
+    #[default]
+    Normal,
+    Deferred(Deferral),
+    CompactRequested(CompactRequest),
+}
+
 /// Input-token baseline for the current window. A server-observed value comes
 /// from real usage reported by the provider and always wins over an estimate;
 /// once observed it is never overwritten within the same window.
@@ -31,6 +52,8 @@ pub struct Window {
     window_id: Uuid,
     baseline: Option<Baseline>,
     reminder_claimed: bool,
+    deferral_used: bool,
+    control: Control,
 }
 
 impl Window {
@@ -43,7 +66,17 @@ impl Window {
             window_id,
             baseline: None,
             reminder_claimed: false,
+            deferral_used: false,
+            control: Control::Normal,
         }
+    }
+
+    /// Reconstruct a pressure window after resume. UUID identity remains
+    /// process-local; the compaction count is the durable window identity.
+    pub fn from_number(window_number: u64) -> Self {
+        let mut window = Self::new();
+        window.window_number = window_number;
+        window
     }
 
     /// Rotates to a fresh window after a distillation installs replacement
@@ -54,6 +87,8 @@ impl Window {
         self.window_number += 1;
         self.baseline = None;
         self.reminder_claimed = false;
+        self.deferral_used = false;
+        self.control = Control::Normal;
     }
 
     /// Records the server-reported input-token prefill for this window. Only
@@ -79,6 +114,49 @@ impl Window {
     /// claim after each `advance`.
     pub fn claim_reminder(&mut self) -> bool {
         !std::mem::replace(&mut self.reminder_claimed, true)
+    }
+
+    pub fn reminder_claimed(&self) -> bool {
+        self.reminder_claimed
+    }
+
+    pub fn control(&self) -> &Control {
+        &self.control
+    }
+
+    pub fn defer(&mut self, deferral: Deferral) {
+        self.deferral_used = true;
+        self.control = Control::Deferred(deferral);
+    }
+
+    pub fn deferral_used(&self) -> bool {
+        self.deferral_used
+    }
+
+    pub fn request_compaction(&mut self, request: CompactRequest) {
+        self.control = Control::CompactRequested(request);
+    }
+
+    pub fn clear_compaction_request(&mut self) {
+        if matches!(self.control, Control::CompactRequested(_)) {
+            self.control = Control::Normal;
+        }
+    }
+
+    pub fn restore_control(&mut self, control: Control) {
+        if matches!(control, Control::Deferred(_)) {
+            self.deferral_used = true;
+        }
+        self.control = control;
+    }
+
+    pub fn mark_deferral_used(&mut self) {
+        self.deferral_used = true;
+    }
+
+    pub fn reset_control(&mut self) {
+        self.deferral_used = false;
+        self.control = Control::Normal;
     }
 
     pub fn window_number(&self) -> u64 {
@@ -135,6 +213,30 @@ mod tests {
         assert_eq!(window.first_window_id(), first_id);
         assert_ne!(window.window_id(), first_id);
         assert_eq!(window.baseline(), None);
+        assert_eq!(window.control(), &Control::Normal);
+        assert!(!window.deferral_used());
         assert!(window.claim_reminder());
+    }
+
+    #[test]
+    fn reconstructed_window_keeps_number_but_uses_fresh_uuid() {
+        let window = Window::from_number(7);
+        assert_eq!(window.window_number(), 7);
+        assert_eq!(window.first_window_id(), window.window_id());
+        assert_eq!(window.previous_window_id(), None);
+    }
+
+    #[test]
+    fn advance_resets_compaction_control() {
+        let mut window = Window::new();
+        window.defer(Deferral {
+            model: "model".to_string(),
+            effective_context_window: 100,
+            ceiling: 80,
+        });
+        assert!(window.deferral_used());
+        window.advance();
+        assert_eq!(window.control(), &Control::Normal);
+        assert!(!window.deferral_used());
     }
 }

--- a/sys/kern/kern/src/chaos/rollout_reconstruction.rs
+++ b/sys/kern/kern/src/chaos/rollout_reconstruction.rs
@@ -1,4 +1,5 @@
 use chaos_ipc::models::ResponseItem;
+use chaos_ipc::protocol::CompactionControlItem;
 use chaos_ipc::protocol::EventMsg;
 use chaos_ipc::protocol::RolloutItem;
 use chaos_ipc::protocol::TurnContextItem;
@@ -18,6 +19,9 @@ pub(super) struct RolloutReconstruction {
     pub(super) history: Vec<ResponseItem>,
     pub(super) previous_turn_settings: Option<PreviousTurnSettings>,
     pub(super) reference_context_item: Option<TurnContextItem>,
+    pub(super) pressure_window_number: u64,
+    pub(super) compaction_control: Option<CompactionControlItem>,
+    pub(super) deferral_used: bool,
 }
 
 #[derive(Debug, Default)]
@@ -99,6 +103,27 @@ impl Session {
         turn_context: &TurnContext,
         rollout_items: &[RolloutItem],
     ) -> RolloutReconstruction {
+        let pressure_window_number = rollout_items
+            .iter()
+            .filter(|item| matches!(item, RolloutItem::Compacted(_)))
+            .count() as u64;
+        let compaction_control = rollout_items.iter().rev().find_map(|item| match item {
+            RolloutItem::CompactionControl(control)
+                if control.window_number == pressure_window_number =>
+            {
+                Some(control.clone())
+            }
+            _ => None,
+        });
+        let deferral_used = rollout_items.iter().any(|item| {
+            matches!(
+                item,
+                RolloutItem::CompactionControl(control)
+                    if control.window_number == pressure_window_number
+                        && control.action
+                            == chaos_ipc::protocol::CompactionControlAction::DeferOnce
+            )
+        });
         // Replay metadata should already match the shape of the future lazy reverse loader, even
         // while history materialization still uses an eager bridge. Scan newest-to-oldest,
         // stopping once a surviving replacement-history checkpoint and the required resume metadata
@@ -218,6 +243,7 @@ impl Session {
                 }
                 RolloutItem::ResponseItem(_)
                 | RolloutItem::EventMsg(_)
+                | RolloutItem::CompactionControl(_)
                 | RolloutItem::SessionMeta(_) => {}
             }
 
@@ -286,6 +312,7 @@ impl Session {
                     history.drop_last_n_user_turns(rollback.num_turns);
                 }
                 RolloutItem::EventMsg(_)
+                | RolloutItem::CompactionControl(_)
                 | RolloutItem::TurnContext(_)
                 | RolloutItem::SessionMeta(_) => {}
             }
@@ -307,6 +334,9 @@ impl Session {
             history: history.raw_items().to_vec(),
             previous_turn_settings,
             reference_context_item,
+            pressure_window_number,
+            compaction_control,
+            deferral_used,
         }
     }
 }

--- a/sys/kern/kern/src/chaos/rollout_reconstruction_tests.rs
+++ b/sys/kern/kern/src/chaos/rollout_reconstruction_tests.rs
@@ -6,6 +6,8 @@ use crate::protocol::ResumedHistory;
 use chaos_ipc::ProcessId;
 use chaos_ipc::models::ContentItem;
 use chaos_ipc::models::ResponseItem;
+use chaos_ipc::protocol::CompactionControlAction;
+use chaos_ipc::protocol::CompactionControlItem;
 use pretty_assertions::assert_eq;
 fn user_message(text: &str) -> ResponseItem {
     ResponseItem::Message {
@@ -29,6 +31,54 @@ fn assistant_message(text: &str) -> ResponseItem {
         end_turn: None,
         phase: None,
     }
+}
+
+#[tokio::test]
+async fn reconstruction_uses_compaction_count_as_durable_pressure_window_identity() {
+    let (session, turn_context) = make_session_and_context().await;
+    let current = CompactionControlItem {
+        window_number: 2,
+        window_id: "process-local-id".to_string(),
+        action: CompactionControlAction::DeferOnce,
+        model: turn_context.model_info.slug.clone(),
+        effective_context_window: turn_context.model_context_window().unwrap_or(128_000),
+        deferral_ceiling: Some(100_000),
+        active_tokens: 90_000,
+    };
+    let rollout_items = vec![
+        RolloutItem::CompactionControl(CompactionControlItem {
+            window_number: 0,
+            ..current.clone()
+        }),
+        RolloutItem::Compacted(CompactedItem {
+            message: "first".to_string(),
+            replacement_history: Some(Vec::new()),
+        }),
+        RolloutItem::Compacted(CompactedItem {
+            message: "second".to_string(),
+            replacement_history: Some(Vec::new()),
+        }),
+        RolloutItem::CompactionControl(current.clone()),
+    ];
+
+    let reconstructed = session
+        .reconstruct_history_from_rollout(&turn_context, &rollout_items)
+        .await;
+
+    assert_eq!(reconstructed.pressure_window_number, 2);
+    assert_eq!(reconstructed.compaction_control, Some(current));
+    assert!(reconstructed.deferral_used);
+
+    {
+        let mut state = session.state.lock().await;
+        assert!(state.pressure.claim_reminder());
+    }
+    session
+        .apply_rollout_reconstruction(&turn_context, &rollout_items)
+        .await;
+    let state = session.state.lock().await;
+    assert_eq!(state.pressure.window_number(), 2);
+    assert!(!state.pressure.reminder_claimed());
 }
 
 #[tokio::test]

--- a/sys/kern/kern/src/chaos/session.rs
+++ b/sys/kern/kern/src/chaos/session.rs
@@ -3,7 +3,7 @@ mod context;
 mod event;
 mod history;
 mod init;
-mod tokens;
+pub(crate) mod tokens;
 mod turn;
 
 use std::sync::atomic::AtomicU64;

--- a/sys/kern/kern/src/chaos/session/history.rs
+++ b/sys/kern/kern/src/chaos/session/history.rs
@@ -1,6 +1,7 @@
 use chaos_ipc::models::ContentItem;
 use chaos_ipc::models::ResponseItem;
 use chaos_ipc::protocol::CompactedItem;
+use chaos_ipc::protocol::CompactionControlAction;
 use chaos_ipc::protocol::RolloutItem;
 use chaos_ipc::protocol::TurnContextItem;
 use tracing::error;
@@ -108,6 +109,9 @@ impl Session {
             InitialHistory::Forked(rollout_items) => {
                 self.apply_rollout_reconstruction(&turn_context, &rollout_items)
                     .await;
+                // Forks inherit transcript history, not a pending decision made
+                // by the source agent for the source process.
+                self.state.lock().await.pressure.reset_control();
 
                 if let Some(info) = Self::last_token_info_from_rollout(&rollout_items) {
                     let mut state = self.state.lock().await;
@@ -144,11 +148,59 @@ impl Session {
             .reconstruct_history_from_rollout(turn_context, rollout_items)
             .await;
         let previous_turn_settings = reconstructed_rollout.previous_turn_settings.clone();
+        let control = reconstructed_rollout
+            .compaction_control
+            .as_ref()
+            .and_then(|item| {
+                let effective_context_window = turn_context.model_context_window()?;
+                if turn_context.config.agent_compaction_control
+                    != crate::config::AgentCompactionControl::Bounded
+                    || item.model != turn_context.model_info.slug
+                    || item.effective_context_window != effective_context_window
+                {
+                    return None;
+                }
+                match item.action {
+                    CompactionControlAction::CompactNow => {
+                        Some(chaos_context::pressure::Control::CompactRequested(
+                            chaos_context::pressure::CompactRequest {
+                                model: item.model.clone(),
+                                effective_context_window,
+                            },
+                        ))
+                    }
+                    CompactionControlAction::DeferOnce => {
+                        let ceiling = crate::chaos::session::tokens::compaction_deferral_ceiling(
+                            turn_context,
+                        )?;
+                        (item.deferral_ceiling == Some(ceiling)).then(|| {
+                            chaos_context::pressure::Control::Deferred(
+                                chaos_context::pressure::Deferral {
+                                    model: item.model.clone(),
+                                    effective_context_window,
+                                    ceiling,
+                                },
+                            )
+                        })
+                    }
+                }
+            })
+            .unwrap_or(chaos_context::pressure::Control::Normal);
         self.replace_history(
             reconstructed_rollout.history,
             reconstructed_rollout.reference_context_item,
         )
         .await;
+        {
+            let mut state = self.state.lock().await;
+            state.pressure = chaos_context::pressure::Window::from_number(
+                reconstructed_rollout.pressure_window_number,
+            );
+            if reconstructed_rollout.deferral_used {
+                state.pressure.mark_deferral_used();
+            }
+            state.pressure.restore_control(control);
+        }
         self.set_previous_turn_settings(previous_turn_settings.clone())
             .await;
         previous_turn_settings

--- a/sys/kern/kern/src/chaos/session/tokens.rs
+++ b/sys/kern/kern/src/chaos/session/tokens.rs
@@ -12,18 +12,56 @@ use crate::context_manager::TotalTokenUsageBreakdown;
 use super::Session;
 use crate::chaos::TurnContext;
 
+pub(crate) const DISTILLATION_RESERVE_TOKENS: i64 = 20_000;
+
+fn deferral_ceiling_for_windows(
+    raw_context_window: i64,
+    effective_context_window: i64,
+) -> Option<i64> {
+    let raw_safety_ceiling = raw_context_window.saturating_mul(9).saturating_div(10);
+    let distillation_ceiling = effective_context_window.saturating_sub(DISTILLATION_RESERVE_TOKENS);
+    Some(raw_safety_ceiling.min(distillation_ceiling)).filter(|ceiling| *ceiling > 0)
+}
+
+pub(crate) fn compaction_deferral_ceiling(turn_context: &TurnContext) -> Option<i64> {
+    let raw_context_window = turn_context.model_info.context_window?;
+    let effective_context_window = turn_context.model_context_window()?;
+    deferral_ceiling_for_windows(raw_context_window, effective_context_window)
+}
+
 fn compaction_reflex_reserve(context_window: i64, compaction_token_limit: i64) -> i64 {
     let soft_to_hard_gap = context_window.saturating_sub(compaction_token_limit).max(1);
     let proportional_lead = compaction_token_limit.saturating_div(4).max(1);
     soft_to_hard_gap.min(proportional_lead)
 }
 
+#[cfg(test)]
+mod compaction_control_tests {
+    use super::deferral_ceiling_for_windows;
+
+    #[test]
+    fn observed_400k_window_keeps_distillation_reserve() {
+        assert_eq!(
+            deferral_ceiling_for_windows(400_000, 380_000),
+            Some(360_000)
+        );
+    }
+
+    #[test]
+    fn raw_window_safety_fraction_can_be_the_binding_ceiling() {
+        assert_eq!(
+            deferral_ceiling_for_windows(340_000, 320_000),
+            Some(300_000)
+        );
+    }
+}
+
 fn compaction_reflex_due(remaining: i64, context_window: i64, compaction_token_limit: i64) -> bool {
     remaining <= compaction_reflex_reserve(context_window, compaction_token_limit)
 }
 
-fn compaction_reflex_follow_up_allowed(active_tokens: i64, context_window: i64) -> bool {
-    active_tokens < context_window.saturating_mul(9).saturating_div(10)
+fn compaction_reflex_follow_up_allowed(active_tokens: i64, deferral_ceiling: i64) -> bool {
+    active_tokens < deferral_ceiling
 }
 
 fn compaction_reflex_instructions(
@@ -33,15 +71,24 @@ fn compaction_reflex_instructions(
     tokens_until_compaction: i64,
     compaction_token_limit: i64,
     context_window: i64,
+    bounded_control: bool,
 ) -> String {
+    let control_guidance = if bounded_control {
+        format!(
+            "You have bounded timing control for this pressure window. If you need a little more room after continuity work, call `compaction_control` with action `defer_once` and window_id `{window_id}`. You may instead request `compact_now`. Doing neither means normal automatic compaction will proceed. A deferral is one-time and cannot override Chaos's fixed safety ceiling.\n\n"
+        )
+    } else {
+        String::new()
+    };
     format!(
         "<compaction_reflex window_id=\"{window_id}\" window_number=\"{window_number}\">\n\
 Automatic context compaction is approaching. This notice is for you, the continuing agent, not merely for the user.\n\n\
 Current context: approximately {active_tokens} active tokens.\n\
 Automatic compaction threshold: {compaction_token_limit} tokens.\n\
-Hard context window: {context_window} tokens.\n\
+Effective input window: {context_window} tokens.\n\
 Estimated tokens remaining before automatic compaction: {tokens_until_compaction}.\n\n\
 Before continuing substantive work, pause and consider whether anything should be preserved across compaction. Use your normal tools now to perform any continuity practices required by your existing instructions: for example, recording current commitments or operational state, updating memory, or writing a personal journal entry when there is genuine narrative shape. Do not manufacture memories or journal entries when your instructions say no action is warranted. Do not substitute a generic user-facing summary for the practices available to you.\n\n\
+{control_guidance}\
 After completing or deliberately declining those actions, continue the current turn normally.\n\
 </compaction_reflex>"
     )
@@ -54,20 +101,44 @@ impl Session {
         &self,
         turn_context: &TurnContext,
     ) -> chaos_context::allotment::AllotmentStatus {
-        let state = self.state.lock().await;
+        let mut state = self.state.lock().await;
         let active_tokens = state.get_total_token_usage(state.server_reasoning_included());
         let baseline = state
             .pressure
             .baseline()
             .map(chaos_context::pressure::Baseline::tokens);
+        let effective_context_window = turn_context.model_context_window();
+        let control_is_current = match state.pressure.control() {
+            chaos_context::pressure::Control::Deferred(deferral) => {
+                deferral.model == turn_context.model_info.slug
+                    && Some(deferral.effective_context_window) == effective_context_window
+                    && Some(deferral.ceiling) == compaction_deferral_ceiling(turn_context)
+            }
+            chaos_context::pressure::Control::CompactRequested(request) => {
+                request.model == turn_context.model_info.slug
+                    && Some(request.effective_context_window) == effective_context_window
+            }
+            chaos_context::pressure::Control::Normal => true,
+        };
+        if !control_is_current {
+            state
+                .pressure
+                .restore_control(chaos_context::pressure::Control::Normal);
+        }
+        let deferred = matches!(
+            state.pressure.control(),
+            chaos_context::pressure::Control::Deferred(_)
+        );
         chaos_context::allotment::status(
             turn_context.config.model_auto_compact_token_limit_scope,
             active_tokens,
             baseline,
             chaos_context::allotment::Limits {
                 auto_distill_token_limit: turn_context.model_info.auto_compact_token_limit(),
-                context_window: turn_context.model_context_window(),
+                context_window: effective_context_window,
+                deferral_ceiling: compaction_deferral_ceiling(turn_context),
             },
+            deferred,
         )
     }
 
@@ -87,6 +158,14 @@ impl Session {
                 .map(chaos_context::pressure::Baseline::tokens);
             let compaction_token_limit = turn_context.model_info.auto_compact_token_limit();
             let context_window = turn_context.model_context_window();
+            let deferral_ceiling = compaction_deferral_ceiling(turn_context);
+            let deferred = matches!(
+                state.pressure.control(),
+                chaos_context::pressure::Control::Deferred(deferral)
+                    if deferral.model == turn_context.model_info.slug
+                        && Some(deferral.effective_context_window) == context_window
+                        && Some(deferral.ceiling) == deferral_ceiling
+            );
             let allotment = chaos_context::allotment::status(
                 turn_context.config.model_auto_compact_token_limit_scope,
                 active_tokens,
@@ -94,7 +173,9 @@ impl Session {
                 chaos_context::allotment::Limits {
                     auto_distill_token_limit: compaction_token_limit,
                     context_window,
+                    deferral_ceiling,
                 },
+                deferred,
             );
 
             let instructions = match (
@@ -104,7 +185,7 @@ impl Session {
             ) {
                 (Some(compaction_token_limit), Some(context_window), Some(remaining))
                     if compaction_reflex_due(remaining, context_window, compaction_token_limit)
-                        && active_tokens < context_window
+                        && deferral_ceiling.is_some_and(|ceiling| active_tokens < ceiling)
                         && state.pressure.claim_reminder() =>
                 {
                     Some(compaction_reflex_instructions(
@@ -114,13 +195,17 @@ impl Session {
                         remaining,
                         compaction_token_limit,
                         context_window,
+                        matches!(
+                            turn_context.config.agent_compaction_control,
+                            crate::config::AgentCompactionControl::Bounded
+                        ),
                     ))
                 }
                 _ => None,
             };
             let follow_up_allowed = instructions.is_some()
-                && context_window.is_some_and(|context_window| {
-                    compaction_reflex_follow_up_allowed(active_tokens, context_window)
+                && deferral_ceiling.is_some_and(|ceiling| {
+                    compaction_reflex_follow_up_allowed(active_tokens, ceiling)
                 });
             (allotment, instructions, follow_up_allowed)
         };
@@ -128,11 +213,36 @@ impl Session {
         let injected = if let Some(instructions) = instructions {
             let item: ResponseItem = DeveloperInstructions::new(instructions).into();
             self.record_conversation_items(turn_context, &[item]).await;
+            self.services
+                .session_telemetry
+                .counter("chaos.compaction.control_offered", 1, &[]);
             true
         } else {
             false
         };
         (allotment, injected, follow_up_allowed)
+    }
+
+    pub(crate) async fn compaction_requested(&self, turn_context: &TurnContext) -> bool {
+        let mut state = self.state.lock().await;
+        let effective_context_window = turn_context.model_context_window();
+        match state.pressure.control() {
+            chaos_context::pressure::Control::CompactRequested(request)
+                if request.model == turn_context.model_info.slug
+                    && Some(request.effective_context_window) == effective_context_window =>
+            {
+                true
+            }
+            chaos_context::pressure::Control::CompactRequested(_) => {
+                state.pressure.clear_compaction_request();
+                false
+            }
+            _ => false,
+        }
+    }
+
+    pub(crate) async fn clear_compaction_request(&self) {
+        self.state.lock().await.pressure.clear_compaction_request();
     }
 
     pub(crate) async fn get_total_token_usage_breakdown(&self) -> TotalTokenUsageBreakdown {
@@ -346,21 +456,23 @@ mod tests {
     }
 
     #[test]
-    fn compaction_reflex_follow_up_stays_below_the_ninety_percent_ceiling() {
-        assert!(compaction_reflex_follow_up_allowed(359_999, 400_000));
-        assert!(!compaction_reflex_follow_up_allowed(360_000, 400_000));
-        assert!(!compaction_reflex_follow_up_allowed(400_000, 400_000));
+    fn compaction_reflex_follow_up_stays_below_the_fixed_ceiling() {
+        assert!(compaction_reflex_follow_up_allowed(359_999, 360_000));
+        assert!(!compaction_reflex_follow_up_allowed(360_000, 360_000));
+        assert!(!compaction_reflex_follow_up_allowed(400_000, 360_000));
     }
 
     #[test]
     fn compaction_reflex_addresses_the_agent_and_preserves_choice() {
         let instructions =
-            compaction_reflex_instructions("window-1", 2, 300_000, 50_000, 350_000, 400_000);
+            compaction_reflex_instructions("window-1", 2, 300_000, 50_000, 350_000, 400_000, true);
 
         assert!(instructions.contains("for you, the continuing agent"));
         assert!(instructions.contains("Use your normal tools now"));
         assert!(instructions.contains("Do not manufacture memories"));
         assert!(instructions.contains("window_id=\"window-1\""));
         assert!(instructions.contains("window_number=\"2\""));
+        assert!(instructions.contains("compaction_control"));
+        assert!(instructions.contains("defer_once"));
     }
 }

--- a/sys/kern/kern/src/chaos/session/tokens.rs
+++ b/sys/kern/kern/src/chaos/session/tokens.rs
@@ -50,8 +50,8 @@ mod compaction_control_tests {
     #[test]
     fn raw_window_safety_fraction_can_be_the_binding_ceiling() {
         assert_eq!(
-            deferral_ceiling_for_windows(340_000, 320_000),
-            Some(300_000)
+            deferral_ceiling_for_windows(300_000, 295_000),
+            Some(270_000)
         );
     }
 }

--- a/sys/kern/kern/src/chaos/submission_loop.rs
+++ b/sys/kern/kern/src/chaos/submission_loop.rs
@@ -42,6 +42,7 @@ pub(crate) fn initial_replay_event_msgs(
             }
             RolloutItem::SessionMeta(_)
             | RolloutItem::TurnContext(_)
+            | RolloutItem::CompactionControl(_)
             | RolloutItem::Compacted(_) => {}
         }
     }
@@ -324,6 +325,10 @@ pub(super) async fn spawn_review_thread(
         vfs_policy: &parent_turn_context.vfs_policy,
         collab_enabled: config.collab_enabled,
     })
+    .with_agent_compaction_control(matches!(
+        config.agent_compaction_control,
+        crate::config::AgentCompactionControl::Bounded
+    ))
     .with_web_search_config(/*web_search_config*/ None)
     .with_allow_login_shell(config.permissions.allow_login_shell)
     .with_agent_roles(config.agent_roles.clone());

--- a/sys/kern/kern/src/chaos/turn.rs
+++ b/sys/kern/kern/src/chaos/turn.rs
@@ -446,6 +446,36 @@ pub(crate) async fn run_turn(
                     needs_follow_up,
                     last_agent_message: sampling_request_last_agent_message,
                 } = sampling_request_output;
+
+                // The compaction-control handler records intent during tool
+                // dispatch. Because dispatch completes inside sampling, a
+                // defer_once decision affects the status calculation below
+                // immediately, while compact_now is acted on here at the next
+                // safe turn-loop boundary.
+                if sess.compaction_requested(turn_context.as_ref()).await {
+                    match run_auto_compact(
+                        &sess,
+                        &turn_context,
+                        InitialContextInjection::BeforeLastUserMessage,
+                    )
+                    .await
+                    {
+                        Ok(()) => continue,
+                        Err(err) => {
+                            sess.clear_compaction_request().await;
+                            warn!(%err, "agent-requested compaction failed; returning to normal automatic compaction");
+                            sess.send_event(
+                                &turn_context,
+                                EventMsg::Warning(WarningEvent {
+                                    message: format!(
+                                        "Agent-requested compaction failed; normal automatic compaction remains active: {err}"
+                                    ),
+                                }),
+                            )
+                            .await;
+                        }
+                    }
+                }
                 let (allotment, compaction_reflex_injected, compaction_reflex_follow_up_allowed) =
                     sess.maybe_inject_compaction_reflex(turn_context.as_ref())
                         .await;

--- a/sys/kern/kern/src/chaos/turn/preparation.rs
+++ b/sys/kern/kern/src/chaos/turn/preparation.rs
@@ -15,6 +15,10 @@ pub(super) async fn run_pre_sampling_compact(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
 ) -> ChaosResult<()> {
+    if sess.compaction_requested(turn_context).await {
+        run_auto_compact(sess, turn_context, InitialContextInjection::DoNotInject).await?;
+        return Ok(());
+    }
     if maybe_run_previous_model_inline_compact(sess, turn_context).await? {
         return Ok(());
     }

--- a/sys/kern/kern/src/chaos/turn_context.rs
+++ b/sys/kern/kern/src/chaos/turn_context.rs
@@ -153,6 +153,10 @@ impl TurnContext {
             vfs_policy: &self.vfs_policy,
             collab_enabled: config.collab_enabled,
         })
+        .with_agent_compaction_control(matches!(
+            config.agent_compaction_control,
+            crate::config::AgentCompactionControl::Bounded
+        ))
         .with_dynamic_parent_effort(config.dynamic_parent_effort, &self.session_source)
         .with_unified_exec_shell_mode(self.tools_config.unified_exec_shell_mode.clone())
         .with_web_search_config(self.tools_config.web_search_config.clone())
@@ -428,6 +432,10 @@ pub(super) fn make_turn_context(
         vfs_policy: &session_configuration.vfs_policy,
         collab_enabled: per_turn_config.collab_enabled,
     })
+    .with_agent_compaction_control(matches!(
+        per_turn_config.agent_compaction_control,
+        crate::config::AgentCompactionControl::Bounded
+    ))
     .with_dynamic_parent_effort(per_turn_config.dynamic_parent_effort, &session_source)
     .with_web_search_config(per_turn_config.web_search_config.clone())
     .with_allow_login_shell(per_turn_config.permissions.allow_login_shell)

--- a/sys/kern/kern/src/config.rs
+++ b/sys/kern/kern/src/config.rs
@@ -134,6 +134,15 @@ impl ChatgptContextWindow {
     }
 }
 
+/// Standing user policy for model-visible compaction timing controls.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentCompactionControl {
+    #[default]
+    Disabled,
+    Bounded,
+}
+
 /// First-party CLI transport selected when clamp mode is enabled.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
@@ -294,6 +303,10 @@ pub struct Config {
     /// How the auto-compaction token limit is measured: against the total
     /// active context, or only the tokens grown since the last compaction.
     pub model_auto_compact_token_limit_scope: chaos_context::allotment::Scope,
+
+    /// Whether the model may compact early or defer once within a
+    /// harness-computed safety band.
+    pub agent_compaction_control: AgentCompactionControl,
 
     /// Key into the model_providers map that specifies which provider to use.
     pub model_provider_id: String,
@@ -625,6 +638,12 @@ pub struct ConfigToml {
     /// active context ("total", the default), or only the tokens grown since
     /// the last compaction ("body-after-prefix").
     pub model_auto_compact_token_limit_scope: Option<chaos_context::allotment::Scope>,
+
+    /// Model-visible compaction timing control. `"disabled"` preserves normal
+    /// automatic behavior; `"bounded"` also exposes `compact_now` and one
+    /// harness-bounded deferral per pressure window.
+    #[serde(default)]
+    pub agent_compaction_control: Option<AgentCompactionControl>,
 
     /// Default approval policy for executing commands.
     pub approval_policy: Option<ApprovalPolicy>,

--- a/sys/kern/kern/src/config/config_tests.rs
+++ b/sys/kern/kern/src/config/config_tests.rs
@@ -916,6 +916,7 @@ fn expected_precedence_fixture_config_baseline(fixture: &PrecedenceTestFixture) 
         chatgpt_context_window: ChatgptContextWindow::Catalog,
         model_auto_compact_token_limit: None,
         model_auto_compact_token_limit_scope: Default::default(),
+        agent_compaction_control: Default::default(),
         service_tier: None,
         model_provider_id: "openai".to_string(),
         model_provider: fixture.openai_provider.clone(),

--- a/sys/kern/kern/src/config/requirements.rs
+++ b/sys/kern/kern/src/config/requirements.rs
@@ -621,6 +621,7 @@ impl Config {
             model_auto_compact_token_limit_scope: cfg
                 .model_auto_compact_token_limit_scope
                 .unwrap_or_default(),
+            agent_compaction_control: cfg.agent_compaction_control.unwrap_or_default(),
             model_provider_id,
             model_provider,
             cwd: resolved_cwd,

--- a/sys/kern/kern/src/rollout/metadata.rs
+++ b/sys/kern/kern/src/rollout/metadata.rs
@@ -34,6 +34,7 @@ pub(crate) fn builder_from_items(items: &[RolloutItem]) -> Option<ProcessMetadat
         RolloutItem::SessionMeta(meta_line) => builder_from_session_meta(meta_line),
         RolloutItem::ResponseItem(_)
         | RolloutItem::Compacted(_)
+        | RolloutItem::CompactionControl(_)
         | RolloutItem::TurnContext(_)
         | RolloutItem::EventMsg(_) => None,
     })

--- a/sys/kern/kern/src/rollout/policy.rs
+++ b/sys/kern/kern/src/rollout/policy.rs
@@ -17,9 +17,10 @@ pub fn is_persisted_response_item(item: &RolloutItem, mode: EventPersistenceMode
         RolloutItem::ResponseItem(item) => should_persist_response_item(item),
         RolloutItem::EventMsg(ev) => should_persist_event_msg(ev, mode),
         // Persist structural markers so replay and rollback remain stable.
-        RolloutItem::Compacted(_) | RolloutItem::TurnContext(_) | RolloutItem::SessionMeta(_) => {
-            true
-        }
+        RolloutItem::Compacted(_)
+        | RolloutItem::CompactionControl(_)
+        | RolloutItem::TurnContext(_)
+        | RolloutItem::SessionMeta(_) => true,
     }
 }
 

--- a/sys/kern/kern/src/rollout/recorder.rs
+++ b/sys/kern/kern/src/rollout/recorder.rs
@@ -1208,6 +1208,7 @@ fn journal_process_item_from_loaded(
             }
             RolloutItem::ResponseItem(_)
             | RolloutItem::Compacted(_)
+            | RolloutItem::CompactionControl(_)
             | RolloutItem::TurnContext(_)
             | RolloutItem::EventMsg(_) => {}
         }

--- a/sys/kern/kern/src/tools/handlers.rs
+++ b/sys/kern/kern/src/tools/handlers.rs
@@ -1,5 +1,6 @@
 pub mod apply_patch;
 mod catalog_module;
+mod compaction_control;
 mod dynamic;
 mod halluacinate;
 mod mcp;
@@ -33,6 +34,7 @@ pub use apply_patch::ApplyPatchHandler;
 pub use catalog_module::CatalogModuleHandler;
 use chaos_ipc::models::PermissionProfile;
 use chaos_ipc::protocol::ApprovalPolicy;
+pub use compaction_control::CompactionControlHandler;
 pub use dynamic::DynamicToolHandler;
 pub use halluacinate::HalluacinateHandler;
 pub use mcp::McpHandler;

--- a/sys/kern/kern/src/tools/handlers/compaction_control.rs
+++ b/sys/kern/kern/src/tools/handlers/compaction_control.rs
@@ -1,0 +1,246 @@
+use chaos_context::pressure::CompactRequest;
+use chaos_context::pressure::Control;
+use chaos_context::pressure::Deferral;
+use chaos_ipc::protocol::CompactionControlAction;
+use chaos_ipc::protocol::CompactionControlItem;
+use chaos_ipc::protocol::RolloutItem;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::chaos::session::tokens::compaction_deferral_ceiling;
+use crate::config::AgentCompactionControl;
+use crate::function_tool::FunctionCallError;
+use crate::tools::context::FunctionToolOutput;
+use crate::tools::context::ToolInvocation;
+use crate::tools::registry::ToolHandler;
+use crate::tools::registry::ToolKind;
+
+use super::extract_function_arguments;
+use super::parse_arguments;
+
+pub struct CompactionControlHandler;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Action {
+    CompactNow,
+    DeferOnce,
+}
+
+#[derive(Debug, Deserialize)]
+struct Args {
+    action: Action,
+    #[serde(default)]
+    window_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct Output {
+    accepted: bool,
+    action: &'static str,
+    window_number: u64,
+    window_id: String,
+    active_tokens: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    deferral_ceiling: Option<i64>,
+    idempotent: bool,
+}
+
+impl ToolHandler for CompactionControlHandler {
+    type Output = FunctionToolOutput;
+
+    fn kind(&self) -> ToolKind {
+        ToolKind::Function
+    }
+
+    async fn handle(&self, invocation: ToolInvocation) -> Result<Self::Output, FunctionCallError> {
+        let ToolInvocation {
+            session,
+            turn,
+            tool_name,
+            payload,
+            ..
+        } = invocation;
+        if turn.config.agent_compaction_control != AgentCompactionControl::Bounded {
+            return Err(FunctionCallError::RespondToModel(
+                "agent compaction control is disabled for this session".to_string(),
+            ));
+        }
+        let arguments = extract_function_arguments(payload, &tool_name)?;
+        let args: Args = parse_arguments(&arguments)?;
+        let effective_context_window = turn.model_context_window().ok_or_else(|| {
+            FunctionCallError::RespondToModel(
+                "the current model has no known effective context window".to_string(),
+            )
+        })?;
+
+        let (
+            window_number,
+            live_window_id,
+            active_tokens,
+            existing_control,
+            reminder_claimed,
+            deferral_used,
+        ) = {
+            let state = session.state.lock().await;
+            (
+                state.pressure.window_number(),
+                state.pressure.window_id().to_string(),
+                state.get_total_token_usage(state.server_reasoning_included()),
+                state.pressure.control().clone(),
+                state.pressure.reminder_claimed(),
+                state.pressure.deferral_used(),
+            )
+        };
+        if let Some(window_id) = args.window_id.as_deref()
+            && window_id != live_window_id
+        {
+            return Err(FunctionCallError::RespondToModel(format!(
+                "stale compaction window: current window_id is {live_window_id}"
+            )));
+        }
+
+        let (action, action_name, deferral_ceiling, new_control, idempotent) = match args.action {
+            Action::CompactNow => {
+                let request = CompactRequest {
+                    model: turn.model_info.slug.clone(),
+                    effective_context_window,
+                };
+                let idempotent = matches!(
+                    &existing_control,
+                    Control::CompactRequested(existing) if existing == &request
+                );
+                (
+                    CompactionControlAction::CompactNow,
+                    "compact_now",
+                    None,
+                    Control::CompactRequested(request),
+                    idempotent,
+                )
+            }
+            Action::DeferOnce => {
+                let supplied_window_id = args.window_id.as_deref().ok_or_else(|| {
+                    FunctionCallError::RespondToModel(
+                        "defer_once requires the window_id from the current compaction reflex"
+                            .to_string(),
+                    )
+                })?;
+                if supplied_window_id != live_window_id || !reminder_claimed {
+                    return Err(FunctionCallError::RespondToModel(
+                        "defer_once is only available after the current window's compaction reflex"
+                            .to_string(),
+                    ));
+                }
+                let ceiling = compaction_deferral_ceiling(&turn).ok_or_else(|| {
+                    FunctionCallError::RespondToModel(
+                        "no safe deferral ceiling is available for the current model".to_string(),
+                    )
+                })?;
+                let soft_limit = turn.model_info.auto_compact_token_limit().ok_or_else(|| {
+                    FunctionCallError::RespondToModel(
+                        "the current model has no automatic compaction threshold".to_string(),
+                    )
+                })?;
+                if ceiling <= soft_limit {
+                    return Err(FunctionCallError::RespondToModel(
+                        "the current model has no safe extension beyond its automatic compaction threshold"
+                            .to_string(),
+                    ));
+                }
+                if active_tokens >= ceiling {
+                    return Err(FunctionCallError::RespondToModel(format!(
+                        "the safe deferral ceiling ({ceiling} tokens) has already been reached"
+                    )));
+                }
+                let deferral = Deferral {
+                    model: turn.model_info.slug.clone(),
+                    effective_context_window,
+                    ceiling,
+                };
+                let idempotent = matches!(&existing_control, Control::Deferred(existing) if existing == &deferral);
+                if deferral_used && !idempotent {
+                    return Err(FunctionCallError::RespondToModel(
+                        "the one-time deferral for this pressure window has already been used"
+                            .to_string(),
+                    ));
+                }
+                (
+                    CompactionControlAction::DeferOnce,
+                    "defer_once",
+                    Some(ceiling),
+                    Control::Deferred(deferral),
+                    idempotent,
+                )
+            }
+        };
+
+        if !idempotent {
+            let item = RolloutItem::CompactionControl(CompactionControlItem {
+                window_number,
+                window_id: live_window_id.clone(),
+                action,
+                model: turn.model_info.slug.clone(),
+                effective_context_window,
+                deferral_ceiling,
+                active_tokens,
+            });
+            let recorder = {
+                let guard = session.services.rollout.lock().await;
+                guard.clone()
+            }
+            .ok_or_else(|| {
+                FunctionCallError::RespondToModel(
+                    "this session has no durable journal for compaction control".to_string(),
+                )
+            })?;
+            recorder.record_items(&[item]).await.map_err(|err| {
+                FunctionCallError::RespondToModel(format!(
+                    "failed to persist compaction decision: {err}"
+                ))
+            })?;
+
+            let mut state = session.state.lock().await;
+            if state.pressure.window_number() != window_number
+                || state.pressure.window_id().to_string() != live_window_id
+            {
+                return Err(FunctionCallError::RespondToModel(
+                    "the compaction window changed while recording the decision; inspect the new reflex before retrying"
+                        .to_string(),
+                ));
+            }
+            match new_control {
+                Control::Deferred(deferral) => state.pressure.defer(deferral),
+                control => state.pressure.restore_control(control),
+            }
+        }
+        session.services.session_telemetry.counter(
+            "chaos.compaction.control",
+            1,
+            &[
+                ("action", action_name),
+                ("idempotent", if idempotent { "true" } else { "false" }),
+            ],
+        );
+        tracing::info!(
+            action = action_name,
+            window_number,
+            %live_window_id,
+            active_tokens,
+            ?deferral_ceiling,
+            idempotent,
+            "accepted agent compaction control"
+        );
+
+        let output = serde_json::to_string_pretty(&Output {
+            accepted: true,
+            action: action_name,
+            window_number,
+            window_id: live_window_id,
+            active_tokens,
+            deferral_ceiling,
+            idempotent,
+        })
+        .map_err(|err| FunctionCallError::Fatal(err.to_string()))?;
+        Ok(FunctionToolOutput::from_text(output, Some(true)))
+    }
+}

--- a/sys/kern/kern/src/tools/handlers/compaction_control.rs
+++ b/sys/kern/kern/src/tools/handlers/compaction_control.rs
@@ -46,6 +46,57 @@ struct Output {
     idempotent: bool,
 }
 
+fn validate_window_id(supplied: Option<&str>, live: &str) -> Result<(), String> {
+    if supplied.is_some_and(|window_id| window_id != live) {
+        Err(format!(
+            "stale compaction window: current window_id is {live}"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_defer_once(
+    existing_control: &Control,
+    reminder_claimed: bool,
+    deferral_used: bool,
+    active_tokens: i64,
+    soft_limit: i64,
+    deferral: &Deferral,
+) -> Result<bool, String> {
+    if matches!(existing_control, Control::CompactRequested(_)) {
+        return Err("compact_now is already pending for this pressure window".to_string());
+    }
+    if !reminder_claimed {
+        return Err(
+            "defer_once is only available after the current window's compaction reflex".to_string(),
+        );
+    }
+    let idempotent =
+        matches!(existing_control, Control::Deferred(existing) if existing == deferral);
+    if idempotent {
+        return Ok(true);
+    }
+    if deferral.ceiling <= soft_limit {
+        return Err(
+            "the current model has no safe extension beyond its automatic compaction threshold"
+                .to_string(),
+        );
+    }
+    if active_tokens >= deferral.ceiling {
+        return Err(format!(
+            "the safe deferral ceiling ({} tokens) has already been reached",
+            deferral.ceiling
+        ));
+    }
+    if deferral_used {
+        return Err(
+            "the one-time deferral for this pressure window has already been used".to_string(),
+        );
+    }
+    Ok(false)
+}
+
 impl ToolHandler for CompactionControlHandler {
     type Output = FunctionToolOutput;
 
@@ -92,13 +143,8 @@ impl ToolHandler for CompactionControlHandler {
                 state.pressure.deferral_used(),
             )
         };
-        if let Some(window_id) = args.window_id.as_deref()
-            && window_id != live_window_id
-        {
-            return Err(FunctionCallError::RespondToModel(format!(
-                "stale compaction window: current window_id is {live_window_id}"
-            )));
-        }
+        validate_window_id(args.window_id.as_deref(), &live_window_id)
+            .map_err(FunctionCallError::RespondToModel)?;
 
         let (action, action_name, deferral_ceiling, new_control, idempotent) = match args.action {
             Action::CompactNow => {
@@ -119,18 +165,12 @@ impl ToolHandler for CompactionControlHandler {
                 )
             }
             Action::DeferOnce => {
-                let supplied_window_id = args.window_id.as_deref().ok_or_else(|| {
+                args.window_id.as_deref().ok_or_else(|| {
                     FunctionCallError::RespondToModel(
                         "defer_once requires the window_id from the current compaction reflex"
                             .to_string(),
                     )
                 })?;
-                if supplied_window_id != live_window_id || !reminder_claimed {
-                    return Err(FunctionCallError::RespondToModel(
-                        "defer_once is only available after the current window's compaction reflex"
-                            .to_string(),
-                    ));
-                }
                 let ceiling = compaction_deferral_ceiling(&turn).ok_or_else(|| {
                     FunctionCallError::RespondToModel(
                         "no safe deferral ceiling is available for the current model".to_string(),
@@ -141,29 +181,20 @@ impl ToolHandler for CompactionControlHandler {
                         "the current model has no automatic compaction threshold".to_string(),
                     )
                 })?;
-                if ceiling <= soft_limit {
-                    return Err(FunctionCallError::RespondToModel(
-                        "the current model has no safe extension beyond its automatic compaction threshold"
-                            .to_string(),
-                    ));
-                }
-                if active_tokens >= ceiling {
-                    return Err(FunctionCallError::RespondToModel(format!(
-                        "the safe deferral ceiling ({ceiling} tokens) has already been reached"
-                    )));
-                }
                 let deferral = Deferral {
                     model: turn.model_info.slug.clone(),
                     effective_context_window,
                     ceiling,
                 };
-                let idempotent = matches!(&existing_control, Control::Deferred(existing) if existing == &deferral);
-                if deferral_used && !idempotent {
-                    return Err(FunctionCallError::RespondToModel(
-                        "the one-time deferral for this pressure window has already been used"
-                            .to_string(),
-                    ));
-                }
+                let idempotent = validate_defer_once(
+                    &existing_control,
+                    reminder_claimed,
+                    deferral_used,
+                    active_tokens,
+                    soft_limit,
+                    &deferral,
+                )
+                .map_err(FunctionCallError::RespondToModel)?;
                 (
                     CompactionControlAction::DeferOnce,
                     "defer_once",
@@ -196,6 +227,11 @@ impl ToolHandler for CompactionControlHandler {
             recorder.record_items(&[item]).await.map_err(|err| {
                 FunctionCallError::RespondToModel(format!(
                     "failed to persist compaction decision: {err}"
+                ))
+            })?;
+            recorder.flush().await.map_err(|err| {
+                FunctionCallError::RespondToModel(format!(
+                    "failed to commit compaction decision to the journal: {err}"
                 ))
             })?;
 
@@ -242,5 +278,99 @@ impl ToolHandler for CompactionControlHandler {
         })
         .map_err(|err| FunctionCallError::Fatal(err.to_string()))?;
         Ok(FunctionToolOutput::from_text(output, Some(true)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn deferral() -> Deferral {
+        Deferral {
+            model: "model".to_string(),
+            effective_context_window: 380_000,
+            ceiling: 360_000,
+        }
+    }
+
+    #[test]
+    fn stale_window_ids_are_rejected() {
+        assert!(validate_window_id(Some("old"), "current").is_err());
+        assert!(validate_window_id(Some("current"), "current").is_ok());
+        assert!(validate_window_id(None, "current").is_ok());
+    }
+
+    #[test]
+    fn defer_once_requires_the_reflex() {
+        assert!(
+            validate_defer_once(
+                &Control::Normal,
+                false,
+                false,
+                320_000,
+                350_000,
+                &deferral()
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn repeated_defer_once_is_idempotent_even_at_the_ceiling() {
+        let deferral = deferral();
+        assert_eq!(
+            validate_defer_once(
+                &Control::Deferred(deferral.clone()),
+                true,
+                true,
+                deferral.ceiling,
+                350_000,
+                &deferral,
+            ),
+            Ok(true)
+        );
+    }
+
+    #[test]
+    fn second_distinct_deferral_is_refused() {
+        assert!(
+            validate_defer_once(&Control::Normal, true, true, 320_000, 350_000, &deferral())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn defer_once_cannot_replace_pending_compaction() {
+        let request = CompactRequest {
+            model: "model".to_string(),
+            effective_context_window: 380_000,
+        };
+        assert!(
+            validate_defer_once(
+                &Control::CompactRequested(request),
+                true,
+                false,
+                320_000,
+                350_000,
+                &deferral(),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn defer_once_is_refused_at_the_ceiling() {
+        let deferral = deferral();
+        assert!(
+            validate_defer_once(
+                &Control::Normal,
+                true,
+                false,
+                deferral.ceiling,
+                350_000,
+                &deferral,
+            )
+            .is_err()
+        );
     }
 }

--- a/sys/kern/kern/src/tools/handlers/session_history.rs
+++ b/sys/kern/kern/src/tools/handlers/session_history.rs
@@ -333,7 +333,10 @@ fn render_journal_entry(entry: &JournalEntry) -> Option<TranscriptEntry> {
             Some("assistant".to_string()),
             compacted.message.clone(),
         ),
-        RolloutItem::SessionMeta(_) | RolloutItem::TurnContext(_) | RolloutItem::EventMsg(_) => {
+        RolloutItem::SessionMeta(_)
+        | RolloutItem::TurnContext(_)
+        | RolloutItem::CompactionControl(_)
+        | RolloutItem::EventMsg(_) => {
             return None;
         }
     };

--- a/sys/kern/kern/src/tools/spec/config.rs
+++ b/sys/kern/kern/src/tools/spec/config.rs
@@ -42,6 +42,7 @@ pub(crate) struct ToolsConfig {
     pub experimental_supported_tools: Vec<String>,
     pub minion_jobs_tools: bool,
     pub minion_jobs_worker_tools: bool,
+    pub agent_compaction_control: bool,
     /// Native server-side tools declared by the model/provider ABI.
     pub native_server_side_tools: Vec<String>,
 }
@@ -121,12 +122,18 @@ impl ToolsConfig {
             experimental_supported_tools: model_info.experimental_supported_tools.clone(),
             minion_jobs_tools: include_minion_jobs,
             minion_jobs_worker_tools,
+            agent_compaction_control: false,
             native_server_side_tools: model_info.native_server_side_tools.clone(),
         }
     }
 
     pub fn with_agent_roles(mut self, agent_roles: BTreeMap<String, AgentRoleConfig>) -> Self {
         self.agent_roles = agent_roles;
+        self
+    }
+
+    pub fn with_agent_compaction_control(mut self, enabled: bool) -> Self {
+        self.agent_compaction_control = enabled;
         self
     }
 

--- a/sys/kern/kern/src/tools/spec/registry.rs
+++ b/sys/kern/kern/src/tools/spec/registry.rs
@@ -18,14 +18,14 @@ use super::adapters::{
 };
 use super::tool_builders::{
     create_call_mcp_tool_async_tool, create_cancel_mcp_task_tool, create_close_agent_tool,
-    create_exec_command_tool, create_list_mcp_resource_templates_tool,
-    create_list_mcp_resources_tool, create_read_mcp_resource_tool,
-    create_read_session_history_tool, create_report_minion_job_result_tool,
-    create_request_permissions_tool, create_request_user_input_tool, create_resume_agent_tool,
-    create_search_session_history_tool, create_send_input_tool, create_set_parent_effort_tool,
-    create_shell_command_tool, create_shell_tool, create_spawn_agent_tool,
-    create_spawn_minions_on_csv_tool, create_test_sync_tool, create_view_image_tool,
-    create_wait_agent_tool, create_write_stdin_tool,
+    create_compaction_control_tool, create_exec_command_tool,
+    create_list_mcp_resource_templates_tool, create_list_mcp_resources_tool,
+    create_read_mcp_resource_tool, create_read_session_history_tool,
+    create_report_minion_job_result_tool, create_request_permissions_tool,
+    create_request_user_input_tool, create_resume_agent_tool, create_search_session_history_tool,
+    create_send_input_tool, create_set_parent_effort_tool, create_shell_command_tool,
+    create_shell_tool, create_spawn_agent_tool, create_spawn_minions_on_csv_tool,
+    create_test_sync_tool, create_view_image_tool, create_wait_agent_tool, create_write_stdin_tool,
 };
 
 pub(crate) fn push_tool_spec(
@@ -93,6 +93,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
     use crate::minions::tools::WaitAgentHandler;
     use crate::tools::handlers::ApplyPatchHandler;
     use crate::tools::handlers::CatalogModuleHandler;
+    use crate::tools::handlers::CompactionControlHandler;
     use crate::tools::handlers::DynamicToolHandler;
     use crate::tools::handlers::HalluacinateHandler;
     use crate::tools::handlers::McpHandler;
@@ -130,6 +131,7 @@ pub(crate) fn build_specs_with_discoverable_tools(
         default_mode_request_user_input: config.default_mode_request_user_input,
     });
     let session_history_handler = Arc::new(SessionHistoryHandler);
+    let compaction_control_handler = Arc::new(CompactionControlHandler);
     let exec_permission_approvals_enabled = config.exec_permission_approvals_enabled;
 
     match &config.shell_type {
@@ -239,6 +241,15 @@ pub(crate) fn build_specs_with_discoverable_tools(
     );
     builder.register_handler("read_session_history", session_history_handler.clone());
     builder.register_handler("search_session_history", session_history_handler);
+
+    if config.agent_compaction_control {
+        push_tool_spec(
+            &mut builder,
+            create_compaction_control_tool(),
+            /*supports_parallel_tool_calls*/ false,
+        );
+        builder.register_handler("compaction_control", compaction_control_handler);
+    }
 
     if config.request_user_input {
         use crate::collaboration_modes::CollaborationModesConfig;

--- a/sys/kern/kern/src/tools/spec/tool_builders.rs
+++ b/sys/kern/kern/src/tools/spec/tool_builders.rs
@@ -20,6 +20,42 @@ use super::schemas::{
     unified_exec_output_schema, wait_output_schema,
 };
 
+pub(crate) fn create_compaction_control_tool() -> ToolSpec {
+    let properties = BTreeMap::from([
+        (
+            "action".to_string(),
+            JsonSchema::String {
+                description: Some(
+                    "Action to request. Use `compact_now` to compact at the next safe turn-loop boundary, or `defer_once` to extend only the current pressure window to Chaos's fixed safety ceiling."
+                        .to_string(),
+                ),
+            },
+        ),
+        (
+            "window_id".to_string(),
+            JsonSchema::String {
+                description: Some(
+                    "The current compaction_reflex window_id. Required for `defer_once`; optional for `compact_now`, but if supplied it must be current."
+                        .to_string(),
+                ),
+            },
+        ),
+    ]);
+    ToolSpec::Function(ResponsesApiTool {
+        name: "compaction_control".to_string(),
+        description: "Exercise bounded control over this session's automatic compaction timing. `defer_once` is available only after the current compaction reflex, cannot stack, and never overrides Chaos's fixed safety ceiling. `compact_now` may be requested at any time. Doing nothing means continue with normal automatic compaction."
+            .to_string(),
+        strict: false,
+        defer_loading: None,
+        parameters: JsonSchema::Object {
+            properties,
+            required: Some(vec!["action".to_string()]),
+            additional_properties: Some(false.into()),
+        },
+        output_schema: None,
+    })
+}
+
 pub(crate) fn create_read_session_history_tool() -> ToolSpec {
     let properties = BTreeMap::from([
         (

--- a/sys/kern/kern/src/tools/spec_tests.rs
+++ b/sys/kern/kern/src/tools/spec_tests.rs
@@ -1312,6 +1312,37 @@ fn mcp_resource_tools_are_hidden_without_mcp_servers() {
 }
 
 #[test]
+fn compaction_control_tool_is_opt_in() {
+    let config = test_config();
+    let model_info = ModelsManager::construct_model_info_offline_for_tests("gpt-5-codex", &config);
+    let available_models = Vec::new();
+    let base = ToolsConfig::new(&ToolsConfigParams {
+        model_info: &model_info,
+        available_models: &available_models,
+        approval_policy: ApprovalPolicy::Interactive,
+        minion_jobs_allowed: false,
+        web_search_mode: Some(WebSearchMode::Cached),
+        session_source: SessionSource::Cli,
+        vfs_policy: &VfsPolicy::unrestricted(),
+        collab_enabled: true,
+    });
+    let (disabled, _) = build_specs(&base, None, None, &[]).build();
+    assert!(
+        !disabled
+            .iter()
+            .any(|tool| tool.spec.name() == "compaction_control")
+    );
+
+    let (enabled, _) =
+        build_specs(&base.with_agent_compaction_control(true), None, None, &[]).build();
+    assert!(
+        enabled
+            .iter()
+            .any(|tool| tool.spec.name() == "compaction_control")
+    );
+}
+
+#[test]
 fn mcp_resource_tools_are_included_when_mcp_servers_are_present() {
     let config = test_config();
     let model_info = ModelsManager::construct_model_info_offline_for_tests("gpt-5-codex", &config);

--- a/var/proc/src/extract.rs
+++ b/var/proc/src/extract.rs
@@ -23,7 +23,7 @@ pub fn apply_rollout_item(
         RolloutItem::TurnContext(turn_ctx) => apply_turn_context(metadata, turn_ctx),
         RolloutItem::EventMsg(event) => apply_event_msg(metadata, event),
         RolloutItem::ResponseItem(item) => apply_response_item(metadata, item),
-        RolloutItem::Compacted(_) => {}
+        RolloutItem::Compacted(_) | RolloutItem::CompactionControl(_) => {}
     }
     if metadata.model_provider.is_empty() {
         metadata.model_provider = default_provider.to_string();
@@ -35,9 +35,10 @@ pub fn rollout_item_affects_process_metadata(item: &RolloutItem) -> bool {
     match item {
         RolloutItem::SessionMeta(_) | RolloutItem::TurnContext(_) => true,
         RolloutItem::EventMsg(EventMsg::TokenCount(_) | EventMsg::UserMessage(_)) => true,
-        RolloutItem::EventMsg(_) | RolloutItem::ResponseItem(_) | RolloutItem::Compacted(_) => {
-            false
-        }
+        RolloutItem::EventMsg(_)
+        | RolloutItem::ResponseItem(_)
+        | RolloutItem::Compacted(_)
+        | RolloutItem::CompactionControl(_) => false,
     }
 }
 

--- a/var/proc/src/runtime.rs
+++ b/var/proc/src/runtime.rs
@@ -2027,6 +2027,7 @@ fn extract_dynamic_tools(items: &[RolloutItem]) -> Option<Option<Vec<DynamicTool
         RolloutItem::SessionMeta(meta_line) => Some(meta_line.meta.dynamic_tools.clone()),
         RolloutItem::ResponseItem(_)
         | RolloutItem::Compacted(_)
+        | RolloutItem::CompactionControl(_)
         | RolloutItem::TurnContext(_)
         | RolloutItem::EventMsg(_) => None,
     })
@@ -2037,6 +2038,7 @@ fn extract_memory_mode(items: &[RolloutItem]) -> Option<String> {
         RolloutItem::SessionMeta(meta_line) => meta_line.meta.memory_mode.clone(),
         RolloutItem::ResponseItem(_)
         | RolloutItem::Compacted(_)
+        | RolloutItem::CompactionControl(_)
         | RolloutItem::TurnContext(_)
         | RolloutItem::EventMsg(_) => None,
     })

--- a/var/proc/src/runtime/processes.rs
+++ b/var/proc/src/runtime/processes.rs
@@ -612,6 +612,7 @@ pub(super) fn extract_dynamic_tools(items: &[RolloutItem]) -> Option<Option<Vec<
         RolloutItem::SessionMeta(meta_line) => Some(meta_line.meta.dynamic_tools.clone()),
         RolloutItem::ResponseItem(_)
         | RolloutItem::Compacted(_)
+        | RolloutItem::CompactionControl(_)
         | RolloutItem::TurnContext(_)
         | RolloutItem::EventMsg(_) => None,
     })
@@ -622,6 +623,7 @@ pub(super) fn extract_memory_mode(items: &[RolloutItem]) -> Option<String> {
         RolloutItem::SessionMeta(meta_line) => meta_line.meta.memory_mode.clone(),
         RolloutItem::ResponseItem(_)
         | RolloutItem::Compacted(_)
+        | RolloutItem::CompactionControl(_)
         | RolloutItem::TurnContext(_)
         | RolloutItem::EventMsg(_) => None,
     })


### PR DESCRIPTION
## What changed

- Add opt-in `agent_compaction_control = "bounded"` configuration.
- Expose a `compaction_control` tool that lets the agent request `compact_now` at any time or use one `defer_once` after the compaction reflex.
- Preserve a non-negotiable safety ceiling and 20k-token distillation reserve; the agent can influence timing, not veto compaction.
- Persist accepted control decisions structurally and flush them before mutating live state, so resume reconstructs valid pending decisions safely.
- Teach the compaction reflex to address the agent directly with its available choices, and document the behavior.

## Why

Automatic compaction currently gives the agent no way to participate in its timing. This adds bounded agency: enough warning and control to journal, leave continuity notes, finish a thought, or compact early, while Chaos retains a fixed safety boundary and normal automatic behavior remains the default.

## How to verify

Focused verification after rebasing onto current `origin/master`:

- `just fmt`
- `cargo check -p chaos-kern`
- `cargo test -p chaos-context pressure::tests`
- `cargo test -p chaos-kern compaction_reflex`
- `cargo test -p chaos-kern compaction_control`
- `cargo test -p chaos-kern reconstruction_uses_compaction_count_as_durable_pressure_window_identity`

The feature was also exercised end-to-end in a live resumed session: `defer_once` was accepted after the reflex, work continued beyond the soft limit, `compact_now` was then accepted, and Chaos compacted at the next safe turn boundary with successful post-compaction orientation.

A full `just test` run completed 2,817/2,821 tests. The four failures match the existing unrelated local baseline:

- `review_diff_prefetch_disables_external_diff_helpers`
- `review_diff_prefetch_disables_textconv_helpers`
- `undo_restores_untracked_file_edit`
- `unified_exec_emits_one_begin_and_one_end_event`

Turn-level automated integration coverage for crossing the soft limit under deferral, compact-now ordering, manual-compaction reset, model-switch invalidation, and provider-exhaustion override remains a known follow-up gap; the state machine, handler safety transitions, reflex, allotment, and reconstruction paths are covered directly.

- [ ] Tests pass (four known unrelated baseline failures above)
- [x] Builds on target hardware
