### PR TITLE
fix(kern): restore live mode test suite

### DIFF
--- a/sys/kern/kern/src/chaos_tests/session_lifecycle.rs
+++ b/sys/kern/kern/src/chaos_tests/session_lifecycle.rs
@@ -120,6 +120,39 @@ async fn legacy_collaboration_mode_updates_keep_mode_policy_in_sync() {
 }
 
 #[tokio::test]
+async fn legacy_collaboration_mode_aliases_use_the_current_live_mode() {
+    let session_configuration = make_session_configuration_for_tests().await;
+
+    for legacy_mode in [
+        chaos_ipc::config_types::ModeKind::Execute,
+        chaos_ipc::config_types::ModeKind::PairProgramming,
+    ] {
+        let updated = session_configuration
+            .apply(&SessionSettingsUpdate {
+                collaboration_mode: Some(chaos_ipc::config_types::CollaborationMode {
+                    mode: legacy_mode,
+                    settings: chaos_ipc::config_types::Settings {
+                        model: session_configuration.collaboration_mode.model().to_string(),
+                        reasoning_effort: None,
+                        minion_instructions: None,
+                    },
+                }),
+                ..Default::default()
+            })
+            .expect("apply legacy collaboration mode alias");
+
+        assert_eq!(
+            updated.mode_policy.active_mode,
+            crate::modes::DEFAULT_MODE_ID
+        );
+        assert_eq!(
+            updated.collaboration_mode.mode,
+            chaos_ipc::config_types::ModeKind::Default
+        );
+    }
+}
+
+#[tokio::test]
 async fn switch_mode_changes_the_next_sample_context_in_the_same_session() {
     let (session, turn_context) = make_session_and_context().await;
     let turn_context = Arc::new(turn_context);

--- a/sys/kern/kern/src/context_manager/updates.rs
+++ b/sys/kern/kern/src/context_manager/updates.rs
@@ -58,14 +58,18 @@ fn build_collaboration_mode_update_item(
     next: &TurnContext,
 ) -> Option<DeveloperInstructions> {
     let prev = previous?;
-    if prev.collaboration_mode.as_ref() != Some(&next.collaboration_mode) {
+    let previous_instructions = prev
+        .collaboration_mode
+        .as_ref()
+        .and_then(DeveloperInstructions::from_collaboration_mode);
+    let next_instructions =
+        DeveloperInstructions::from_collaboration_mode(&next.collaboration_mode);
+    if previous_instructions == next_instructions {
+        None
+    } else {
         // If the next mode has empty developer instructions, this returns None and we emit no
         // update, so prior collaboration instructions remain in the prompt history.
-        Some(DeveloperInstructions::from_collaboration_mode(
-            &next.collaboration_mode,
-        )?)
-    } else {
-        None
+        next_instructions
     }
 }
 

--- a/sys/kern/kern/src/tools/handlers/mcp_resource_tests.rs
+++ b/sys/kern/kern/src/tools/handlers/mcp_resource_tests.rs
@@ -126,14 +126,14 @@ fn template_with_server_serializes_server_field() {
 }
 
 #[test]
-fn merge_inline_resources_adds_local_chaos_crons_resource() {
+fn merge_inline_resources_adds_local_chaos_resources() {
     let merged = merge_inline_resources(HashMap::new());
 
     let resources = merged
         .get(INTERNAL_TASK_SERVER_NAME)
         .expect("inline chaos resources should exist");
 
-    assert_eq!(resources.len(), 4);
+    assert_eq!(resources.len(), 5);
     assert_eq!(resources[0].uri, builtin_mcp_resources::CHAOS_SESSIONS_URI);
     assert_eq!(resources[0].name, "sessions");
     assert_eq!(
@@ -156,6 +156,12 @@ fn merge_inline_resources_adds_local_chaos_crons_resource() {
     assert_eq!(resources[3].name, "models");
     assert_eq!(
         resources[3].mime_type.as_deref(),
+        Some(builtin_mcp_resources::JSON_MIME_TYPE)
+    );
+    assert_eq!(resources[4].uri, builtin_mcp_resources::CHAOS_MODES_URI);
+    assert_eq!(resources[4].name, "modes");
+    assert_eq!(
+        resources[4].mime_type.as_deref(),
         Some(builtin_mcp_resources::JSON_MIME_TYPE)
     );
 }

--- a/sys/kern/kern/tests/suite/request_user_input.rs
+++ b/sys/kern/kern/tests/suite/request_user_input.rs
@@ -46,27 +46,6 @@ fn call_output(req: &ResponsesRequest, call_id: &str) -> String {
     }
 }
 
-fn call_output_content_and_success(
-    req: &ResponsesRequest,
-    call_id: &str,
-) -> (String, Option<bool>) {
-    let raw = req.function_call_output(call_id);
-    assert_eq!(
-        raw.get("call_id").and_then(Value::as_str),
-        Some(call_id),
-        "mismatched call_id in function_call_output"
-    );
-    let (content_opt, success) = match req.function_call_output_content_and_success(call_id) {
-        Some(values) => values,
-        None => panic!("function_call_output present"),
-    };
-    let content = match content_opt {
-        Some(content) => content,
-        None => panic!("function_call_output content present"),
-    };
-    (content, success)
-}
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn request_user_input_round_trip_resolves_pending() -> anyhow::Result<()> {
     request_user_input_round_trip_for_mode(ModeKind::Plan).await
@@ -185,115 +164,7 @@ async fn request_user_input_round_trip_for_mode(mode: ModeKind) -> anyhow::Resul
     Ok(())
 }
 
-async fn assert_request_user_input_rejected<F>(mode_name: &str, build_mode: F) -> anyhow::Result<()>
-where
-    F: FnOnce(String) -> CollaborationMode,
-{
-    skip_if_no_network!(Ok(()));
-
-    let server = start_mock_server().await;
-
-    let mut builder = test_chaos();
-    let TestChaos {
-        process: chaos,
-        cwd,
-        session_configured,
-        ..
-    } = builder.build(&server).await?;
-
-    let mode_slug = mode_name.to_lowercase().replace(' ', "-");
-    let call_id = format!("user-input-{mode_slug}-call");
-    let request_args = json!({
-        "questions": [{
-            "id": "confirm_path",
-            "header": "Confirm",
-            "question": "Proceed with the plan?",
-            "options": [{
-                "label": "Yes (Recommended)",
-                "description": "Continue the current plan."
-            }, {
-                "label": "No",
-                "description": "Stop and revisit the approach."
-            }]
-        }]
-    })
-    .to_string();
-
-    let first_response = sse(vec![
-        ev_response_created("resp-1"),
-        ev_function_call(&call_id, "request_user_input", &request_args),
-        ev_completed("resp-1"),
-    ]);
-    responses::mount_sse_once(&server, first_response).await;
-
-    let second_response = sse(vec![
-        ev_assistant_message("msg-1", "thanks"),
-        ev_completed("resp-2"),
-    ]);
-    let second_mock = responses::mount_sse_once(&server, second_response).await;
-
-    let session_model = session_configured.model.clone();
-    let collaboration_mode = build_mode(session_model.clone());
-
-    chaos
-        .submit(Op::UserTurn {
-            items: vec![UserInput::Text {
-                text: "please confirm".into(),
-                text_elements: Vec::new(),
-            }],
-            final_output_json_schema: None,
-            cwd: cwd.path().to_path_buf(),
-            approval_policy: ApprovalPolicy::Headless,
-            sandbox_policy: SandboxPolicy::RootAccess,
-            model: session_model,
-            effort: None,
-            summary: None,
-            service_tier: None,
-            collaboration_mode: Some(collaboration_mode),
-            personality: None,
-        })
-        .await?;
-
-    wait_for_event(&chaos, |event| matches!(event, EventMsg::TurnComplete(_))).await;
-
-    let req = second_mock.single_request();
-    let (output, success) = call_output_content_and_success(&req, &call_id);
-    assert_eq!(success, None);
-    assert_eq!(
-        output,
-        format!("request_user_input is unavailable in {mode_name} mode")
-    );
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn request_user_input_rejected_in_execute_mode_alias() -> anyhow::Result<()> {
-    assert_request_user_input_rejected("Execute", |model| CollaborationMode {
-        mode: ModeKind::Execute,
-        settings: Settings {
-            model,
-            reasoning_effort: None,
-            minion_instructions: None,
-        },
-    })
-    .await
-}
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn request_user_input_round_trip_in_default_mode() -> anyhow::Result<()> {
     request_user_input_round_trip_for_mode(ModeKind::Default).await
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn request_user_input_rejected_in_pair_mode_alias() -> anyhow::Result<()> {
-    assert_request_user_input_rejected("Pair Programming", |model| CollaborationMode {
-        mode: ModeKind::PairProgramming,
-        settings: Settings {
-            model,
-            reasoning_effort: None,
-            minion_instructions: None,
-        },
-    })
-    .await
 }


### PR DESCRIPTION
## What?

Restore the test suite after live collaboration mode switching landed.

- Compare rendered collaboration-mode instructions instead of the full mode payload, so model-only changes do not re-inject unchanged mode instructions.
- Update built-in MCP resource coverage for `chaos://modes`.
- Replace obsolete request-user-input tests for hidden, non-serializable legacy aliases with direct coverage that they normalize to the current live mode.

## Why?

Commit `a2d32fce2` left four deterministic failures across all CI platforms. The alias tests also waited for an elicitation that is valid after normalization, causing ten-second timeouts.

## How?

The repository-required checks pass in a clean Git environment:

- `just fmt`
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null NO_COLOR=1 CLICOLOR=0 just test`
- 2,865 passed, 19 skipped

Fixes #51.