### PR TITLE
feat(hooks): expose Stop transcript snapshots

### DIFF
--- a/sys/exec/fork/src/cli.rs
+++ b/sys/exec/fork/src/cli.rs
@@ -44,6 +44,10 @@ pub struct Cli {
     #[arg(long = "ephemeral", global = true, default_value_t = false)]
     pub ephemeral: bool,
 
+    /// Internal: start from a serialized Stop-hook transcript snapshot.
+    #[arg(long = "fork-snapshot", value_name = "FILE", hide = true)]
+    pub fork_snapshot: Option<PathBuf>,
+
     /// Path to a JSON Schema file describing the model's final response shape.
     #[arg(long = "output-schema", value_name = "FILE")]
     pub output_schema: Option<PathBuf>,
@@ -287,5 +291,23 @@ mod tests {
         };
         assert_eq!(args.session_id.as_deref(), Some("session-123"));
         assert_eq!(args.prompt.as_deref(), Some(PROMPT));
+    }
+
+    #[test]
+    fn hidden_fork_snapshot_option_is_parsed() {
+        let cli = Cli::parse_from([
+            "chaos-exec",
+            "--fork-snapshot",
+            "/tmp/turn-snapshot.json",
+            "--ephemeral",
+            "reflect",
+        ]);
+
+        assert_eq!(
+            cli.fork_snapshot,
+            Some(PathBuf::from("/tmp/turn-snapshot.json"))
+        );
+        assert!(cli.ephemeral);
+        assert_eq!(cli.prompt.as_deref(), Some("reflect"));
     }
 }

--- a/sys/exec/fork/src/lib.rs
+++ b/sys/exec/fork/src/lib.rs
@@ -16,9 +16,11 @@ use chaos_ipc::config_types::SandboxMode;
 use chaos_ipc::product::CHAOS_VERSION;
 use chaos_ipc::protocol::ApprovalPolicy;
 use chaos_ipc::protocol::EventMsg;
+use chaos_ipc::protocol::InitialHistory;
 use chaos_ipc::protocol::Op;
 use chaos_ipc::protocol::ReviewRequest;
 use chaos_ipc::protocol::ReviewTarget;
+use chaos_ipc::protocol::RolloutItem;
 use chaos_ipc::protocol::SessionSource;
 use chaos_ipc::user_input::UserInput;
 use chaos_kern::AuthManager;
