### PR TITLE
fix(lex): hide web citation markers

### DIFF
--- a/lib/libutil/lex/src/citation.rs
+++ b/lib/libutil/lex/src/citation.rs
@@ -9,17 +9,19 @@ enum CitationTag {
     Citation,
 }
 
-const CITATION_OPEN: &str = "<oai-mem-citation>";
-const CITATION_CLOSE: &str = "</oai-mem-citation>";
+const MEMORY_CITATION_OPEN: &str = "<oai-mem-citation>";
+const MEMORY_CITATION_CLOSE: &str = "</oai-mem-citation>";
+const WEB_CITATION_OPEN: &str = "\u{e200}cite\u{e202}";
+const WEB_CITATION_CLOSE: &str = "\u{e201}";
 
-/// Stream parser for `<oai-mem-citation>...</oai-mem-citation>` tags.
+/// Stream parser for hidden citation markup.
 ///
 /// This is a thin convenience wrapper around [`InlineHiddenTagParser`]. It returns citation bodies
-/// as plain strings and omits the citation tags from visible text.
+/// as plain strings and omits both `<oai-mem-citation>...</oai-mem-citation>` memory citations and
+/// `\u{e200}cite\u{e202}...\u{e201}` web citations from visible text.
 ///
 /// Matching is literal and non-nested. If EOF is reached before a closing
-/// `</oai-mem-citation>`, the parser auto-closes the tag and returns the buffered body as an
-/// extracted citation.
+/// delimiter, the parser auto-closes the citation and returns the buffered body as extracted data.
 #[derive(Debug)]
 pub struct CitationStreamParser {
     inner: InlineHiddenTagParser<CitationTag>,
@@ -28,11 +30,18 @@ pub struct CitationStreamParser {
 impl CitationStreamParser {
     pub fn new() -> Self {
         Self {
-            inner: InlineHiddenTagParser::new(vec![InlineTagSpec {
-                tag: CitationTag::Citation,
-                open: CITATION_OPEN,
-                close: CITATION_CLOSE,
-            }]),
+            inner: InlineHiddenTagParser::new(vec![
+                InlineTagSpec {
+                    tag: CitationTag::Citation,
+                    open: MEMORY_CITATION_OPEN,
+                    close: MEMORY_CITATION_CLOSE,
+                },
+                InlineTagSpec {
+                    tag: CitationTag::Citation,
+                    open: WEB_CITATION_OPEN,
+                    close: WEB_CITATION_CLOSE,
+                },
+            ]),
         }
     }
 }

--- a/tests/regress/tests/lex.rs
+++ b/tests/regress/tests/lex.rs
@@ -40,6 +40,22 @@ fn assistant_text_stream_splits_citations_across_chunks_and_streams_plan_segment
     assert!(tail.visible_text.is_empty());
     assert!(tail.citations.is_empty());
 
+    // Responses following a native web search can contain private-use
+    // citation markers. They must be hidden just like memory citations.
+    let mut parser = AssistantTextStreamParser::new(false);
+    let seeded = parser
+        .push_str("GLM-5.3-Flash is available and cheap enough for this boundary check. \u{e200}");
+    let parsed = parser.push_str("cite\u{e202}turn0search1\u{e201} I'll benchmark it.");
+    let tail = parser.finish();
+    assert_eq!(
+        seeded.visible_text,
+        "GLM-5.3-Flash is available and cheap enough for this boundary check. "
+    );
+    assert!(seeded.citations.is_empty());
+    assert_eq!(parsed.visible_text, " I'll benchmark it.");
+    assert_eq!(parsed.citations, vec!["turn0search1".to_string()]);
+    assert!(tail.is_empty());
+
     // With proposed-plan parsing enabled, a nested citation inside a
     // plan block should be reported as a citation AND the plan block
     // should emit start/delta/end segments in order.
@@ -91,6 +107,21 @@ fn citation_parser_streams_partial_tags_and_handles_finish_semantics() {
     assert_eq!(out.visible_text, "Hello  world");
     assert_eq!(out.extracted, vec!["source A".to_string()]);
 
+    // Private-use web citation markers can also straddle arbitrary
+    // streamed text boundaries, including inside the opener.
+    let mut parser = CitationStreamParser::new();
+    let out = collect_chunks(
+        &mut parser,
+        &[
+            "Before \u{e200}",
+            "cit",
+            "e\u{e202}turn0search1",
+            "\u{e201} after",
+        ],
+    );
+    assert_eq!(out.visible_text, "Before  after");
+    assert_eq!(out.extracted, vec!["turn0search1".to_string()]);
+
     // A partial open-tag prefix at the end of a chunk must be buffered,
     // not emitted — otherwise half a tag leaks into the visible stream.
     let mut parser = CitationStreamParser::new();
@@ -123,6 +154,17 @@ fn citation_parser_streams_partial_tags_and_handles_finish_semantics() {
     );
     assert_eq!(visible, "abc");
     assert_eq!(citations, vec!["one".to_string(), "two".to_string()]);
+
+    // Batch parsing supports memory and web citation forms in the same
+    // response while preserving their source order.
+    let (visible, citations) = strip_citations(
+        "a<oai-mem-citation>memory</oai-mem-citation>b\u{e200}cite\u{e202}turn0search1\u{e201}c",
+    );
+    assert_eq!(visible, "abc");
+    assert_eq!(
+        citations,
+        vec!["memory".to_string(), "turn0search1".to_string()]
+    );
 
     // Batch helper also auto-closes a dangling open tag at EOF.
     let (visible, citations) = strip_citations("x<oai-mem-citation>y");


### PR DESCRIPTION
## What changed

- recognize the private-use `\u{e200}cite\u{e202}...\u{e201}` citation markers emitted after native web searches
- strip those markers through the existing streaming citation parser, including when delimiters cross chunk boundaries
- preserve the existing `<oai-mem-citation>...</oai-mem-citation>` behavior and citation ordering
- add regression coverage based on the observed leaking response

## Why

Web-backed assistant responses can contain renderer-oriented citation markup such as `citeturn0search1`. Chaos only recognized the older memory-citation tags, so it forwarded the private-use marker as visible terminal text.

## How to verify

- `cargo test -p chaos-regress --test lex` — 7 passed
- `cargo test -p chaos-kern strips_citations -- --nocapture` — 2 passed
- `cargo clippy -p chaos-lex -p chaos-regress --all-targets --all-features -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed

Full current-master QA was also attempted. `just qa` reaches three unrelated Rust 1.98 Clippy failures in `sys/arch/macos/src/seatbelt_tests.rs`; `just test` reaches unrelated timeout/infrastructure failures in Clamp, minion, review-diff, and apply-patch integration tests. No failures touched the citation parser or its regression tests.

- [x] Changed tests pass
- [x] Builds on target hardware
