### PR TITLE
test(kern): align provider fixtures with auth semantics

### DIFF
--- a/sys/kern/kern/tests/suite/models_by_provider.rs
+++ b/sys/kern/kern/tests/suite/models_by_provider.rs
@@ -5,6 +5,8 @@ use chaos_ipc::openai_models::ModelVisibility;
 use chaos_ipc::openai_models::ModelsResponse;
 use chaos_kern::ChaosAuth;
 use chaos_kern::ModelProviderInfo;
+use chaos_kern::ProviderAuthCapabilities;
+use chaos_kern::ProviderAuthMethod;
 use chaos_kern::models_manager::manager::RefreshStrategy;
 use chaos_kern::test_support::test_remote_model;
 use chaos_model_catalog::ModelsCache;
@@ -65,7 +67,9 @@ async fn lists_cached_models_for_every_usable_provider() -> Result<()> {
     locked_out.experimental_bearer_token = None;
     locked_out.env_key = None;
     locked_out.requires_openai_auth = false;
-    locked_out.auth = None;
+    locked_out.auth = Some(ProviderAuthCapabilities {
+        methods: vec![ProviderAuthMethod::ApiKey],
+    });
 
     // Only the "cached" third party has ever been listed.
     let fetched_at = Timestamp::from_second(1_600_000_000).expect("valid timestamp");

--- a/sys/kern/kern/tests/suite/remote_models.rs
+++ b/sys/kern/kern/tests/suite/remote_models.rs
@@ -526,6 +526,7 @@ async fn remote_models_do_not_append_removed_builtin_presets() -> Result<()> {
         base_url: Some(format!("{}/v1", server.uri())),
         ..built_in_model_providers()["openai"].clone()
     };
+    let expected_model_family = provider.model_family.clone();
     let manager = models_manager_with_provider(
         chaos_home.path().to_path_buf(),
         auth_manager_from_auth(auth),
@@ -539,6 +540,7 @@ async fn remote_models_do_not_append_removed_builtin_presets() -> Result<()> {
         .expect("remote model should be listed");
     let mut expected_remote: ModelPreset = remote_model.into();
     expected_remote.is_default = remote.is_default;
+    expected_remote.model_family = expected_model_family;
     assert_eq!(*remote, expected_remote);
     let default_model = available
         .iter()


### PR DESCRIPTION
## Summary

- mark the deliberately locked-out provider fixture as requiring API-key auth
- expect discovered remote models to inherit the provider model family
- restore the two deterministic provider-model tests currently failing on `master`

## Why

Provider provenance handling changed the intended semantics in `d368c77fc`:

- a provider declaring no managed auth is usable, so the locked-out fixture must declare the API-key auth it lacks
- an unknown remote model inherits its provider's model family

The existing assertions still encoded the previous behavior.

## Tests

- `cargo fmt --all -- --check`
- `git diff --check`
- `scripts/with-local-qa-tmp.sh cargo nextest run --workspace --all-features --no-fail-fast -E 'test(lists_cached_models_for_every_usable_provider) | test(remote_models_do_not_append_removed_builtin_presets)'`
