### PR TITLE
test(kern): await child shutdown before notification

### DIFF
--- a/sys/kern/kern/src/minions/control_tests.rs
+++ b/sys/kern/kern/src/minions/control_tests.rs
@@ -655,10 +655,10 @@ async fn spawn_child_completion_notifies_parent_history() {
         .get_process(child_process_id)
         .await
         .expect("child thread should exist");
-    let _ = child_thread
-        .submit(Op::Shutdown {})
+    child_thread
+        .shutdown_and_wait()
         .await
-        .expect("child shutdown should submit");
+        .expect("child shutdown should complete");
 
     assert_eq!(wait_for_subagent_notification(&parent_thread).await, true);
 }


### PR DESCRIPTION
## Summary

- wait for the spawned child session to terminate before asserting its parent notification
- use the existing lifecycle-aware `shutdown_and_wait()` helper instead of only enqueueing `Op::Shutdown`

## Why

`spawn_child_completion_notifies_parent_history` currently begins its five-second notification timeout immediately after enqueueing shutdown. Under CI load, shutdown processing can consume that window before the completion watcher has a final child status. The test has failed repeatedly across x64, ARM, and macOS runs while passing on rerun.

Waiting for session-loop termination makes the test assert notification delivery rather than scheduler latency.

## Tests

- `cargo fmt --all -- --check`
- `git diff --check`
- targeted test passed repeatedly locally (10 consecutive runs, followed by a confirming run)