@@ -126,6 +128,7 @@ struct ExecRunArgs {
     json_mode: bool,
     last_message_file: Option<PathBuf>,
     output_schema_path: Option<PathBuf>,
+    fork_snapshot: Option<PathBuf>,
     prompt: Option<String>,
     skip_git_repo_check: bool,
     stderr_with_ansi: bool,
@@ -208,6 +211,7 @@ pub async fn run_main(cli: Cli, arg0_paths: Arg0DispatchPaths) -> anyhow::Result
         skip_git_repo_check,
         add_dir,
         ephemeral,
+        fork_snapshot,
         color,
         last_message_file,
         json: json_mode,
@@ -427,6 +431,7 @@ pub async fn run_main(cli: Cli, arg0_paths: Arg0DispatchPaths) -> anyhow::Result
         json_mode,
         last_message_file,
         output_schema_path,
+        fork_snapshot,
         prompt,
         skip_git_repo_check,
         stderr_with_ansi,
@@ -447,6 +452,7 @@ async fn run_exec_session(args: ExecRunArgs) -> anyhow::Result<()> {
         json_mode,
         last_message_file,
         output_schema_path,
+        fork_snapshot,
         prompt,
         skip_git_repo_check,
         stderr_with_ansi,
@@ -482,7 +488,31 @@ async fn run_exec_session(args: ExecRunArgs) -> anyhow::Result<()> {
     }
 
     // Start or resume a process directly via the ProcessTable.
-    let new_process = if let Some(ExecCommand::Resume(ref resume_args)) = command {
+    let new_process = if let Some(snapshot_path) = fork_snapshot.as_deref() {
+        let snapshot_bytes = std::fs::read(snapshot_path).map_err(|err| {
+            anyhow::anyhow!(
+                "failed to read fork snapshot {}: {err}",
+                snapshot_path.display()
+            )
+        })?;
+        let rollout_items: Vec<RolloutItem> =
+            serde_json::from_slice(&snapshot_bytes).map_err(|err| {
+                anyhow::anyhow!(
+                    "fork snapshot {} is not valid rollout JSON: {err}",
+                    snapshot_path.display()
+                )
+            })?;
+        process_table
+            .resume_process_with_history(
+                config.clone(),
+                InitialHistory::Forked(rollout_items),
+                auth_manager.clone(),
+                /*persist_extended_history*/ false,
+                /*parent_trace*/ None,
+            )
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to start process from fork snapshot: {err}"))?
+    } else if let Some(ExecCommand::Resume(ref resume_args)) = command {
         let resume_process_id = resolve_resume_process_id(&config, resume_args).await?;
 
         if let Some(process_id) = resume_process_id {

--- a/sys/kern/kern/src/chaos/turn.rs
+++ b/sys/kern/kern/src/chaos/turn.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::io;
+use std::io::Write;
 use std::sync::Arc;
 
 use chaos_dtrace::HookEvent;
@@ -14,6 +16,7 @@ use chaos_ipc::protocol::ApprovalPolicy;
 use chaos_ipc::protocol::EventMsg;
 use chaos_ipc::protocol::HookCompletedEvent;
 use chaos_ipc::protocol::HookRunSummary;
+use chaos_ipc::protocol::RolloutItem;
 use chaos_ipc::protocol::SessionSource;
 use chaos_ipc::protocol::SubAgentSource;
 use chaos_ipc::protocol::TurnStartedEvent;
@@ -24,6 +27,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
+
+use tempfile::NamedTempFile;
 
 use crate::client::ModelClientSession;
 use crate::distill::InitialContextInjection;
@@ -63,6 +68,23 @@ struct ContextHookOutcome {
     completed_events: Vec<HookCompletedEvent>,
     should_stop: bool,
     additional_context: Option<String>,
+}
+
+fn write_stop_hook_transcript_snapshot(items: &[ResponseItem]) -> io::Result<NamedTempFile> {
+    let mut file = tempfile::Builder::new()
+        .prefix("chaos-stop-transcript-")
+        .suffix(".json")
+        .tempfile()?;
+    let rollout_items = items
+        .iter()
+        .cloned()
+        .map(RolloutItem::ResponseItem)
+        .collect::<Vec<_>>();
+    serde_json::to_writer(file.as_file_mut(), &rollout_items).map_err(|err| {
+        io::Error::other(format!("failed to serialize transcript snapshot: {err}"))
+    })?;
+    file.as_file_mut().flush()?;
+    Ok(file)
 }
 
 fn hook_agent_context(
@@ -513,7 +535,7 @@ pub(crate) async fn run_turn(
 
                 if !needs_follow_up {
                     last_agent_message = sampling_request_last_agent_message;
-                    let stop_request = chaos_dtrace::StopRequest {
+                    let mut stop_request = chaos_dtrace::StopRequest {
                         session_id: sess.conversation_id,
                         turn_id: turn_context.sub_id.clone(),
                         cwd: turn_context.cwd.clone(),
@@ -525,7 +547,27 @@ pub(crate) async fn run_turn(
                         last_assistant_message: last_agent_message.clone(),
                         agent_context: agent_context.clone(),
                     };
-                    for run in sess.hooks().preview_stop(&stop_request) {
+                    let stop_previews = sess.hooks().preview_stop(&stop_request);
+                    let stop_transcript_snapshot = if stop_previews.is_empty() {
+                        None
+                    } else {
+                        let history = sess.clone_history().await;
+                        match write_stop_hook_transcript_snapshot(history.raw_items()) {
+                            Ok(snapshot) => {
+                                stop_request.transcript_path = Some(snapshot.path().to_path_buf());
+                                Some(snapshot)
+                            }
+                            Err(err) => {
+                                warn!(
+                                    turn_id = %turn_context.sub_id,
+                                    error = %err,
+                                    "failed to materialize Stop-hook transcript snapshot"
+                                );
+                                None
+                            }
+                        }
+                    };
+                    for run in stop_previews {
                         sess.send_event(
                             &turn_context,
                             EventMsg::HookStarted(crate::protocol::HookStartedEvent {
@@ -536,6 +578,9 @@ pub(crate) async fn run_turn(
                         .await;
                     }
                     let stop_outcome = sess.hooks().run_stop(stop_request).await;
+                    // The path is intentionally valid only while Stop handlers
+                    // execute. A background hook must copy it before returning.
+                    drop(stop_transcript_snapshot);
                     for completed in stop_outcome.hook_events {
                         sess.send_event(&turn_context, EventMsg::HookCompleted(completed))
                             .await;
@@ -749,11 +794,43 @@ pub(crate) async fn built_tools(
 
 #[cfg(test)]
 mod hook_agent_context_tests {
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
     use chaos_ipc::ProcessId;
+    use chaos_ipc::models::DeveloperInstructions;
+    use chaos_ipc::protocol::RolloutItem;
     use chaos_ipc::protocol::SessionSource;
     use chaos_ipc::protocol::SubAgentSource;
 
     use super::hook_agent_context;
+    use super::write_stop_hook_transcript_snapshot;
+
+    #[test]
+    fn stop_hook_snapshot_is_fork_ready_and_ephemeral() {
+        let item = DeveloperInstructions::new("snapshot marker").into();
+        let snapshot = write_stop_hook_transcript_snapshot(&[item]).expect("write snapshot");
+        let path = snapshot.path().to_path_buf();
+        #[cfg(unix)]
+        assert_eq!(
+            fs::metadata(&path)
+                .expect("snapshot metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+
+        let rollout_items: Vec<RolloutItem> =
+            serde_json::from_slice(&fs::read(&path).expect("read snapshot"))
+                .expect("parse rollout snapshot");
+        assert_eq!(rollout_items.len(), 1);
+        assert!(matches!(rollout_items[0], RolloutItem::ResponseItem(_)));
+
+        drop(snapshot);
+        assert!(!path.exists());
+    }
 
     #[test]
     fn root_sessions_have_no_agent_identity() {


### PR DESCRIPTION
## What changed

- Materialize the prompt-ready conversation history as an owner-only JSON snapshot before running Stop hooks.
- Expose that short-lived path through the existing `transcript_path` Stop payload field and remove it after all Stop handlers return.
- Add a hidden `chaos exec --fork-snapshot FILE` path for starting an ephemeral continuation from serialized `RolloutItem` history.
- Add focused tests for snapshot format, permissions, lifetime, and CLI parsing.

## Why

A synchronous Stop hook currently has no way to hand exact completed-turn context to detached post-turn work. Exposing a scoped, fork-ready snapshot lets hooks copy the completed state, return immediately, and run background reflection or other processing without blocking the interactive session or admitting later user messages into the branch.

Closes #53.

## How to verify

- `just fmt`
- `cargo check -p chaos-kern -p chaos-fork`
- `cargo test -p chaos-kern --lib stop_hook_snapshot_is_fork_ready_and_ephemeral`
- `cargo test -p chaos-fork --lib hidden_fork_snapshot_option_is_parsed`
- Local end-to-end verification: a Stop hook copied the snapshot, returned without blocking the next turn, and an ephemeral snapshot fork completed successfully.

After rebasing onto current `master`, the previously failing tool-spec tests pass. A full local `just test` ran 2,838 tests: 2,830 passed; seven machine-specific git/shell/undo tests failed and one libui test timed out. The focused snapshot tests pass, and all three GitHub CI platforms pass.

- [x] Focused tests pass
- [x] Builds on target hardware (macOS arm64)
