### PR TITLE
feat(tui): add terminal title activity icons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2278,6 +2278,8 @@ dependencies = [
  "toml 1.1.3+spec-1.1.0",
  "toml_edit",
  "tracing",
+ "unicode-segmentation",
+ "unicode-width",
  "wildmatch",
 ]
 

--- a/etc/sysctl/Cargo.toml
+++ b/etc/sysctl/Cargo.toml
@@ -26,6 +26,8 @@ tokio = { workspace = true, features = ["fs"] }
 toml = { workspace = true }
 toml_edit = { workspace = true }
 tracing = { workspace = true }
+unicode-segmentation = { workspace = true }
+unicode-width = { workspace = true }
 wildmatch = { workspace = true }
 
 [dev-dependencies]

--- a/etc/sysctl/src/types.rs
+++ b/etc/sysctl/src/types.rs
@@ -23,6 +23,8 @@ use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
 use serde::de::Error as SerdeError;
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
 
 pub const DEFAULT_OTEL_ENVIRONMENT: &str = "dev";
 pub const DEFAULT_MEMORIES_MAX_ROLLOUTS_PER_STARTUP: usize = 16;
@@ -758,6 +760,19 @@ pub struct Tui {
     #[serde(default)]
     pub status_line: Option<Vec<String>>,
 
+    /// Optional identity marker prefixed to terminal session titles while idle.
+    ///
+    /// Empty strings disable the marker. Non-empty values must contain exactly
+    /// one grapheme cluster and occupy no more than four terminal cells.
+    #[serde(default, deserialize_with = "deserialize_terminal_title_icon")]
+    pub terminal_title_icon: Option<String>,
+
+    /// Optional replacement marker shown while the active session is working.
+    ///
+    /// When unset or empty, `terminal_title_icon` remains visible while working.
+    #[serde(default, deserialize_with = "deserialize_terminal_title_icon")]
+    pub terminal_title_working_icon: Option<String>,
+
     /// Syntax highlighting theme name (kebab-case).
     ///
     /// When set, overrides automatic light/dark theme detection.
@@ -768,6 +783,46 @@ pub struct Tui {
     /// Startup tooltip availability NUX state persisted by the TUI.
     #[serde(default)]
     pub model_availability_nux: ModelAvailabilityNuxConfig,
+}
+
+fn deserialize_terminal_title_icon<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    const MAX_TERMINAL_TITLE_ICON_WIDTH: usize = 4;
+
+    let value = Option::<String>::deserialize(deserializer)?;
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    if trimmed.chars().any(char::is_control) {
+        return Err(D::Error::custom(
+            "terminal title icons cannot contain control characters",
+        ));
+    }
+
+    let mut graphemes = trimmed.graphemes(true);
+    let icon = graphemes
+        .next()
+        .ok_or_else(|| D::Error::custom("terminal title icon cannot be empty"))?;
+    if graphemes.next().is_some() {
+        return Err(D::Error::custom(
+            "terminal title icons must contain exactly one grapheme",
+        ));
+    }
+
+    let width = UnicodeWidthStr::width(icon);
+    if width == 0 || width > MAX_TERMINAL_TITLE_ICON_WIDTH {
+        return Err(D::Error::custom(format!(
+            "terminal title icons must occupy between 1 and {MAX_TERMINAL_TITLE_ICON_WIDTH} terminal cells"
+        )));
+    }
+
+    Ok(Some(icon.to_string()))
 }
 
 const fn default_true() -> bool {

--- a/lib/libui/chatwidget.rs
+++ b/lib/libui/chatwidget.rs
@@ -174,6 +174,7 @@ use self::session_header::SessionHeader;
 mod dispatch;
 mod popups;
 mod streaming;
+mod terminal_title;
 use crate::mention_codec::LinkedMention;
 use crate::mention_codec::encode_history_mentions;
 use crate::streaming::chunking::AdaptiveChunkingPolicy;

--- a/lib/libui/chatwidget/events/protocol_dispatch/lifecycle.rs
+++ b/lib/libui/chatwidget/events/protocol_dispatch/lifecycle.rs
@@ -16,12 +16,6 @@ use super::super::super::core::ReplayKind;
 use super::super::super::core::UserMessage;
 use super::super::super::core::merge_user_messages;
 
-const DEFAULT_TERMINAL_TITLE: &str = "new session";
-
-fn terminal_title_for_process_name(process_name: Option<String>) -> String {
-    process_name.unwrap_or_else(|| DEFAULT_TERMINAL_TITLE.to_string())
-}
-
 impl ChatWidget {
     // ── Session / process events ──────────────────────────────────────────────
 
@@ -37,12 +31,7 @@ impl ChatWidget {
         self.session_network_proxy = event.network_proxy.clone();
         self.process_id = Some(event.session_id);
         self.process_name = event.process_name.clone();
-        if self.config.terminal_title != chaos_kern::config::TerminalTitleMode::Off {
-            self.app_event_tx
-                .send(crate::app_event::AppEvent::SetTerminalTitle(Some(
-                    terminal_title_for_process_name(event.process_name.clone()),
-                )));
-        }
+        self.refresh_terminal_title();
         self.forked_from = event.forked_from_id;
         self.current_cwd = Some(event.cwd.clone());
         self.config.cwd = event.cwd.clone();
@@ -125,12 +114,7 @@ impl ChatWidget {
     ) {
         if self.process_id == Some(event.process_id) {
             self.process_name = event.process_name.clone();
-            if self.config.terminal_title != chaos_kern::config::TerminalTitleMode::Off {
-                self.app_event_tx
-                    .send(crate::app_event::AppEvent::SetTerminalTitle(Some(
-                        terminal_title_for_process_name(event.process_name),
-                    )));
-            }
+            self.refresh_terminal_title();
             self.request_redraw();
         }
     }
@@ -409,23 +393,5 @@ impl ChatWidget {
                 Some(ReplayKind::ResumeInitialMessages),
             );
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::terminal_title_for_process_name;
-
-    #[test]
-    fn unnamed_process_uses_new_session_terminal_title() {
-        assert_eq!(terminal_title_for_process_name(None), "new session");
-    }
-
-    #[test]
-    fn named_process_keeps_its_terminal_title() {
-        assert_eq!(
-            terminal_title_for_process_name(Some("Compaction Control Testing".to_string())),
-            "Compaction Control Testing"
-        );
     }
 }

--- a/lib/libui/chatwidget/render.rs
+++ b/lib/libui/chatwidget/render.rs
@@ -89,8 +89,9 @@ impl ChatWidget {
     /// The bottom pane only has one running flag, but this module treats it as a derived state of
     /// both the agent turn lifecycle and MCP startup lifecycle.
     pub(super) fn update_task_running_state(&mut self) {
-        self.bottom_pane
-            .set_task_running(self.agent_turn_running || self.mcp_startup_status.is_some());
+        let task_running = self.agent_turn_running || self.mcp_startup_status.is_some();
+        self.bottom_pane.set_task_running(task_running);
+        self.refresh_terminal_title();
     }
 
     /// Update the status indicator header and details.

--- a/lib/libui/chatwidget/terminal_title.rs
+++ b/lib/libui/chatwidget/terminal_title.rs
@@ -1,0 +1,115 @@
+use crate::app_event::AppEvent;
+
+use super::ChatWidget;
+
+const DEFAULT_TERMINAL_TITLE: &str = "new session";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum TerminalTitleState {
+    Idle,
+    Working,
+    #[allow(dead_code)]
+    Attention,
+}
+
+impl ChatWidget {
+    pub(super) fn refresh_terminal_title(&self) {
+        if self.config.terminal_title == chaos_kern::config::TerminalTitleMode::Off {
+            return;
+        }
+        let state = if self.agent_turn_running || self.mcp_startup_status.is_some() {
+            TerminalTitleState::Working
+        } else {
+            TerminalTitleState::Idle
+        };
+        let title = terminal_title_text(
+            self.process_name.as_deref(),
+            state,
+            self.config.tui_terminal_title_icon.as_deref(),
+            self.config.tui_terminal_title_working_icon.as_deref(),
+            /*attention_icon*/ None,
+        );
+        self.app_event_tx
+            .send(AppEvent::SetTerminalTitle(Some(title)));
+    }
+}
+
+fn terminal_title_text(
+    process_name: Option<&str>,
+    state: TerminalTitleState,
+    idle_icon: Option<&str>,
+    working_icon: Option<&str>,
+    attention_icon: Option<&str>,
+) -> String {
+    let process_name = process_name.unwrap_or(DEFAULT_TERMINAL_TITLE);
+    let icon = match state {
+        TerminalTitleState::Idle => idle_icon,
+        TerminalTitleState::Working => working_icon.or(idle_icon),
+        TerminalTitleState::Attention => attention_icon.or(working_icon).or(idle_icon),
+    };
+    match icon {
+        Some(icon) => format!("{icon} {process_name}"),
+        None => process_name.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn title_without_icons_preserves_existing_behavior() {
+        assert_eq!(
+            terminal_title_text(
+                Some("Compaction Control"),
+                TerminalTitleState::Idle,
+                None,
+                None,
+                None,
+            ),
+            "Compaction Control"
+        );
+        assert_eq!(
+            terminal_title_text(None, TerminalTitleState::Idle, None, None, None),
+            "new session"
+        );
+    }
+
+    #[test]
+    fn working_icon_replaces_idle_icon_and_falls_back_when_absent() {
+        assert_eq!(
+            terminal_title_text(
+                Some("Terminal Icons"),
+                TerminalTitleState::Working,
+                Some("✦"),
+                Some("◒"),
+                None,
+            ),
+            "◒ Terminal Icons"
+        );
+        assert_eq!(
+            terminal_title_text(
+                Some("Terminal Icons"),
+                TerminalTitleState::Working,
+                Some("✦"),
+                None,
+                None,
+            ),
+            "✦ Terminal Icons"
+        );
+    }
+
+    #[test]
+    fn attention_precedence_is_ready_for_follow_up() {
+        assert_eq!(
+            terminal_title_text(
+                Some("Terminal Icons"),
+                TerminalTitleState::Attention,
+                Some("✦"),
+                Some("◒"),
+                Some("●"),
+            ),
+            "● Terminal Icons"
+        );
+    }
+}

--- a/lib/libui/chatwidget/tests.rs
+++ b/lib/libui/chatwidget/tests.rs
@@ -81,10 +81,14 @@ use chaos_ipc::protocol::ReasoningContentDeltaEvent;
 use crate::test_render::render_to_trimmed_string;
 use chaos_ipc::protocol::ImageGenerationEndEvent;
 use chaos_ipc::protocol::ItemCompletedEvent;
+use chaos_ipc::protocol::McpStartupCompleteEvent;
+use chaos_ipc::protocol::McpStartupStatus;
+use chaos_ipc::protocol::McpStartupUpdateEvent;
 use chaos_ipc::protocol::Op;
 use chaos_ipc::protocol::PatchApplyBeginEvent;
 use chaos_ipc::protocol::PatchApplyEndEvent;
 use chaos_ipc::protocol::PatchApplyStatus as CorePatchApplyStatus;
+use chaos_ipc::protocol::ProcessNameUpdatedEvent;
 use chaos_ipc::protocol::ProcessRolledBackEvent;
 use chaos_ipc::protocol::RateLimitWindow;
 use chaos_ipc::protocol::ReviewRequest;
@@ -391,6 +395,9 @@ pub(crate) async fn chatwidget_suite() {
         .expect("apply_patch_request_shows_diff_summary");
     Box::pin(plan_update_renders_history_cell()).await;
     Box::pin(stream_error_updates_status_indicator()).await;
+    Box::pin(terminal_title_icons_follow_turn_and_mcp_lifecycle()).await;
+    Box::pin(terminal_title_rename_and_mcp_update_preserve_working_icon()).await;
+    Box::pin(terminal_title_off_suppresses_icon_updates()).await;
     Box::pin(replayed_turn_started_does_not_mark_task_running()).await;
     Box::pin(process_snapshot_replayed_turn_started_marks_task_running()).await;
     Box::pin(replayed_stream_error_does_not_set_retry_status_or_status_indicator()).await;
@@ -2303,6 +2310,16 @@ fn drain_insert_history(
         }
     }
     out
+}
+
+fn drain_terminal_titles(rx: &mut tokio::sync::mpsc::UnboundedReceiver<AppEvent>) -> Vec<String> {
+    let mut titles = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        if let AppEvent::SetTerminalTitle(Some(title)) = event {
+            titles.push(title);
+        }
+    }
+    titles
 }
 
 fn lines_to_single_string(lines: &[ratatui::text::Line<'static>]) -> String {
@@ -8012,8 +8029,102 @@ async fn stream_error_updates_status_indicator() {
 }
 
 #[cfg(test)]
+async fn terminal_title_icons_follow_turn_and_mcp_lifecycle() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
+    chat.config.tui_terminal_title_icon = Some("✦".to_string());
+    chat.config.tui_terminal_title_working_icon = Some("◒".to_string());
+    chat.process_name = Some("Terminal Icons".to_string());
+
+    chat.refresh_terminal_title();
+    assert_eq!(
+        drain_terminal_titles(&mut rx),
+        vec!["✦ Terminal Icons".to_string()]
+    );
+
+    chat.on_task_started();
+    assert_eq!(
+        drain_terminal_titles(&mut rx),
+        vec!["◒ Terminal Icons".to_string()]
+    );
+
+    chat.on_mcp_startup_update(McpStartupUpdateEvent {
+        server: "browser".to_string(),
+        status: McpStartupStatus::Starting,
+    });
+    assert_eq!(
+        drain_terminal_titles(&mut rx),
+        vec!["◒ Terminal Icons".to_string()]
+    );
+
+    chat.on_task_complete(None, /*from_replay*/ false);
+    assert_eq!(
+        drain_terminal_titles(&mut rx),
+        vec!["◒ Terminal Icons".to_string()],
+        "MCP startup keeps the tab working after the model turn completes"
+    );
+
+    chat.on_mcp_startup_complete(McpStartupCompleteEvent::default());
+    assert_eq!(
+        drain_terminal_titles(&mut rx),
+        vec!["✦ Terminal Icons".to_string()]
+    );
+}
+
+#[cfg(test)]
+async fn terminal_title_rename_and_mcp_update_preserve_working_icon() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
+    let process_id = ProcessId::new();
+    chat.config.tui_terminal_title_icon = Some("✦".to_string());
+    chat.config.tui_terminal_title_working_icon = Some("◒".to_string());
+    chat.process_id = Some(process_id);
+    chat.process_name = Some("Old Name".to_string());
+    chat.on_task_started();
+    drain_terminal_titles(&mut rx);
+
+    chat.on_process_name_updated(ProcessNameUpdatedEvent {
+        process_id,
+        process_name: Some("New Name".to_string()),
+    });
+    assert_eq!(
+        drain_terminal_titles(&mut rx),
+        vec!["◒ New Name".to_string()]
+    );
+
+    chat.on_mcp_startup_update(McpStartupUpdateEvent {
+        server: "browser".to_string(),
+        status: McpStartupStatus::Starting,
+    });
+    assert_eq!(
+        drain_terminal_titles(&mut rx),
+        vec!["◒ New Name".to_string()]
+    );
+}
+
+#[cfg(test)]
+async fn terminal_title_off_suppresses_icon_updates() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
+    chat.config.terminal_title = chaos_kern::config::TerminalTitleMode::Off;
+    chat.config.tui_terminal_title_icon = Some("✦".to_string());
+    chat.config.tui_terminal_title_working_icon = Some("◒".to_string());
+    chat.process_name = Some("Hidden Title".to_string());
+
+    chat.refresh_terminal_title();
+    chat.on_task_started();
+
+    assert!(
+        drain_terminal_titles(&mut rx).is_empty(),
+        "terminal title mode off must suppress idle and working updates"
+    );
+}
+
+#[cfg(test)]
 async fn replayed_turn_started_does_not_mark_task_running() {
-    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None).await;
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
+    chat.config.tui_terminal_title_icon = Some("✦".to_string());
+    chat.config.tui_terminal_title_working_icon = Some("◒".to_string());
+    chat.process_name = Some("Replay Test".to_string());
+    chat.refresh_terminal_title();
+    drain_terminal_titles(&mut rx);
 
     chat.replay_initial_messages(vec![EventMsg::TurnStarted(TurnStartedEvent {
         turn_id: "turn-1".to_string(),
@@ -8023,11 +8134,18 @@ async fn replayed_turn_started_does_not_mark_task_running() {
 
     assert!(!chat.bottom_pane.is_task_running());
     assert!(chat.bottom_pane.status_widget().is_none());
+    assert!(
+        drain_terminal_titles(&mut rx).is_empty(),
+        "historical resume replay must not flash the working icon"
+    );
 }
 
 #[cfg(test)]
 async fn process_snapshot_replayed_turn_started_marks_task_running() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
+    chat.config.tui_terminal_title_icon = Some("✦".to_string());
+    chat.config.tui_terminal_title_working_icon = Some("◒".to_string());
+    chat.process_name = Some("Replay Test".to_string());
 
     chat.handle_codex_event_replay(Event {
         id: "turn-1".into(),
@@ -8038,7 +8156,10 @@ async fn process_snapshot_replayed_turn_started_marks_task_running() {
         }),
     });
 
-    drain_insert_history(&mut rx);
+    assert_eq!(
+        drain_terminal_titles(&mut rx),
+        vec!["◒ Replay Test".to_string()]
+    );
     assert!(chat.bottom_pane.is_task_running());
     let status = chat
         .bottom_pane

--- a/man/chaos-providers.7.md
+++ b/man/chaos-providers.7.md
@@ -137,23 +137,54 @@ terminal_title = "process-name"
 
 # Also let the current root agent name the session.
 terminal_title = "agent"
+
+# Optional identity and working markers are TUI presentation only.
+[tui]
+terminal_title_icon = "✦"
+terminal_title_working_icon = "◒"
 ```
+
+The idle icon prefixes both named sessions and the `new session` fallback. While
+a model turn or MCP startup is active, the working icon replaces it. If only
+`terminal_title_icon` is configured, that icon remains visible in both states.
+Icons must be one grapheme cluster and no more than four terminal cells; an
+empty string disables the corresponding icon.
 
 Agent mode exposes `set_session_title` to the current root agent and privately
 asks it to review the title at the start of a session, after resume or
 compaction, and periodically during longer work. A reminder does not require a
 rename: the agent is instructed to retain a title that still accurately names
-the session's primary work. The title remains the existing process name used by
-`/rename` and `chaos resume`; the separate database `title` field remains a
-first-message preview and is never used as the terminal fallback. An explicit
-`/rename` always marks the name as user-authored, preventing the agent from
-replacing it. Agent-generated names must also be distinct from other unarchived
-sessions.
+the session's primary work. Reconnecting also runs a hidden, title-only review
+against the restored conversation before accepting a new user turn, allowing an
+unnamed or stale tab to update immediately. The title remains the existing
+process name used by `/rename` and `chaos resume`; the separate database `title`
+field remains a first-message preview and is never used as the terminal
+fallback. An explicit `/rename` always marks the name as user-authored,
+preventing the agent from replacing it. Agent-generated names must also be
+distinct from other unarchived sessions.
 
 Chaos emits the portable OSC terminal-title sequence and clears it when the TUI
 exits. Terminal configuration can still override or transform the displayed
 tab title; for example, a custom WezTerm `format-tab-title` callback may choose
-not to show the pane title.
+not to show the pane title. OSC titles cannot independently color the icon, but
+WezTerm can style configured markers locally:
+
+```lua
+local wezterm = require("wezterm")
+
+wezterm.on("format-tab-title", function(tab)
+  local title = tab.active_pane.title
+  local color = title:match("^✦ ") and "#7bd88f"
+    or title:match("^◒ ") and "#f5c451"
+  if color then
+    return {
+      { Foreground = { Color = color } },
+      { Text = title },
+    }
+  end
+  return title
+end)
+```
 
 ### xAI (Grok)
 

--- a/sys/kern/kern/src/chaos/spawn.rs
+++ b/sys/kern/kern/src/chaos/spawn.rs
@@ -217,6 +217,10 @@ impl Chaos {
         } else {
             None
         };
+        let reconnect_title_history = match &conversation_history {
+            InitialHistory::Resumed(history) => Some(history.history.clone()),
+            InitialHistory::New | InitialHistory::Forked(_) => None,
+        };
         let dynamic_tools = if dynamic_tools.is_empty() {
             persisted_tools
                 .or_else(|| conversation_history.get_dynamic_tools())
@@ -293,6 +297,9 @@ impl Chaos {
                 .instrument(info_span!("session_loop", process_id = %process_id))
                 .await;
         });
+        if let Some(history) = reconnect_title_history {
+            super::title_reflex::review_title_after_reconnect(Arc::clone(&session), history).await;
+        }
         let chaos = Chaos {
             tx_sub,
             rx_event,

--- a/sys/kern/kern/src/chaos/title_reflex.rs
+++ b/sys/kern/kern/src/chaos/title_reflex.rs
@@ -1,9 +1,37 @@
+use std::sync::Arc;
+
+use chaos_ipc::protocol::EventMsg;
+use chaos_ipc::protocol::InitialHistory;
+use chaos_ipc::protocol::RolloutItem;
 use chaos_ipc::protocol::SessionSource;
+use chaos_ipc::protocol::SubAgentSource;
+use chaos_ipc::user_input::UserInput;
+use serde::Deserialize;
+use tracing::warn;
+
+use super::Session;
+use crate::chaos_delegate::run_chaos_process_one_shot;
+use crate::config::Constrained;
+use crate::config::TerminalTitleMode;
+use crate::rollout::process_names;
+use crate::rollout::process_names::ProcessNameSource;
 
 pub(crate) const TITLE_REVIEW_TURN_INTERVAL: u64 = 12;
 pub(crate) const TITLE_REVIEW_TOKEN_INTERVAL: i64 = 50_000;
 
 const SESSION_TITLE_REFLEX_MARKER: &str = "<session_title_reflex";
+const RECONNECT_TITLE_REVIEW_SOURCE: &str = "session_title_review";
+const RECONNECT_TITLE_REVIEW_PROMPT: &str = "\
+You have just reconnected to an existing session. Review the restored conversation and decide \
+whether its current title still accurately names the primary work. Return JSON with exactly one \
+field, `title`, containing a short, concrete, distinctive 2-6 word title. Retain the current title \
+when it remains accurate. If it is absent or generic, infer a useful title from the session's actual \
+work. Do not explain your decision.";
+
+#[derive(Debug, Deserialize)]
+struct ReconnectTitleDecision {
+    title: String,
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum TitleReviewTrigger {
@@ -44,7 +72,7 @@ impl SessionTitleReflex {
         self.turns_since_review = self.turns_since_review.saturating_add(1);
         self.rebase_after_compaction(active_tokens);
 
-        let trigger = if resumed {
+        let trigger = if resumed && !self.reviewed_once {
             Some(TitleReviewTrigger::Resume)
         } else if !self.reviewed_once {
             Some(TitleReviewTrigger::Initial)
@@ -74,6 +102,10 @@ impl SessionTitleReflex {
     }
 
     pub(crate) fn mark_title_changed(&mut self, active_tokens: i64) {
+        self.mark_reviewed(active_tokens);
+    }
+
+    pub(crate) fn mark_reconnect_reviewed(&mut self, active_tokens: i64) {
         self.mark_reviewed(active_tokens);
     }
 
@@ -121,6 +153,166 @@ pub(crate) fn title_review_instructions(
     )
 }
 
+pub(crate) async fn review_title_after_reconnect(session: Arc<Session>, history: Vec<RolloutItem>) {
+    let (config, session_source, current_title) = {
+        let state = session.state.lock().await;
+        (
+            Arc::clone(&state.session_configuration.original_config_do_not_use),
+            state.session_configuration.session_source.clone(),
+            state.session_configuration.process_name.clone(),
+        )
+    };
+    if !title_review_enabled(config.terminal_title, &session_source) {
+        return;
+    }
+
+    match process_names::find_process_name_record_by_id(&session.conversation_id).await {
+        Ok(Some(record)) if record.source == ProcessNameSource::User => {
+            mark_reconnect_reviewed(&session).await;
+            return;
+        }
+        Ok(_) => {}
+        Err(err) => {
+            warn!(%err, "failed to inspect process title before reconnect review");
+            return;
+        }
+    }
+
+    let parent_ctx = session
+        .new_default_turn_with_sub_id("reconnect-title-review".to_string())
+        .await;
+    let mut reviewer_config = config.as_ref().clone();
+    reviewer_config.ephemeral = true;
+    reviewer_config.minion_jobs_allowed = false;
+    reviewer_config.collab_enabled = false;
+    reviewer_config.terminal_title = TerminalTitleMode::Off;
+    if let Err(err) = reviewer_config
+        .web_search_mode
+        .set(chaos_ipc::config_types::WebSearchMode::Disabled)
+    {
+        warn!(%err, "failed to disable web search for reconnect title review");
+        return;
+    }
+    reviewer_config.permissions.approval_policy =
+        Constrained::allow_only(chaos_ipc::protocol::ApprovalPolicy::Headless);
+
+    let input = vec![UserInput::Text {
+        text: format!(
+            "{RECONNECT_TITLE_REVIEW_PROMPT}\n\nCurrent title: {:?}",
+            current_title.as_deref().unwrap_or("new session")
+        ),
+        text_elements: Vec::new(),
+    }];
+    let output_schema =
+        if crate::model_provider_info::is_anthropic_wire(parent_ctx.provider.base_url.as_deref()) {
+            None
+        } else {
+            Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "title": { "type": "string" }
+                },
+                "required": ["title"],
+                "additionalProperties": false
+            }))
+        };
+    let reviewer = match run_chaos_process_one_shot(
+        reviewer_config,
+        Arc::clone(&session.services.auth_manager),
+        Arc::clone(&session.services.models_manager),
+        input,
+        Arc::clone(&session),
+        parent_ctx,
+        tokio_util::sync::CancellationToken::new(),
+        SubAgentSource::Other(RECONNECT_TITLE_REVIEW_SOURCE.to_string()),
+        output_schema,
+        Some(InitialHistory::Forked(history)),
+    )
+    .await
+    {
+        Ok(reviewer) => reviewer,
+        Err(err) => {
+            warn!(%err, "failed to start reconnect title review");
+            return;
+        }
+    };
+
+    let mut decision = None;
+    while let Ok(event) = reviewer.next_event().await {
+        match event.msg {
+            EventMsg::TurnComplete(event) => {
+                decision = event
+                    .last_agent_message
+                    .as_deref()
+                    .and_then(parse_reconnect_title_decision);
+                break;
+            }
+            EventMsg::TurnAborted(_) => break,
+            _ => {}
+        }
+    }
+    let Some(title) =
+        decision.and_then(|decision| crate::util::normalize_process_name(&decision.title))
+    else {
+        return;
+    };
+    if title.chars().count() > 80 {
+        return;
+    }
+    if current_title.as_deref() == Some(title.as_str()) {
+        mark_reconnect_reviewed(&session).await;
+        return;
+    }
+
+    match process_names::find_process_name_record_by_id(&session.conversation_id).await {
+        Ok(Some(record)) if record.source == ProcessNameSource::User => return,
+        Ok(_) => {}
+        Err(err) => {
+            warn!(%err, "failed to recheck process title after reconnect review");
+            return;
+        }
+    }
+    match process_names::find_unarchived_process_id_by_name(&title).await {
+        Ok(Some(other_process_id)) if other_process_id != session.conversation_id => {
+            warn!(%title, "reconnect title review chose a title already used by another session");
+            return;
+        }
+        Ok(_) => {}
+        Err(err) => {
+            warn!(%err, "failed to check reconnect title uniqueness");
+            return;
+        }
+    }
+    if let Err(err) = crate::chaos::submission_loop::handlers::persist_process_name(
+        &session,
+        "reconnect-title-review".to_string(),
+        title,
+        ProcessNameSource::Agent,
+    )
+    .await
+    {
+        warn!(%err, "failed to persist reconnect title review");
+    }
+}
+
+async fn mark_reconnect_reviewed(session: &Session) {
+    let mut state = session.state.lock().await;
+    let active_tokens = state.get_total_token_usage(state.server_reasoning_included());
+    state
+        .session_title_reflex
+        .mark_reconnect_reviewed(active_tokens);
+}
+
+fn parse_reconnect_title_decision(text: &str) -> Option<ReconnectTitleDecision> {
+    serde_json::from_str(text).ok().or_else(|| {
+        let start = text.find('{')?;
+        let end = text.rfind('}')?;
+        (start < end)
+            .then(|| serde_json::from_str(&text[start..=end]).ok())
+            .flatten()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -137,6 +329,31 @@ mod tests {
         assert_eq!(
             resumed.claim_for_turn(1_000, true),
             Some(TitleReviewTrigger::Resume)
+        );
+    }
+
+    #[test]
+    fn completed_reconnect_review_suppresses_duplicate_resume_reminder() {
+        let mut reflex = SessionTitleReflex::default();
+        reflex.mark_reconnect_reviewed(1_000);
+        assert_eq!(reflex.claim_for_turn(1_000, true), None);
+    }
+
+    #[test]
+    fn reconnect_title_decision_parses_plain_and_wrapped_json() {
+        assert_eq!(
+            parse_reconnect_title_decision(r#"{"title":"Souls House Work"}"#)
+                .expect("plain JSON")
+                .title,
+            "Souls House Work"
+        );
+        assert_eq!(
+            parse_reconnect_title_decision(
+                "Here is the decision:\n```json\n{\"title\":\"Souls House Work\"}\n```"
+            )
+            .expect("wrapped JSON")
+            .title,
+            "Souls House Work"
         );
     }
 

--- a/sys/kern/kern/src/config.rs
+++ b/sys/kern/kern/src/config.rs
@@ -399,6 +399,12 @@ pub struct Config {
     /// Syntax highlighting theme override (kebab-case name).
     pub tui_theme: Option<String>,
 
+    /// Optional identity marker prefixed to terminal session titles while idle.
+    pub tui_terminal_title_icon: Option<String>,
+
+    /// Optional replacement marker shown while the active session is working.
+    pub tui_terminal_title_working_icon: Option<String>,
+
     /// The directory that should be treated as the current working directory
     /// for the session. All relative paths inside the business-logic layer are
     /// resolved against this path.

--- a/sys/kern/kern/src/config/config_tests.rs
+++ b/sys/kern/kern/src/config/config_tests.rs
@@ -141,6 +141,8 @@ fn config_toml_deserializes_model_availability_nux() {
             animations: true,
             alternate_screen: AltScreenMode::default(),
             status_line: None,
+            terminal_title_icon: None,
+            terminal_title_working_icon: None,
             theme: None,
             model_availability_nux: ModelAvailabilityNuxConfig {
                 shown_count: HashMap::from(
@@ -222,6 +224,51 @@ terminal_title = "agent"
     assert_eq!(agent_cfg.terminal_title, super::TerminalTitleMode::Agent);
 }
 
+#[test]
+fn terminal_title_icons_parse_normalize_and_reject_invalid_values() {
+    let parsed = toml::from_str::<ConfigToml>(
+        r#"
+[tui]
+terminal_title_icon = " ✦ "
+terminal_title_working_icon = "🧑‍💻"
+"#,
+    )
+    .expect("valid terminal title icons should deserialize");
+    let cfg = Config::load_from_base_config_with_overrides(
+        parsed,
+        ConfigOverrides::default(),
+        tempdir().expect("tempdir").path().to_path_buf(),
+    )
+    .expect("load terminal title icon config");
+    assert_eq!(cfg.tui_terminal_title_icon.as_deref(), Some("✦"));
+    assert_eq!(cfg.tui_terminal_title_working_icon.as_deref(), Some("🧑‍💻"));
+
+    let empty = toml::from_str::<ConfigToml>(
+        r#"
+[tui]
+terminal_title_icon = ""
+terminal_title_working_icon = "   "
+"#,
+    )
+    .expect("empty terminal title icons should deserialize");
+    let tui = empty.tui.expect("tui config");
+    assert_eq!(tui.terminal_title_icon, None);
+    assert_eq!(tui.terminal_title_working_icon, None);
+
+    for invalid in ["two icons", "✦✦", "\\u001b"] {
+        let input = format!(
+            r#"
+[tui]
+terminal_title_icon = "{invalid}"
+"#
+        );
+        assert!(
+            toml::from_str::<ConfigToml>(&input).is_err(),
+            "expected invalid terminal title icon to fail: {invalid:?}"
+        );
+    }
+}
+
 #[tokio::test]
 async fn config_builder_applies_clamp_cli_override() {
     let chaos_home = tempdir().expect("tempdir");
@@ -283,6 +330,8 @@ fn tui_config_missing_notifications_field_defaults_to_enabled() {
             animations: true,
             alternate_screen: AltScreenMode::Auto,
             status_line: None,
+            terminal_title_icon: None,
+            terminal_title_working_icon: None,
             theme: None,
             model_availability_nux: ModelAvailabilityNuxConfig::default(),
         }
@@ -1021,6 +1070,8 @@ fn expected_precedence_fixture_config_baseline(fixture: &PrecedenceTestFixture) 
         feedback_enabled: true,
         tui_alternate_screen: AltScreenMode::Auto,
         tui_theme: None,
+        tui_terminal_title_icon: None,
+        tui_terminal_title_working_icon: None,
         otel: OtelConfig::default(),
         disable_user_scripts: false,
     }

--- a/sys/kern/kern/src/config/requirements.rs
+++ b/sys/kern/kern/src/config/requirements.rs
@@ -749,6 +749,11 @@ impl Config {
                 .map(|t| t.alternate_screen)
                 .unwrap_or_default(),
             tui_theme: cfg.tui.as_ref().and_then(|t| t.theme.clone()),
+            tui_terminal_title_icon: cfg.tui.as_ref().and_then(|t| t.terminal_title_icon.clone()),
+            tui_terminal_title_working_icon: cfg
+                .tui
+                .as_ref()
+                .and_then(|t| t.terminal_title_working_icon.clone()),
             otel: {
                 let t: OtelConfigToml = cfg.otel.unwrap_or_default();
                 let log_user_prompt = t.log_user_prompt.unwrap_or(false);

--- a/sys/kern/kern/src/tools/spec/config.rs
+++ b/sys/kern/kern/src/tools/spec/config.rs
@@ -22,6 +22,7 @@ pub enum UnifiedExecShellMode {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ToolsConfig {
+    pub model_tools_disabled: bool,
     pub available_models: Vec<ModelPreset>,
     pub shell_type: ConfigShellToolType,
     pub unified_exec_shell_mode: UnifiedExecShellMode,
@@ -81,6 +82,11 @@ impl ToolsConfig {
         let include_default_mode_request_user_input = include_request_user_input;
         let include_original_image_detail = can_request_original_image_detail(model_info);
         let include_image_gen_tool = false;
+        let model_tools_disabled = matches!(
+            session_source,
+            SessionSource::SubAgent(SubAgentSource::Other(label))
+                if label == "session_title_review"
+        );
         let exec_permission_approvals_enabled = approval_policy.allows_escalation();
         let request_permissions_tool_enabled =
             approval_policy.advertises_request_permissions_tool();
@@ -103,6 +109,7 @@ impl ToolsConfig {
             );
 
         Self {
+            model_tools_disabled,
             available_models: available_models_ref.to_vec(),
             shell_type,
             unified_exec_shell_mode: UnifiedExecShellMode::Direct,

--- a/sys/kern/kern/src/tools/spec/registry.rs
+++ b/sys/kern/kern/src/tools/spec/registry.rs
@@ -116,6 +116,9 @@ pub(crate) fn build_specs_with_discoverable_tools(
     use chaos_traits::catalog::CatalogRegistration;
 
     let mut builder = ToolRegistryBuilder::new();
+    if config.model_tools_disabled {
+        return builder;
+    }
 
     let shell_handler = Arc::new(ShellHandler);
     let unified_exec_handler = Arc::new(UnifiedExecHandler);


### PR DESCRIPTION
## What changed

- add configurable idle and working icons for terminal session titles
- centralize terminal-title composition and update icons across model-turn and MCP-startup lifecycle changes
- validate icons as one visible grapheme of at most four terminal cells
- run a hidden, tool-free title review when reconnecting to an agent-managed session, before accepting a new user turn
- preserve user-authored titles and suppress title updates when terminal titles are disabled
- document configuration and optional WezTerm styling

## Why

Terminal tabs should remain individually recognizable while also showing which sessions are actively working. Resumed sessions also need immediate semantic orientation: an unnamed or stale session should not remain `new session` merely because no new user turn has happened yet.

## How to verify

1. Configure:
   ```toml
   terminal_title = "agent"

   [tui]
   terminal_title_icon = "✦"
   terminal_title_working_icon = "◒"
   ```
2. Start or resume a session and confirm the idle title uses `✦`.
3. Submit a turn and confirm the icon changes to `◒`, then returns to `✦` when work completes.
4. Resume an unnamed existing session and confirm its restored conversation is privately reviewed and the title updates without a user turn.
5. Set `terminal_title = "off"` and confirm no title updates are emitted.

- [ ] Tests pass — `just test`: 2,843 passed, 4 unrelated local failures, 19 skipped. The additional truncation failure passed immediately when rerun alone; the other three are the existing review-prompt and undo failures.
- [x] Builds on target hardware — installed and exercised locally on macOS; idle/working icons and automatic reconnect naming were manually verified.
